### PR TITLE
Add support for GCP compute instances

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,103 +2,425 @@
 
 
 [[projects]]
+  digest = "1:7131fa3a68e56764067bb569886cc7b03de5523fe5e81cbe0c70368932a1c622"
+  name = "cloud.google.com/go"
+  packages = [
+    "compute/metadata",
+    "iam",
+    "internal",
+    "internal/optional",
+    "internal/trace",
+    "internal/version",
+    "storage",
+  ]
+  pruneopts = ""
+  revision = "28a4bc8c44b3acbcc482cff0cdf7de29a4688b61"
+  version = "v0.35.1"
+
+[[projects]]
+  digest = "1:aed256b750b1ada7b3b9bd85e07ff3f1ef679302d43b81aafba0dc31ba326e0d"
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/ec2query","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/ec2","service/sts"]
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/ec2query",
+    "private/protocol/json/jsonutil",
+    "private/protocol/jsonrpc",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/autoscaling",
+    "service/ec2",
+    "service/ecs",
+    "service/elb",
+    "service/elbv2",
+    "service/iam",
+    "service/sts",
+  ]
+  pruneopts = ""
   revision = "c13a879e75646fe750d21bcb05bf2cabea9791c1"
   version = "v1.12.65"
 
 [[projects]]
+  digest = "1:15ceb8ca7a71db4c426d8aef1909ea074f6840efa163490bb2798f475624e4ae"
   name = "github.com/bgentry/speakeasy"
   packages = ["."]
+  pruneopts = ""
   revision = "4aabc24848ce5fd31929f7d1e4ea74d3709c14cd"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:c9bebdae4ac52d0c3bbe5876de3d72f3bb05b4986865cdb3f15e305e1dc4fbca"
   name = "github.com/fatih/color"
   packages = ["."]
+  pruneopts = ""
   revision = "570b54cabe6b8eb0bc2dfce68d964677d63b5260"
   version = "v1.5.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:26317724ed32bcf2ef15454613d2a8fe9d670b12f073cfd20db3bcec54e069ab"
   name = "github.com/go-errors/errors"
   packages = ["."]
-  revision = "3afebba5a48dbc89b574d890b6b34d9ee10b4785"
-  version = "v1.0.0"
+  pruneopts = ""
+  revision = "d98b870cc4e05f1545532a80e9909be8216095b6"
 
 [[projects]]
+  digest = "1:a00483fe4106b86fb1187a92b5cf6915c85f294ed4c129ccbe7cb1f1a06abd46"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = ""
   revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
   version = "v1.32.0"
 
 [[projects]]
+  digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
+  name = "github.com/golang/protobuf"
+  packages = [
+    "proto",
+    "protoc-gen-go/descriptor",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp",
+  ]
+  pruneopts = ""
+  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
+  version = "v1.2.0"
+
+[[projects]]
+  digest = "1:55c1b46a80db2baf4d762c1d0b5cb4946e46125baa02b8959310abab15b54aee"
+  name = "github.com/googleapis/gax-go"
+  packages = ["v2"]
+  pruneopts = ""
+  revision = "c8a15bac9b9fe955bd9f900272f9a306465d28cf"
+  version = "v2.0.3"
+
+[[projects]]
+  digest = "1:945bd89ef3393fc20dc43aeec26104306f76923b171efb0f3456ffc7f5164314"
   name = "github.com/gruntwork-io/gruntwork-cli"
-  packages = ["entrypoint","errors","logging","shell"]
+  packages = [
+    "collections",
+    "entrypoint",
+    "errors",
+    "logging",
+    "shell",
+  ]
+  pruneopts = ""
   revision = "94044eeeb0a48b5e8dd52190fa0d0daba53e157f"
   version = "v0.1.2"
 
 [[projects]]
+  branch = "master"
+  digest = "1:b051855ca1aeffb15e191117d0ad77095eba9b1d768c1297ffa2bd80ae107da8"
+  name = "github.com/gruntwork-io/terratest"
+  packages = [
+    "modules/collections",
+    "modules/environment",
+    "modules/gcp",
+    "modules/logger",
+    "modules/random",
+  ]
+  pruneopts = ""
+  revision = "16b8c60f1c1a0a757acc3f25725050d41e47bb77"
+
+[[projects]]
+  digest = "1:6f49eae0c1e5dab1dafafee34b207aeb7a42303105960944828c2079b92fc88e"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = ""
   revision = "0b12d6b5"
 
 [[projects]]
+  digest = "1:9ea83adf8e96d6304f394d40436f2eb44c1dc3250d223b74088cc253a6cd0a1c"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
+  pruneopts = ""
   revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
   version = "v0.0.9"
 
 [[projects]]
+  digest = "1:78229b46ddb7434f881390029bd1af7661294af31f6802e0e1bedaad4ab0af3c"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = ""
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:42a42c4bc67bed17f40fddf0f24d4403e25e7b96488456cf4248e6d16659d370"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = ""
   revision = "d682213848ed68c0a260ca37d6dd5ace8423f5ba"
   version = "v1.0.4"
 
 [[projects]]
