### PR TITLE
Nuke Launch Configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The currently supported functionality includes:
 * Deleting all AMIs in an AWS account
 * Deleting all Snapshots in an AWS account
 * Deleting all Elastic IPs in an AWS account
+* Deleting all Launch Configurations in an AWS account
 
 ## Azure
 

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -101,6 +101,19 @@ func GetAllResources(regions []string, excludedRegions []string, excludeAfter ti
 		resourcesInRegion.Resources = append(resourcesInRegion.Resources, asGroups)
 		// End ASG Names
 
+		// Launch Configuration Names
+		configNames, err := getAllLaunchConfigurations(session, region, excludeAfter)
+		if err != nil {
+			return nil, errors.WithStackTrace(err)
+		}
+
+		configs := LaunchConfigs{
+			LaunchConfigurationNames: awsgo.StringValueSlice(configNames),
+		}
+
+		resourcesInRegion.Resources = append(resourcesInRegion.Resources, configs)
+		// End Launch Configuration Names
+
 		// LoadBalancer Names
 		elbNames, err := getAllElbInstances(session, region, excludeAfter)
 		if err != nil {

--- a/aws/launch_config.go
+++ b/aws/launch_config.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+// Returns a formatted string of Launch config Names
+func getAllLaunchConfigurations(session *session.Session, region string, excludeAfter time.Time) ([]*string, error) {
+	svc := autoscaling.New(session)
+	result, err := svc.DescribeLaunchConfigurations(&autoscaling.DescribeLaunchConfigurationsInput{})
+
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	var configNames []*string
+	for _, config := range result.LaunchConfigurations {
+		if excludeAfter.After(*config.CreatedTime) {
+			configNames = append(configNames, config.LaunchConfigurationName)
+		}
+	}
+
+	return configNames, nil
+}
+
+// Deletes all Launch configurations
+func nukeAllLaunchConfigurations(session *session.Session, configNames []*string) error {
+	svc := autoscaling.New(session)
+
+	if len(configNames) == 0 {
+		logging.Logger.Infof("No Launch Configurations to nuke in region %s", *session.Config.Region)
+		return nil
+	}
+
+	logging.Logger.Infof("Deleting all Launch Configurations in region %s", *session.Config.Region)
+	var deletedConfigNames []*string
+
+	for _, configName := range configNames {
+		params := &autoscaling.DeleteLaunchConfigurationInput{
+			LaunchConfigurationName: configName,
+		}
+
+		_, err := svc.DeleteLaunchConfiguration(params)
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+		} else {
+			deletedConfigNames = append(deletedConfigNames, configName)
+			logging.Logger.Infof("Deleted Launch configuration: %s", *configName)
+		}
+	}
+
+	logging.Logger.Infof("[OK] %d Launch Configuration(s) deleted in %s", len(deletedConfigNames), *session.Config.Region)
+	return nil
+}

--- a/aws/launch_config_test.go
+++ b/aws/launch_config_test.go
@@ -1,0 +1,105 @@
+package aws
+
+import (
+	"testing"
+	"time"
+
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestLaunchConfiguration(t *testing.T, session *session.Session, name string) {
+	svc := autoscaling.New(session)
+	instance := createTestEC2Instance(t, session, name, false)
+
+	param := &autoscaling.CreateLaunchConfigurationInput{
+		LaunchConfigurationName: &name,
+		InstanceId:              instance.InstanceId,
+	}
+
+	_, err := svc.CreateLaunchConfiguration(param)
+	if err != nil {
+		assert.Failf(t, "Could not create test Launch Configuration", errors.WithStackTrace(err).Error())
+	}
+
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+}
+
+func TestListLaunchConfigurations(t *testing.T) {
+	t.Parallel()
+
+	region := getRandomRegion()
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
+
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	uniqueTestID := "cloud-nuke-test-" + util.UniqueID()
+	createTestLaunchConfiguration(t, session, uniqueTestID)
+
+	// clean up after this test
+	defer nukeAllLaunchConfigurations(session, []*string{&uniqueTestID})
+	defer nukeAllEc2Instances(session, findEC2InstancesByNameTag(t, session, uniqueTestID))
+
+	configNames, err := getAllLaunchConfigurations(session, region, time.Now().Add(1*time.Hour*-1))
+	if err != nil {
+		assert.Fail(t, "Unable to fetch list of Launch Configurations")
+	}
+
+	assert.NotContains(t, awsgo.StringValueSlice(configNames), uniqueTestID)
+
+	configNames, err = getAllLaunchConfigurations(session, region, time.Now().Add(1*time.Hour))
+	if err != nil {
+		assert.Fail(t, "Unable to fetch list of Launch Configurations")
+	}
+
+	assert.Contains(t, awsgo.StringValueSlice(configNames), uniqueTestID)
+}
+
+func TestNukeLaunchConfigurations(t *testing.T) {
+	t.Parallel()
+
+	region := getRandomRegion()
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
+	svc := autoscaling.New(session)
+
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	uniqueTestID := "cloud-nuke-test-" + util.UniqueID()
+	createTestLaunchConfiguration(t, session, uniqueTestID)
+
+	// clean up ec2 instance created by the above call
+	defer nukeAllEc2Instances(session, findEC2InstancesByNameTag(t, session, uniqueTestID))
+
+	_, err = svc.DescribeLaunchConfigurations(&autoscaling.DescribeLaunchConfigurationsInput{
+		LaunchConfigurationNames: []*string{&uniqueTestID},
+	})
+
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	if err := nukeAllLaunchConfigurations(session, []*string{&uniqueTestID}); err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	groupNames, err := getAllLaunchConfigurations(session, region, time.Now().Add(1*time.Hour))
+	if err != nil {
+		assert.Fail(t, "Unable to fetch list of Launch Configurations")
+	}
+
+	assert.NotContains(t, awsgo.StringValueSlice(groupNames), uniqueTestID)
+}

--- a/aws/launch_config_types.go
+++ b/aws/launch_config_types.go
@@ -1,0 +1,36 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+// LaunchConfigs - represents all launch configurations
+type LaunchConfigs struct {
+	LaunchConfigurationNames []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (config LaunchConfigs) ResourceName() string {
+	return "lc"
+}
+
+func (config LaunchConfigs) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 200
+}
+
+// ResourceIdentifiers - The names of the launch configurations
+func (config LaunchConfigs) ResourceIdentifiers() []string {
+	return config.LaunchConfigurationNames
+}
+
+// Nuke - nuke 'em all!!!
+func (config LaunchConfigs) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllLaunchConfigurations(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds the ability to nuke launch configurations so we no longer run into our 200 limit.

This brings to light another interesting use case for cloud-nuke. We can consider nuking resources that have quantity limits on them so automated tests don't fail because we hit the limit