### PR TITLE
Improve nuking strategy

### DIFF
--- a/aws/ami.go
+++ b/aws/ami.go
@@ -48,7 +48,7 @@ func nukeAllAMIs(session *session.Session, imageIds []*string) error {
 		return nil
 	}
 
-	logging.Logger.Infof("Terminating all AMIs in region %s", *session.Config.Region)
+	logging.Logger.Infof("Deleting all AMIs in region %s", *session.Config.Region)
 
 	for _, imageID := range imageIds {
 		params := &ec2.DeregisterImageInput{
@@ -58,10 +58,9 @@ func nukeAllAMIs(session *session.Session, imageIds []*string) error {
 		_, err := svc.DeregisterImage(params)
 		if err != nil {
 			logging.Logger.Errorf("[Failed] %s", err)
-			return errors.WithStackTrace(err)
+		} else {
+			logging.Logger.Infof("Deleted AMI: %s", *imageID)
 		}
-
-		logging.Logger.Infof("Deleted AMI: %s", *imageID)
 	}
 
 	logging.Logger.Infof("[OK] %d AMI(s) terminated in %s", len(imageIds), *session.Config.Region)

--- a/aws/asg.go
+++ b/aws/asg.go
@@ -60,6 +60,7 @@ func nukeAllAutoScalingGroups(session *session.Session, groupNames []*string) er
 	})
 
 	if err != nil {
+		logging.Logger.Errorf("[Failed] %s", err)
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/asg.go
+++ b/aws/asg.go
@@ -55,13 +55,15 @@ func nukeAllAutoScalingGroups(session *session.Session, groupNames []*string) er
 		}
 	}
 
-	err := svc.WaitUntilGroupNotExists(&autoscaling.DescribeAutoScalingGroupsInput{
-		AutoScalingGroupNames: deletedGroupNames,
-	})
+	if len(deletedGroupNames) > 0 {
+		err := svc.WaitUntilGroupNotExists(&autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: deletedGroupNames,
+		})
 
-	if err != nil {
-		logging.Logger.Errorf("[Failed] %s", err)
-		return errors.WithStackTrace(err)
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+			return errors.WithStackTrace(err)
+		}
 	}
 
 	logging.Logger.Infof("[OK] %d Auto Scaling Group(s) deleted in %s", len(deletedGroupNames), *session.Config.Region)

--- a/aws/ebs.go
+++ b/aws/ebs.go
@@ -66,6 +66,7 @@ func nukeAllEbsVolumes(session *session.Session, volumeIds []*string) error {
 	})
 
 	if err != nil {
+		logging.Logger.Errorf("[Failed] %s", err)
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/ebs.go
+++ b/aws/ebs.go
@@ -61,13 +61,15 @@ func nukeAllEbsVolumes(session *session.Session, volumeIds []*string) error {
 		}
 	}
 
-	err := svc.WaitUntilVolumeDeleted(&ec2.DescribeVolumesInput{
-		VolumeIds: deletedVolumeIDs,
-	})
+	if len(deletedVolumeIDs) > 0 {
+		err := svc.WaitUntilVolumeDeleted(&ec2.DescribeVolumesInput{
+			VolumeIds: deletedVolumeIDs,
+		})
 
-	if err != nil {
-		logging.Logger.Errorf("[Failed] %s", err)
-		return errors.WithStackTrace(err)
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+			return errors.WithStackTrace(err)
+		}
 	}
 
 	logging.Logger.Infof("[OK] %d EBS volumes(s) terminated in %s", len(deletedVolumeIDs), *session.Config.Region)

--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -89,10 +89,6 @@ func nukeAllEc2Instances(session *session.Session, instanceIds []*string) error 
 		return errors.WithStackTrace(err)
 	}
 
-	for _, instanceID := range instanceIds {
-		logging.Logger.Infof("Terminated EC2 Instance: %s", *instanceID)
-	}
-
 	err = svc.WaitUntilInstanceTerminated(&ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
 			&ec2.Filter{
@@ -101,6 +97,10 @@ func nukeAllEc2Instances(session *session.Session, instanceIds []*string) error 
 			},
 		},
 	})
