### PR TITLE
Fix panic from segfaults caused by continuing from a failed condition

### DIFF
--- a/aws/elbv2_test.go
+++ b/aws/elbv2_test.go
@@ -46,7 +46,7 @@ func createTestELBv2(t *testing.T, session *session.Session, name string) elbv2.
 
 	result, err := svc.CreateLoadBalancer(param)
 	require.NoError(t, err)
-	require.Equal(t, len(result.LoadBalancers), 0)
+	require.True(t, len(result.LoadBalancers) > 0, "Could not create test ELBv2")
 
 	balancer := *result.LoadBalancers[0]
 

--- a/aws/elbv2_test.go
+++ b/aws/elbv2_test.go
@@ -9,19 +9,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/gruntwork-io/cloud-nuke/util"
-	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func getSubnetsInDifferentAZs(t *testing.T, session *session.Session) (*ec2.Subnet, *ec2.Subnet) {
 	subnetOutput, err := ec2.New(session).DescribeSubnets(&ec2.DescribeSubnetsInput{})
-	if err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
-
-	if len(subnetOutput.Subnets) < 2 {
-		assert.Fail(t, "Needs at least 2 subnets to create ELBv2")
-	}
+	require.NoError(t, err)
+	require.True(t, len(subnetOutput.Subnets) >= 2)
 
 	subnet1 := subnetOutput.Subnets[0]
 
@@ -32,7 +27,7 @@ func getSubnetsInDifferentAZs(t *testing.T, session *session.Session) (*ec2.Subn
 		}
 	}
 
-	assert.Fail(t, "Unable to find 2 subnets in different Availability Zones")
+	require.Fail(t, "Unable to find 2 subnets in different Availability Zones")
 	return nil, nil
 }
 
@@ -50,24 +45,15 @@ func createTestELBv2(t *testing.T, session *session.Session, name string) elbv2.
 	}
 
 	result, err := svc.CreateLoadBalancer(param)
-
-	if err != nil {
-		assert.Failf(t, "Could not create test ELBv2", errors.WithStackTrace(err).Error())
-	}
-
-	if len(result.LoadBalancers) == 0 {
-		assert.Failf(t, "Could not create test ELBv2", errors.WithStackTrace(err).Error())
-	}
+	require.NoError(t, err)
+	require.Equal(t, len(result.LoadBalancers), 0)
 
 	balancer := *result.LoadBalancers[0]
 
 	err = svc.WaitUntilLoadBalancerAvailable(&elbv2.DescribeLoadBalancersInput{
 		LoadBalancerArns: []*string{balancer.LoadBalancerArn},
 	})
-
-	if err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
+	require.NoError(t, err)
 
 	return balancer
 }
@@ -79,10 +65,7 @@ func TestListELBv2(t *testing.T) {
 	session, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region)},
 	)
-
-	if err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
+	require.NoError(t, err)
 
 	elbName := "cloud-nuke-test-" + util.UniqueID()
 	balancer := createTestELBv2(t, session, elbName)
@@ -90,16 +73,12 @@ func TestListELBv2(t *testing.T) {
 	defer nukeAllElbv2Instances(session, []*string{balancer.LoadBalancerArn})
 
 	arns, err := getAllElbv2Instances(session, region, time.Now().Add(1*time.Hour*-1))
-	if err != nil {
-		assert.Fail(t, "Unable to fetch list of v2 ELBs")
-	}
+	require.NoError(t, err)
 
 	assert.NotContains(t, awsgo.StringValueSlice(arns), awsgo.StringValue(balancer.LoadBalancerArn))
 
 	arns, err = getAllElbv2Instances(session, region, time.Now().Add(1*time.Hour))
-	if err != nil {
-		assert.Fail(t, "Unable to fetch list of v2 ELBs")
-	}
+	require.NoError(t, err)
 
 	assert.Contains(t, awsgo.StringValueSlice(arns), awsgo.StringValue(balancer.LoadBalancerArn))
 }
@@ -111,11 +90,9 @@ func TestNukeELBv2(t *testing.T) {
 	session, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region)},
 	)
-	svc := elbv2.New(session)
+	require.NoError(t, err)
 
-	if err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
+	svc := elbv2.New(session)
 
 	elbName := "cloud-nuke-test-" + util.UniqueID()
 	balancer := createTestELBv2(t, session, elbName)
@@ -125,27 +102,18 @@ func TestNukeELBv2(t *testing.T) {
 			balancer.LoadBalancerArn,
 		},
 	})
+	require.NoError(t, err)
 
-	if err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
-
-	if err := nukeAllElbv2Instances(session, []*string{balancer.LoadBalancerArn}); err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
+	err = nukeAllElbv2Instances(session, []*string{balancer.LoadBalancerArn})
+	require.NoError(t, err)
 
 	err = svc.WaitUntilLoadBalancersDeleted(&elbv2.DescribeLoadBalancersInput{
 		LoadBalancerArns: []*string{balancer.LoadBalancerArn},
 	})
-
-	if err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
+	require.NoError(t, err)
 
 	arns, err := getAllElbv2Instances(session, region, time.Now().Add(1*time.Hour))
-	if err != nil {
-		assert.Fail(t, "Unable to fetch list of v2 ELBs")
-	}
+	require.NoError(t, err)
 
 	assert.NotContains(t, awsgo.StringValueSlice(arns), awsgo.StringValue(balancer.LoadBalancerArn))
 }


### PR DESCRIPTION
This replaces the `if err != nil { assert.Fail() }` calls with `require.NoError`. Aside from being slightly more readable, the switch to using `require` as opposed to `assert` allows the test to exit when it shouldn't continue. By doing so, we can avoid panics halting the test and leaving resources lying around like in [this failure](https://circleci.com/gh/gruntwork-io/cloud-nuke/5857).