+  digest = "1:2d0dc026c4aef5e2f3a0e06a4dabe268b840d8f63190cf6894e02134a03f52c5"
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "require",
+  ]
+  pruneopts = ""
   revision = "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:e85837cb04b78f61688c6eba93ea9d14f60d611e2aaf8319999b1a60d2dafbfa"
   name = "github.com/urfave/cli"
   packages = ["."]
+  pruneopts = ""
   revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
   version = "v1.20.0"
 
 [[projects]]
+  digest = "1:b1bb9332f6cb7821a730e1681819b2813340eba5e873f05381815a7c6807d172"
+  name = "go.opencensus.io"
+  packages = [
+    ".",
+    "exemplar",
+    "internal",
+    "internal/tagencoding",
+    "plugin/ochttp",
+    "plugin/ochttp/propagation/b3",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
+    "trace",
+    "trace/internal",
+    "trace/propagation",
+    "trace/tracestate",
+  ]
+  pruneopts = ""
+  revision = "2b5032d79456124f42db6b7eb19ac6c155449dc2"
+  version = "v0.19.0"
+
+[[projects]]
   branch = "master"
+  digest = "1:43adf91783cc814f60c0dd21c9aadf0b5284721e13542e124536638e0b43a6b3"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = ""
   revision = "13931e22f9e72ea58bb73048bc752b48c6d4d4ac"
 
 [[projects]]
   branch = "master"
