### PR TITLE
Nuke VPC NAT Gateways

### DIFF
--- a/aws/nat_gateway.go
+++ b/aws/nat_gateway.go
@@ -22,12 +22,14 @@ func waitUntilNatGatewayDeleted(svc *ec2.EC2, input *ec2.DescribeNatGatewaysInpu
 			return err
 		}
 
-		if *result.NatGateways[0].State == "deleted" {
-			return nil
+		if result.NatGateways != nil && len(result.NatGateways) > 0 {
+			if *result.NatGateways[0].State == "deleted" {
+				return nil
+			}
 		}
 
+		logging.Logger.Debug("NAT Gateway still not deleted. Will sleep for 5 seconds and check again")
 		time.Sleep(5 * time.Second)
-		logging.Logger.Debug("Waiting for NAT Gateway to be deleted")
 	}
 
 	return NatGatewayDeleteError{}

--- a/aws/nat_gateway.go
+++ b/aws/nat_gateway.go
@@ -1,0 +1,107 @@
+package aws
+
+import (
+	"time"
+
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+func waitUntilNatGatewayDeleted(svc *ec2.EC2, input *ec2.DescribeNatGatewaysInput) error {
+	for i := 0; i < 30; i++ {
+		result, err := svc.DescribeNatGateways(input)
+		if err != nil {
+			if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == "NatGatewayNotFound" {
+				return nil
+			}
+
+			return err
+		}
+
+		if *result.NatGateways[0].State == "deleted" {
+			return nil
+		}
+
+		time.Sleep(5 * time.Second)
+		logging.Logger.Debug("Waiting for NAT Gateway to be deleted")
+	}
+
+	return NatGatewayDeleteError{}
+}
+
+// Returns a formatted string of NAT Gateways Ids
+func getAllNatGateways(session *session.Session, region string, excludeAfter time.Time) ([]*string, error) {
+	svc := ec2.New(session)
+
+	params := &ec2.DescribeNatGatewaysInput{
+		Filter: []*ec2.Filter{
+			{
+				Name: awsgo.String("state"),
+				Values: []*string{
+					awsgo.String("available"),
+				},
+			},
+		},
+	}
+
+	result, err := svc.DescribeNatGateways(params)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	var natGatewaysIds []*string
+	for _, natGateway := range result.NatGateways {
+		if excludeAfter.After(*natGateway.CreateTime) {
+			natGatewaysIds = append(natGatewaysIds, natGateway.NatGatewayId)
+		}
+	}
+
+	return natGatewaysIds, nil
+}
+
+// Deletes all NAT Gateways
+func nukeAllNatGateways(session *session.Session, natGatewayIds []*string) error {
+	svc := ec2.New(session)
+
+	if len(natGatewayIds) == 0 {
+		logging.Logger.Infof("No NAT Gateways to nuke in region %s", *session.Config.Region)
+		return nil
+	}
+
+	logging.Logger.Infof("Deleting all NAT Gateways in region %s", *session.Config.Region)
+	var deletedNatGatewayIDs []*string
+
+	for _, natGatewayID := range natGatewayIds {
+		params := &ec2.DeleteNatGatewayInput{
+			NatGatewayId: natGatewayID,
+		}
+
+		_, err := svc.DeleteNatGateway(params)
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+		} else {
+			deletedNatGatewayIDs = append(deletedNatGatewayIDs, natGatewayID)
+			logging.Logger.Infof("Deleted NAT Gateway: %s", *natGatewayID)
+		}
+	}
+
+	if len(deletedNatGatewayIDs) > 0 {
+		for _, natGatewayID := range deletedNatGatewayIDs {
+			err := waitUntilNatGatewayDeleted(svc, &ec2.DescribeNatGatewaysInput{
+				NatGatewayIds: []*string{natGatewayID},
+			})
+
+			if err != nil {
+				logging.Logger.Errorf("[Failed] %s", err)
+				return errors.WithStackTrace(err)
+			}
+		}
+	}
+
+	logging.Logger.Infof("[OK] %d NAT Gateway(s) deleted in %s", len(deletedNatGatewayIDs), *session.Config.Region)
+	return nil
+}

--- a/aws/nat_gateway_types.go
+++ b/aws/nat_gateway_types.go
@@ -1,0 +1,42 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+// NATGateways - represents all NAT gateways
+type NATGateways struct {
+	NatGatewayIds []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (natGateways NATGateways) ResourceName() string {
+	return "natgateway"
+}
+
+// ResourceIdentifiers - The instance ids of the eip addresses
+func (natGateways NATGateways) ResourceIdentifiers() []string {
+	return natGateways.NatGatewayIds
+}
+
+// MaxBatchSize - Tentative batch size to ensure AWS doesn't throttle
+func (natGateways NATGateways) MaxBatchSize() int {
+	return 200
+}
+
+// Nuke - nuke 'em all!!!
+func (natGateways NATGateways) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllNatGateways(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+type NatGatewayDeleteError struct{}
+
+func (e NatGatewayDeleteError) Error() string {
+	return "NAT Gateway was not deleted"
+}


### PR DESCRIPTION
**WIP**

This PR adds support for nuking VPC NAT Gateways.

It successfully blocks until the gateway reaches the `deleted` state, so we can then remove the associated Elastic IP address.

### TODO

- [ ] Automated Tests