### PR TITLE
Fix AuthFailure Error

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -17,7 +17,7 @@ import (
 func GetAllRegions() []string {
 	// chinese and government regions are not accessible with regular accounts
 	reservedRegions := []string{
-		"cn-north-1", "cn-northwest-1", "us-gov-west-1",
+		"cn-north-1", "cn-northwest-1", "us-gov-west-1", "us-gov-east-1",
 	}
 
 	resolver := endpoints.DefaultResolver()


### PR DESCRIPTION
This PR fixes the constant `AuthFailure: AWS was not able to validate the provided access credentials` errors when running tests. It turns out that AWS added a new GovCloud region `us-gov-east-1` which I wasn't explicitly ignoring as I did the China and other GovCloud regions.

The simple change was to add `us-gov-east-1` to the `reservedRegions` array so we don't try to get resources from it