+  digest = "1:552c5a9b4a2cd4d21efdba35fff561e13f0c666bf4c82fcedbb4e031b704aa61"
+  name = "golang.org/x/net"
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "trace",
+  ]
+  pruneopts = ""
+  revision = "ed066c81e75eba56dd9bd2139ade88125b855585"
+
+[[projects]]
+  digest = "1:b697592485cb412be4188c08ca0beed9aab87f36b86418e21acc4a3998f63734"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "google",
+    "internal",
+    "jws",
+    "jwt",
+  ]
+  pruneopts = ""
+  revision = "d2e6202438beef2727060aa7cabdd924d92ebfd9"
+
+[[projects]]
+  digest = "1:1132cbdac95d6a2a30f7434f7190b3b1345e85b6071e74911b1dce3e19e1543d"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
-  revision = "2c42eef0765b9837fbdab12011af7830f55f88f0"
+  packages = [
+    "unix",
+    "windows",
+  ]
+  pruneopts = ""
+  revision = "1c9583448a9c3aa0f9a6a5241bf73c0bd8aafded"
+
+[[projects]]
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
+  name = "golang.org/x/text"
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+  ]
+  pruneopts = ""
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:c61acf593dd92045509a7c2e150a3ac54617f1615a02bed6ef471e548334d3d9"
+  name = "google.golang.org/api"
+  packages = [
+    "compute/v1",
+    "gensupport",
+    "googleapi",
+    "googleapi/internal/uritemplates",
+    "googleapi/transport",
+    "internal",
+    "iterator",
+    "option",
+    "storage/v1",
+    "transport/http",
+    "transport/http/internal/propagation",
+  ]
+  pruneopts = ""
+  revision = "94ff0f689b51c3f5629a48b152198c5e386eed9f"
+
+[[projects]]
+  digest = "1:bc09e719c4e2a15d17163f5272d9a3131c45d77542b7fdc53ff518815bc19ab3"
+  name = "google.golang.org/appengine"
+  packages = [
+    ".",
+    "internal",
+    "internal/app_identity",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/modules",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch",
+  ]
+  pruneopts = ""
+  revision = "e9657d882bb81064595ca3b56cbe2546bbabf7b1"
+  version = "v1.4.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2255fee1df9431ec9c0a373a4e112a60b28ae435d7af57d69f4f2e2e86800cad"
+  name = "google.golang.org/genproto"
+  packages = [
+    "googleapis/api/annotations",
+    "googleapis/iam/v1",
+    "googleapis/rpc/code",
+    "googleapis/rpc/status",
+  ]
+  pruneopts = ""
+  revision = "8819c946db4494a2259bf100a377f51aa585d893"
+
+[[projects]]
+  digest = "1:39d4d828b87d58d114fdc211f0638f32dcae84019fe17d6b48f9b697f4b60213"
+  name = "google.golang.org/grpc"
+  packages = [
+    ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "binarylog/grpc_binarylog_v1",
+    "codes",
+    "connectivity",
+    "credentials",
+    "credentials/internal",
+    "encoding",
+    "encoding/proto",
+    "grpclog",
+    "internal",
+    "internal/backoff",
+    "internal/binarylog",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/grpcsync",
+    "internal/syscall",
+    "internal/transport",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap",
+  ]
+  pruneopts = ""
+  revision = "a02b0774206b209466313a0b525d2c738fe407eb"
+  version = "v1.18.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f565d90c6d10da0317d3cf32baa42bce0d5872351b81fc979f36c4b51ccb1be4"
+  input-imports = [
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/awserr",
+    "github.com/aws/aws-sdk-go/aws/endpoints",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/autoscaling",
+    "github.com/aws/aws-sdk-go/service/ec2",
+    "github.com/aws/aws-sdk-go/service/ecs",
+    "github.com/aws/aws-sdk-go/service/elb",
+    "github.com/aws/aws-sdk-go/service/elbv2",
+    "github.com/aws/aws-sdk-go/service/iam",
+    "github.com/fatih/color",
+    "github.com/gruntwork-io/gruntwork-cli/collections",
+    "github.com/gruntwork-io/gruntwork-cli/entrypoint",
+    "github.com/gruntwork-io/gruntwork-cli/errors",
+    "github.com/gruntwork-io/gruntwork-cli/logging",
+    "github.com/gruntwork-io/gruntwork-cli/shell",
+    "github.com/gruntwork-io/terratest/modules/gcp",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+    "github.com/urfave/cli",
+    "golang.org/x/net/context",
+    "golang.org/x/oauth2",
+    "golang.org/x/oauth2/google",
+    "google.golang.org/api/compute/v1",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,3 +47,11 @@
 [[constraint]]
   name = "github.com/fatih/color"
   version = "1.5.0"
+
+[[constraint]]
+  branch = "master"
+  name = "google.golang.org/api"
+
+[[constraint]]
+  branch = "master"
+  name = "golang.org/x/net"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,13 +52,13 @@
   branch = "master"
   name = "google.golang.org/api"
 
+[[override]]
+  name = "golang.org/x/sys"
+  revision = "1c9583448a9c3aa0f9a6a5241bf73c0bd8aafded"
+
 [[constraint]]
   branch = "master"
   name = "golang.org/x/net"
-
-[[constraint]]
-  name = "cloud.google.com/go"
-  version = "0.26.0"
 
 [[constraint]]
   name = "github.com/gruntwork-io/terratest"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -55,3 +55,7 @@
 [[constraint]]
   branch = "master"
   name = "golang.org/x/net"
+
+[[constraint]]
+  name = "github.com/gruntwork-io/terratest"
+  version = "0.13.22"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,5 +57,9 @@
   name = "golang.org/x/net"
 
 [[constraint]]
+  name = "cloud.google.com/go"
+  version = "0.26.0"
+
+[[constraint]]
   name = "github.com/gruntwork-io/terratest"
   version = "0.13.22"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ _Coming Soon_
 
 ## GCP
 
-_Coming Soon_
+*GCP support is in the early stages of development and should be considered experimental.*
+
+* Deleting all Compute Engine Instances in a GCP project
 
 ### WARNING: THIS TOOL IS HIGHLY DESTRUCTIVE, ALL SUPPORTED RESOURCES WILL BE DELETED. ITS EFFECTS ARE IRREVERSIBLE AND SHOULD NEVER BE USED IN A PRODUCTION ENVIRONMENT
 

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -116,6 +116,8 @@ func regionIsValid(ctx *gcp.GcpContext, region string) bool {
 }
 
 func gcpNuke(c *cli.Context) error {
+	// TODO accept multiple credentials and nuke resources on all the projects
+	// specified by a command line parameter we have authorization for.
 	ctx, err := gcp.DefaultContext()
 	if err != nil {
 		return errors.WithStackTrace(err)

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -111,6 +111,10 @@ func promptForConfirmationBeforeNuking(force bool) (bool, error) {
 	}
 }
 
+func regionIsValid(ctx *gcp.GcpContext, region string) bool {
+	return ctx.ContainsRegion(region)
+}
+
 func gcpNuke(c *cli.Context) error {
 	ctx, err := gcp.DefaultContext()
 	if err != nil {
@@ -122,9 +126,9 @@ func gcpNuke(c *cli.Context) error {
 	excludedRegions := c.StringSlice("exclude-region")
 
 	for _, excludedRegion := range excludedRegions {
-		if !ctx.ContainsRegion(excludedRegion) {
+		if !regionIsValid(ctx, excludedRegion) {
 			return InvalidFlagError{
-				Name:  "exclude-regions",
+				Name:  "exclude-region",
 				Value: excludedRegion,
 			}
 		}

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/gruntwork-io/gruntwork-cli/collections"
 
+	goerrors "errors"
 	"github.com/fatih/color"
 	"github.com/gruntwork-io/cloud-nuke/aws"
+	"github.com/gruntwork-io/cloud-nuke/gcp"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/gruntwork-io/gruntwork-cli/shell"
@@ -45,6 +47,26 @@ func CreateCli(version string) *cli.App {
 				},
 			},
 		},
+		{
+			Name:   "gcp",
+			Usage:  "Clean up GCP resources (GCE instances)",
+			Action: errors.WithPanicHandling(gcpNuke),
+			Flags: []cli.Flag{
+				cli.StringSliceFlag{
+					Name:  "exclude-region",
+					Usage: "regions to exclude",
+				},
+				cli.StringFlag{
+					Name:  "older-than",
+					Usage: "Only delete resources older than this specified value. Can be any valid Go duration, such as 10m or 8h.",
+					Value: "0s",
+				},
+				cli.BoolFlag{
+					Name:  "force",
+					Usage: "Skip nuke confirmation prompt. WARNING: this will automatically delete all resources without any confirmation",
+				},
+			},
+		},
 	}
 
 	return app
@@ -61,6 +83,94 @@ func parseDurationParam(paramValue string) (*time.Time, error) {
 
 	excludeAfter := time.Now().Add(duration)
 	return &excludeAfter, nil
+}
+
+func promptForConfirmationBeforeNuking(force bool) (bool, error) {
+	if force {
+		logging.Logger.Infoln("The --force flag is set, so waiting for 10 seconds before proceeding to nuke everything in your project. If you don't want to proceed, hit CTRL+C now!!")
+		for i := 10; i > 0; i-- {
+			fmt.Printf("%d...", i)
+			time.Sleep(1 * time.Second)
+		}
+
+		fmt.Println()
+		return true, nil
+	} else {
+		color := color.New(color.FgHiRed, color.Bold)
+		color.Println("\nTHE NEXT STEPS ARE DESTRUCTIVE AND COMPLETELY IRREVERSIBLE, PROCEED WITH CAUTION!!!")
+
+		prompt := "\nAre you sure you want to nuke all listed resources? Enter 'nuke' to confirm: "
+		shellOptions := shell.ShellOptions{Logger: logging.Logger}
+		input, err := shell.PromptUserForInput(prompt, &shellOptions)
+
+		if err != nil {
+			return false, errors.WithStackTrace(err)
+		}
+
+		return strings.ToLower(input) == "nuke", nil
+	}
+}
+
+func gcpNuke(c *cli.Context) error {
+	ctx, err := gcp.DefaultContext()
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	logging.Logger.Infof("Using project: %s", ctx.Project)
+
+	excludedRegions := c.StringSlice("exclude-region")
+
+	for _, excludedRegion := range excludedRegions {
+		if !ctx.ContainsRegion(excludedRegion) {
+			return InvalidFlagError{
+				Name:  "exclude-regions",
+				Value: excludedRegion,
+			}
+		}
+	}
+
+	excludeAfter, err := parseDurationParam(c.String("older-than"))
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	logging.Logger.Infoln("Retrieving all active GCP resources")
+
+	resources, err := ctx.GetAllResources(excludedRegions, *excludeAfter)
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	if len(resources) == 0 {
+		logging.Logger.Infoln("Nothing to nuke, you're all good!")
+		return nil
+	}
+
+	logging.Logger.Infoln("The following GCP resources are going to be nuked: ")
+
+	for _, resource := range resources {
+		logging.Logger.Infof("* %s: %s Region=%s %s=%s",
+			resource.ResourceName(), resource.Name(), resource.Region(),
+			resource.LocationName(), resource.Location())
+	}
+
+	confirmation, err := promptForConfirmationBeforeNuking(c.Bool("force"))
+	if err != nil {
+		return err
+	}
+
+	if confirmation {
+		nukeErrors := ctx.NukeAllResources(resources)
+		if len(nukeErrors) != 0 {
+			for _, err := range nukeErrors {
+				logging.Logger.Errorf(errors.WithStackTrace(err).Error())
+			}
+			return goerrors.New("Some resources failed to nuke.")
+		}
+	}
+
+	return nil
 }
 
 func awsNuke(c *cli.Context) error {
@@ -103,31 +213,12 @@ func awsNuke(c *cli.Context) error {
 		}
 	}
 
-	if !c.Bool("force") {
-		color := color.New(color.FgHiRed, color.Bold)
-		color.Println("\nTHE NEXT STEPS ARE DESTRUCTIVE AND COMPLETELY IRREVERSIBLE, PROCEED WITH CAUTION!!!")
+	confirmation, err := promptForConfirmationBeforeNuking(c.Bool("force"))
+	if err != nil {
+		return err
+	}
 
-		prompt := "\nAre you sure you want to nuke all listed resources? Enter 'nuke' to confirm: "
-		shellOptions := shell.ShellOptions{Logger: logging.Logger}
-		input, err := shell.PromptUserForInput(prompt, &shellOptions)
-
-		if err != nil {
-			return errors.WithStackTrace(err)
-		}
-
-		if strings.ToLower(input) == "nuke" {
-			if err := aws.NukeAllResources(account, regions); err != nil {
-				return err
-			}
-		}
-	} else {
-		logging.Logger.Infoln("The --force flag is set, so waiting for 10 seconds before proceeding to nuke everything in your account. If you don't want to proceed, hit CTRL+C now!!")
-		for i := 10; i > 0; i-- {
-			fmt.Printf("%d...", i)
-			time.Sleep(1 * time.Second)
-		}
-
-		fmt.Println()
+	if confirmation {
 		if err := aws.NukeAllResources(account, regions); err != nil {
 			return err
 		}

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -150,9 +150,8 @@ func gcpNuke(c *cli.Context) error {
 	logging.Logger.Infoln("The following GCP resources are going to be nuked: ")
 
 	for _, resource := range resources {
-		logging.Logger.Infof("* %s: %s Region=%s %s=%s",
-			resource.ResourceName(), resource.Name(), resource.Region(),
-			resource.LocationName(), resource.Location())
+		logging.Logger.Infof("* %s: %s Region=%s Zone=%s",
+			resource.Kind(), resource.Name(), resource.Region(), resource.Zone())
 	}
 
 	confirmation, err := promptForConfirmationBeforeNuking(c.Bool("force"))

--- a/gcp/gce_instance.go
+++ b/gcp/gce_instance.go
@@ -1,0 +1,85 @@
+package gcp
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+func zoneFromUrl(url string) (string, error) {
+	split := strings.Split(url, "/")
+	if len(split) == 0 {
+		return "", errors.New("got invalid zone url: " + url)
+	}
+	return split[len(split)-1], nil
+}
+
+func regionFromZone(ctx *GcpContext, zone string) (string, error) {
+	for _, region := range ctx.Regions {
+		for _, regionZoneUrl := range region.Zones {
+			regionZone, err := zoneFromUrl(regionZoneUrl)
+			if err != nil {
+				return "", err
+			}
+			if zone == regionZone {
+				return region.Name, nil
+			}
+		}
+	}
+
+	return "", errors.New("could not get region for zone: " + zone)
+}
+
+func GetAllGceInstances(ctx *GcpContext, excludedRegions []string, excludeAfter time.Time) ([]GcpResource, error) {
+	instances := []GcpResource{}
+
+	apiInstances, err := ctx.Service.Instances.AggregatedList(ctx.Project).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range apiInstances.Items {
+		for _, apiInstance := range item.Instances {
+			// skip if deletion protection is turned on
+			if apiInstance.DeletionProtection {
+				continue
+			}
+
+			zone, err := zoneFromUrl(apiInstance.Zone)
+			if err != nil {
+				return nil, err
+			}
+
+			region, err := regionFromZone(ctx, zone)
+			if err != nil {
+				return nil, err
+			}
+
+			// skip if the region is excluded
+			for _, excludedRegion := range excludedRegions {
+				if region == excludedRegion {
+					continue
+				}
+			}
+
+			// skip if created after the given time
+			creationTime, err := time.Parse(time.RFC3339, apiInstance.CreationTimestamp)
+			if err != nil {
+				return nil, err
+			}
+			if creationTime.After(excludeAfter) {
+				continue
+			}
+
+			instance := GceInstanceResource{
+				InstanceName: apiInstance.Name,
+				Zone:         zone,
+				RegionName:   region,
+			}
+
+			instances = append(instances, instance)
+		}
+	}
+
+	return instances, nil
+}

--- a/gcp/gce_instance.go
+++ b/gcp/gce_instance.go
@@ -37,6 +37,7 @@ func regionFromZone(ctx *GcpContext, zone string) (string, error) {
 func GetAllGceInstances(ctx *GcpContext, excludedRegions []string, excludeAfter time.Time) ([]GcpResource, error) {
 	instances := []GcpResource{}
 
+	// TODO add this functionality to terratest
 	apiInstances, err := ctx.Service.Instances.AggregatedList(ctx.Project).Do()
 	if err != nil {
 		return nil, err

--- a/gcp/gce_instance.go
+++ b/gcp/gce_instance.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+// Given a url for a zone from the api, extract the name of the zone
 func zoneFromUrl(url string) (string, error) {
 	split := strings.Split(url, "/")
 	if len(split) == 0 {
@@ -14,6 +15,7 @@ func zoneFromUrl(url string) (string, error) {
 	return split[len(split)-1], nil
 }
 
+// For a given zone, get the region it is located in
 func regionFromZone(ctx *GcpContext, zone string) (string, error) {
 	for _, region := range ctx.Regions {
 		for _, regionZoneUrl := range region.Zones {
@@ -30,6 +32,8 @@ func regionFromZone(ctx *GcpContext, zone string) (string, error) {
 	return "", errors.New("could not get region for zone: " + zone)
 }
 
+// Get the compute instances for the project of the context as a list of
+// GcpResources for nuking
 func GetAllGceInstances(ctx *GcpContext, excludedRegions []string, excludeAfter time.Time) ([]GcpResource, error) {
 	instances := []GcpResource{}
 

--- a/gcp/gce_instance.go
+++ b/gcp/gce_instance.go
@@ -72,9 +72,10 @@ func GetAllGceInstances(ctx *GcpContext, excludedRegions []string, excludeAfter 
 			}
 
 			instance := GceInstanceResource{
-				InstanceName: apiInstance.Name,
-				Zone:         zone,
-				RegionName:   region,
+				kind:   apiInstance.Kind,
+				name:   apiInstance.Name,
+				zone:   zone,
+				region: region,
 			}
 
 			instances = append(instances, instance)

--- a/gcp/gce_instance_test.go
+++ b/gcp/gce_instance_test.go
@@ -16,6 +16,7 @@ func testZone() string {
 	return "us-central1-c"
 }
 
+// Whether this list of resources contains a resource with the given name
 func resourcesContains(resources []GcpResource, name string) bool {
 	for _, resource := range resources {
 		if resource.Name() == name && resource.Zone() == testZone() {
@@ -26,6 +27,7 @@ func resourcesContains(resources []GcpResource, name string) bool {
 	return false
 }
 
+// Create a compute instance with the given name and protection status
 func createTestInstance(ctx *GcpContext, name string, protected bool) error {
 	machineType := fmt.Sprintf("projects/%s/zones/%s/machineTypes/f1-micro", ctx.Project, testZone())
 
@@ -70,6 +72,8 @@ func cleanupInstances(t *testing.T, ctx *GcpContext, names []string) {
 	}
 }
 
+// Test that the context correctly chaches regions and can get zone names from
+// zone urls
 func TestRegionZones(t *testing.T) {
 	t.Parallel()
 
@@ -93,6 +97,7 @@ func TestRegionZones(t *testing.T) {
 	}
 }
 
+// Create several instances and test that they can be nuked
 func TestNukeInstances(t *testing.T) {
 	t.Parallel()
 

--- a/gcp/gce_instance_test.go
+++ b/gcp/gce_instance_test.go
@@ -18,7 +18,7 @@ func testZone() string {
 
 func resourcesContains(resources []GcpResource, name string) bool {
 	for _, resource := range resources {
-		if resource.Name() == name && resource.Location() == testZone() {
+		if resource.Name() == name && resource.Zone() == testZone() {
 			return true
 		}
 	}

--- a/gcp/gce_instance_test.go
+++ b/gcp/gce_instance_test.go
@@ -25,6 +25,8 @@ func resourcesContains(resources []GcpResource, zone string, name string) bool {
 }
 
 // Create a compute instance with the given name and protection status
+// TODO use terratest
+// see: https://github.com/gruntwork-io/terratest/blob/53f629c1d90bd816335ff57f390aa750854b2994/modules/gcp/compute_test.go#L148
 func createTestInstance(ctx *GcpContext, name string, zone string, protected bool) error {
 	machineType := fmt.Sprintf("projects/%s/zones/%s/machineTypes/f1-micro", ctx.Project, zone)
 
@@ -52,6 +54,9 @@ func createTestInstance(ctx *GcpContext, name string, zone string, protected boo
 	return err
 }
 
+// Delete the specified instances
+// TODO use terratest
+// see https://github.com/gruntwork-io/terratest/blob/53f629c1d90bd816335ff57f390aa750854b2994/modules/gcp/compute_test.go#L204
 func cleanupInstances(t *testing.T, ctx *GcpContext, zone string, names []string) {
 	for _, name := range names {
 		call := ctx.Service.Instances.SetDeletionProtection(ctx.Project, zone, name)

--- a/gcp/gce_instance_test.go
+++ b/gcp/gce_instance_test.go
@@ -1,0 +1,147 @@
+package gcp
+
+import (
+	"fmt"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	gruntworkerrors "github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	compute "google.golang.org/api/compute/v1"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testZone() string {
+	return "us-central1-c"
+}
+
+func resourcesContains(resources []GcpResource, name string) bool {
+	for _, resource := range resources {
+		if resource.Name() == name && resource.Location() == testZone() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func createTestInstance(ctx *GcpContext, name string, protected bool) error {
+	machineType := fmt.Sprintf("projects/%s/zones/%s/machineTypes/f1-micro", ctx.Project, testZone())
+
+	iface := &compute.NetworkInterface{}
+
+	initializeParams := &compute.AttachedDiskInitializeParams{
+		SourceImage: "projects/debian-cloud/global/images/debian-9-stretch-v20181113",
+	}
+
+	disk := &compute.AttachedDisk{
+		AutoDelete:       true,
+		Boot:             true,
+		InitializeParams: initializeParams,
+	}
+
+	instance := &compute.Instance{
+		Name:               name,
+		MachineType:        machineType,
+		DeletionProtection: protected,
+		NetworkInterfaces:  []*compute.NetworkInterface{iface},
+		Disks:              []*compute.AttachedDisk{disk},
+	}
+
+	_, err := ctx.Service.Instances.Insert(ctx.Project, testZone(), instance).Do()
+	return err
+}
+
+func cleanupInstances(t *testing.T, ctx *GcpContext, names []string) {
+	for _, name := range names {
+		call := ctx.Service.Instances.SetDeletionProtection(ctx.Project, testZone(), name)
+		call.DeletionProtection(false)
+
+		_, err := call.Do()
+		if err != nil {
+			t.Logf("Warning: could not unset deletion protection on instance: %s %s", name, gruntworkerrors.WithStackTrace(err).Error())
+		}
+
+		_, err = ctx.Service.Instances.Delete(ctx.Project, testZone(), name).Do()
+		if err != nil {
+			t.Logf("Warning: could not delete instance: %s %s", name, gruntworkerrors.WithStackTrace(err).Error())
+		}
+	}
+}
+
+func TestRegionZones(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := DefaultContext()
+	require.NoError(t, err)
+
+	for _, region := range ctx.Regions {
+		for _, zoneUrl := range region.Zones {
+			zone, err := zoneFromUrl(zoneUrl)
+			if !assert.NoError(t, err) {
+				continue
+			}
+
+			regionName, err := regionFromZone(ctx, zone)
+			if !assert.NoError(t, err) {
+				continue
+			}
+
+			assert.Equal(t, region.Name, regionName)
+		}
+	}
+}
+
+func TestNukeInstances(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := DefaultContext()
+	require.NoError(t, err)
+
+	instanceName := strings.ToLower("cloud-nuke-test-" + util.UniqueID())
+	protectedInstanceName := strings.ToLower("cloud-nuke-test-" + util.UniqueID())
+
+	defer cleanupInstances(t, ctx, []string{instanceName, protectedInstanceName})
+
+	err = createTestInstance(ctx, instanceName, false)
+	require.NoError(t, err)
+
+	err = createTestInstance(ctx, protectedInstanceName, true)
+	require.NoError(t, err)
+
+	instances, err := GetAllGceInstances(ctx, []string{}, time.Now().Add(1*time.Hour))
+	require.NoError(t, err)
+
+	assert.True(t, resourcesContains(instances, instanceName),
+		"the created instance should show up in the list of instances")
+	assert.False(t, resourcesContains(instances, protectedInstanceName),
+		"the protected instance should not show up in the list of instances")
+
+	nukeErrors := ctx.NukeAllResources(instances)
+	if len(nukeErrors) != 0 {
+		for _, err = range nukeErrors {
+			t.Logf(gruntworkerrors.WithStackTrace(err).Error())
+		}
+		assert.FailNow(t, "Some resources failed to nuke.")
+	}
+
+	// status doesn't update immediately, so give it a minute or two to show it
+	// is terminating
+	lastStatus := ""
+	for tries := 0; tries < 40; tries++ {
+		instance, err := ctx.Service.Instances.Get(ctx.Project, testZone(), instanceName).Do()
+		require.NoError(t, err)
+
+		lastStatus = instance.Status
+
+		if instance.Status == "TERMINATED" {
+			break
+		}
+
+		time.Sleep(3 * time.Second)
+	}
+
+	require.Equal(t, "TERMINATED", lastStatus,
+		"instance should terminate after it is nuked within two minutes")
+}

--- a/gcp/gce_instance_test.go
+++ b/gcp/gce_instance_test.go
@@ -138,7 +138,7 @@ func TestNukeInstances(t *testing.T) {
 	// status doesn't update immediately, so give it a minute or two to show it
 	// is terminating
 	lastStatus := ""
-	for tries := 0; tries < 40; tries++ {
+	for tries := 0; tries < 100; tries++ {
 		instance, err := ctx.Service.Instances.Get(ctx.Project, zone, instanceName).Do()
 		require.NoError(t, err)
 
@@ -152,5 +152,5 @@ func TestNukeInstances(t *testing.T) {
 	}
 
 	require.Equal(t, "TERMINATED", lastStatus,
-		"instance should terminate after it is nuked within two minutes")
+		"instance should terminate after it is nuked within five minutes")
 }

--- a/gcp/gce_instance_types.go
+++ b/gcp/gce_instance_types.go
@@ -1,32 +1,29 @@
 package gcp
 
 type GceInstanceResource struct {
-	InstanceName string
-	Zone         string
-	RegionName   string
+	kind   string
+	name   string
+	zone   string
+	region string
 }
 
-func (instance GceInstanceResource) ResourceName() string {
-	return "GCE Instance"
+func (instance GceInstanceResource) Kind() string {
+	return instance.kind
 }
 
 func (instance GceInstanceResource) Name() string {
-	return instance.InstanceName
+	return instance.name
 }
 
-func (instance GceInstanceResource) LocationName() string {
-	return "Zone"
-}
-
-func (instance GceInstanceResource) Location() string {
-	return instance.Zone
+func (instance GceInstanceResource) Zone() string {
+	return instance.zone
 }
 
 func (instance GceInstanceResource) Region() string {
-	return instance.RegionName
+	return instance.region
 }
 
 func (instance GceInstanceResource) Nuke(ctx *GcpContext) error {
-	_, err := ctx.Service.Instances.Delete(ctx.Project, instance.Zone, instance.InstanceName).Do()
+	_, err := ctx.Service.Instances.Delete(ctx.Project, instance.zone, instance.name).Do()
 	return err
 }

--- a/gcp/gce_instance_types.go
+++ b/gcp/gce_instance_types.go
@@ -1,0 +1,32 @@
+package gcp
+
+type GceInstanceResource struct {
+	InstanceName string
+	Zone         string
+	RegionName   string
+}
+
+func (instance GceInstanceResource) ResourceName() string {
+	return "GCE Instance"
+}
+
+func (instance GceInstanceResource) Name() string {
+	return instance.InstanceName
+}
+
+func (instance GceInstanceResource) LocationName() string {
+	return "Zone"
+}
+
+func (instance GceInstanceResource) Location() string {
+	return instance.Zone
+}
+
+func (instance GceInstanceResource) Region() string {
+	return instance.RegionName
+}
+
+func (instance GceInstanceResource) Nuke(ctx *GcpContext) error {
+	_, err := ctx.Service.Instances.Delete(ctx.Project, instance.Zone, instance.InstanceName).Do()
+	return err
+}

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -1,0 +1,115 @@
+package gcp
+
+import (
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+	google "golang.org/x/oauth2/google"
+	compute "google.golang.org/api/compute/v1"
+	"net/http"
+	"time"
+)
+
+type GcpContext struct {
+	Client  *http.Client
+	Service *compute.Service
+	Project string
+	Regions []*compute.Region
+}
+
+func DefaultContext() (*GcpContext, error) {
+	creds, err := google.FindDefaultCredentials(oauth2.NoContext, compute.ComputeScope)
+	if err != nil {
+		return nil, err
+	}
+	client := oauth2.NewClient(context.Background(), creds.TokenSource)
+
+	service, err := compute.New(client)
+	if err != nil {
+		return nil, err
+	}
+
+	regions, err := service.Regions.List(creds.ProjectID).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	context := &GcpContext{
+		Client:  client,
+		Service: service,
+		Project: creds.ProjectID,
+		Regions: regions.Items,
+	}
+
+	return context, nil
+}
+
+func (ctx *GcpContext) ContainsRegion(region string) bool {
+	for _, r := range ctx.Regions {
+		if r.Name == region {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ctx *GcpContext) GetAllResources(excludedRegions []string, excludeAfter time.Time) ([]GcpResource, error) {
+	resources := []GcpResource{}
+
+	instances, err := GetAllGceInstances(ctx, excludedRegions, excludeAfter)
+	if err != nil {
+		return nil, err
+	}
+
+	resources = append(resources, instances...)
+
+	return resources, nil
+}
+
+type NukeWorkerResult struct {
+	Resource GcpResource
+	Err      error
+}
+
+func nukeWorker(ctx *GcpContext, resource GcpResource, output chan<- NukeWorkerResult) {
+	err := resource.Nuke(ctx)
+	result := NukeWorkerResult{
+		Resource: resource,
+		Err:      err,
+	}
+	output <- result
+}
+
+func (ctx *GcpContext) NukeAllResources(resources []GcpResource) []error {
+	nukeErrors := []error{}
+	batchSize := 5
+	results := make(chan NukeWorkerResult, 100)
+
+	if len(resources) < batchSize {
+		batchSize = len(resources)
+	}
+
+	for i := 0; i < batchSize; i++ {
+		go nukeWorker(ctx, resources[i], results)
+	}
+
+	for i := 0; i < len(resources); i++ {
+		result := <-results
+		if result.Err != nil {
+			logging.Logger.Warnf("Could not delete resource: %s: %s Region=%s %s=%s \n%s",
+				result.Resource.ResourceName(), result.Resource.Name(), result.Resource.Region(),
+				result.Resource.LocationName(), result.Resource.Location(),
+				errors.WithStackTrace(result.Err).Error())
+			nukeErrors = append(nukeErrors, result.Err)
+		}
+
+		next := i + batchSize
+		if next < len(resources) {
+			go nukeWorker(ctx, resources[next], results)
+		}
+	}
+
+	return nukeErrors
+}

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -98,9 +98,9 @@ func (ctx *GcpContext) NukeAllResources(resources []GcpResource) []error {
 	for i := 0; i < len(resources); i++ {
 		result := <-results
 		if result.Err != nil {
-			logging.Logger.Warnf("Could not delete resource: %s: %s Region=%s %s=%s \n%s",
-				result.Resource.ResourceName(), result.Resource.Name(), result.Resource.Region(),
-				result.Resource.LocationName(), result.Resource.Location(),
+			logging.Logger.Warnf("Could not delete resource: %s: %s Region=%s Zone=%s \n%s",
+				result.Resource.Kind(), result.Resource.Name(), result.Resource.Region(),
+				result.Resource.Zone(),
 				errors.WithStackTrace(result.Err).Error())
 			nukeErrors = append(nukeErrors, result.Err)
 		}

--- a/gcp/types.go
+++ b/gcp/types.go
@@ -1,10 +1,16 @@
 package gcp
 
+// An abstract GCP Resource
 type GcpResource interface {
-	ResourceName() string
+	// Friendly name for what kind of resource this is
+	Kind() string
+	// The name that identifies this resources for the location
 	Name() string
-	LocationName() string
-	Location() string
+	// The zone this resource is located in. Empty if the kind of resource kind
+	// is not located by zone.
+	Zone() string
+	// The region this resource is located in
 	Region() string
+	// Destroys the resource
 	Nuke(ctx *GcpContext) error
 }

--- a/gcp/types.go
+++ b/gcp/types.go
@@ -1,0 +1,10 @@
+package gcp
+
+type GcpResource interface {
+	ResourceName() string
+	Name() string
+	LocationName() string
+	Location() string
+	Region() string
+	Nuke(ctx *GcpContext) error
+}


### PR DESCRIPTION
This lays the groundwork for general GCP support for cloud-nuke with
support for deleting compute instances.

Add the `gcp` package and CLI argument to nuke GCP resources.