+
+	for _, instanceID := range instanceIds {
+		logging.Logger.Infof("Terminated EC2 Instance: %s", *instanceID)
+	}
 
 	if err != nil {
 		logging.Logger.Errorf("[Failed] %s", err)

--- a/aws/eip.go
+++ b/aws/eip.go
@@ -90,6 +90,7 @@ func nukeAllEIPAddresses(session *session.Session, allocationIds []*string) erro
 	}
 
 	logging.Logger.Infof("Deleting all Elastic IPs in region %s", *session.Config.Region)
+	var deletedAllocationIDs []*string
 
 	for _, allocationID := range allocationIds {
 		params := &ec2.ReleaseAddressInput{
@@ -101,16 +102,15 @@ func nukeAllEIPAddresses(session *session.Session, allocationIds []*string) erro
 			if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == "AuthFailure" {
 				// TODO: Figure out why we get an AuthFailure
 				logging.Logger.Warnf("EIP %s can't be deleted, it is still attached to an active resource", *allocationID)
-				return nil
+			} else {
+				logging.Logger.Errorf("[Failed] %s", err)
 			}
-
-			logging.Logger.Errorf("[Failed] %s", err)
-			return errors.WithStackTrace(err)
+		} else {
+			deletedAllocationIDs = append(deletedAllocationIDs, allocationID)
+			logging.Logger.Infof("Deleted Elastic IP: %s", *allocationID)
 		}
-
-		logging.Logger.Infof("Deleted Elastic IP: %s", *allocationID)
 	}
 
-	logging.Logger.Infof("[OK] %d Elastc IP(s) deleted in %s", len(allocationIds), *session.Config.Region)
+	logging.Logger.Infof("[OK] %d Elastc IP(s) deleted in %s", len(deletedAllocationIDs), *session.Config.Region)
 	return nil
 }

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -77,6 +77,7 @@ func nukeAllElbInstances(session *session.Session, names []*string) error {
 	})
 
 	if err != nil {
+		logging.Logger.Errorf("[Failed] %s", err)
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -56,6 +56,7 @@ func nukeAllElbInstances(session *session.Session, names []*string) error {
 	}
 
 	logging.Logger.Infof("Deleting all Elastic Load Balancers in region %s", *session.Config.Region)
+	var deletedNames []*string
 
 	for _, name := range names {
 		params := &elb.DeleteLoadBalancerInput{
@@ -65,20 +66,20 @@ func nukeAllElbInstances(session *session.Session, names []*string) error {
 		_, err := svc.DeleteLoadBalancer(params)
 		if err != nil {
 			logging.Logger.Errorf("[Failed] %s", err)
-			return errors.WithStackTrace(err)
+		} else {
+			deletedNames = append(deletedNames, name)
+			logging.Logger.Infof("Deleted ELB: %s", *name)
 		}
-
-		logging.Logger.Infof("Deleted ELB: %s", *name)
 	}
 
 	err := waitUntilElbDeleted(svc, &elb.DescribeLoadBalancersInput{
-		LoadBalancerNames: names,
+		LoadBalancerNames: deletedNames,
 	})
 
 	if err != nil {
 		return errors.WithStackTrace(err)
 	}
 
-	logging.Logger.Infof("[OK] %d Elastic Load Balancer(s) deleted in %s", len(names), *session.Config.Region)
+	logging.Logger.Infof("[OK] %d Elastic Load Balancer(s) deleted in %s", len(deletedNames), *session.Config.Region)
 	return nil
 }

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -72,13 +72,15 @@ func nukeAllElbInstances(session *session.Session, names []*string) error {
 		}
 	}
 
-	err := waitUntilElbDeleted(svc, &elb.DescribeLoadBalancersInput{
-		LoadBalancerNames: deletedNames,
-	})
+	if len(deletedNames) > 0 {
+		err := waitUntilElbDeleted(svc, &elb.DescribeLoadBalancersInput{
+			LoadBalancerNames: deletedNames,
+		})
 
-	if err != nil {
-		logging.Logger.Errorf("[Failed] %s", err)
-		return errors.WithStackTrace(err)
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+			return errors.WithStackTrace(err)
+		}
 	}
 
 	logging.Logger.Infof("[OK] %d Elastic Load Balancer(s) deleted in %s", len(deletedNames), *session.Config.Region)

--- a/aws/elbv2.go
+++ b/aws/elbv2.go
@@ -53,13 +53,15 @@ func nukeAllElbv2Instances(session *session.Session, arns []*string) error {
 		}
 	}
 
-	err := svc.WaitUntilLoadBalancersDeleted(&elbv2.DescribeLoadBalancersInput{
-		LoadBalancerArns: deletedArns,
-	})
+	if len(deletedArns) > 0 {
+		err := svc.WaitUntilLoadBalancersDeleted(&elbv2.DescribeLoadBalancersInput{
+			LoadBalancerArns: deletedArns,
+		})
 
-	if err != nil {
-		logging.Logger.Errorf("[Failed] %s", err)
-		return errors.WithStackTrace(err)
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+			return errors.WithStackTrace(err)
+		}
 	}
 
 	logging.Logger.Infof("[OK] %d V2 Elastic Load Balancer(s) deleted in %s", len(deletedArns), *session.Config.Region)

--- a/aws/elbv2.go
+++ b/aws/elbv2.go
@@ -37,6 +37,7 @@ func nukeAllElbv2Instances(session *session.Session, arns []*string) error {
 	}
 
 	logging.Logger.Infof("Deleting all V2 Elastic Load Balancers in region %s", *session.Config.Region)
+	var deletedArns []*string
 
 	for _, arn := range arns {
 		params := &elbv2.DeleteLoadBalancerInput{
@@ -46,20 +47,20 @@ func nukeAllElbv2Instances(session *session.Session, arns []*string) error {
 		_, err := svc.DeleteLoadBalancer(params)
 		if err != nil {
 			logging.Logger.Errorf("[Failed] %s", err)
-			return errors.WithStackTrace(err)
+		} else {
+			deletedArns = append(deletedArns, arn)
+			logging.Logger.Infof("Deleted ELBv2: %s", *arn)
 		}
-
-		logging.Logger.Infof("Deleted ELBv2: %s", *arn)
 	}
 
 	err := svc.WaitUntilLoadBalancersDeleted(&elbv2.DescribeLoadBalancersInput{
-		LoadBalancerArns: arns,
+		LoadBalancerArns: deletedArns,
 	})
 
 	if err != nil {
 		return errors.WithStackTrace(err)
 	}
 
-	logging.Logger.Infof("[OK] %d V2 Elastic Load Balancer(s) deleted in %s", len(arns), *session.Config.Region)
+	logging.Logger.Infof("[OK] %d V2 Elastic Load Balancer(s) deleted in %s", len(deletedArns), *session.Config.Region)
 	return nil
 }

--- a/aws/elbv2.go
+++ b/aws/elbv2.go
@@ -58,6 +58,7 @@ func nukeAllElbv2Instances(session *session.Session, arns []*string) error {
 	})
 
 	if err != nil {
+		logging.Logger.Errorf("[Failed] %s", err)
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/snapshot.go
+++ b/aws/snapshot.go
@@ -42,7 +42,8 @@ func nukeAllSnapshots(session *session.Session, snapshotIds []*string) error {
 		return nil
 	}
 
-	logging.Logger.Infof("Terminating all Snapshots in region %s", *session.Config.Region)
+	logging.Logger.Infof("Deleting all Snapshots in region %s", *session.Config.Region)
+	var deletedSnapshotIDs []*string
 
 	for _, snapshotID := range snapshotIds {
 		params := &ec2.DeleteSnapshotInput{
@@ -52,12 +53,12 @@ func nukeAllSnapshots(session *session.Session, snapshotIds []*string) error {
 		_, err := svc.DeleteSnapshot(params)
 		if err != nil {
 			logging.Logger.Errorf("[Failed] %s", err)
-			return errors.WithStackTrace(err)
+		} else {
+			deletedSnapshotIDs = append(deletedSnapshotIDs, snapshotID)
+			logging.Logger.Infof("Deleted Snapshot: %s", *snapshotID)
 		}
-
-		logging.Logger.Infof("Deleted Snapshot: %s", *snapshotID)
 	}
 
-	logging.Logger.Infof("[OK] %d Snapshot(s) terminated in %s", len(snapshotIds), *session.Config.Region)
+	logging.Logger.Infof("[OK] %d Snapshot(s) terminated in %s", len(deletedSnapshotIDs), *session.Config.Region)
 	return nil
 }


### PR DESCRIPTION
Currently when iterating over resource IDs and nuking each, cloud-nuke returns from the function when it encounters an error. This results in the other resources further down the list not being deleted on that pass.

This PR updates cloud-nuke to log when it encounters an error and continue with other resources in the list. This should greatly reduce the amount of leftover resources we see and should slightly reduce our monthly costs