### PR TITLE
Make sure we don't attempt to get EKS resources in an unsupported region

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -223,15 +223,17 @@ func GetAllResources(regions []string, excludedRegions []string, excludeAfter ti
 		// End ECS resources
 
 		// EKS resources
-		eksClusterNames, err := getAllEksClusters(session, excludeAfter)
-		if err != nil {
-			return nil, errors.WithStackTrace(err)
-		}
+		if eksSupportedRegion(region) {
+			eksClusterNames, err := getAllEksClusters(session, excludeAfter)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
 
-		eksClusters := EKSClusters{
-			Clusters: awsgo.StringValueSlice(eksClusterNames),
+			eksClusters := EKSClusters{
+				Clusters: awsgo.StringValueSlice(eksClusterNames),
+			}
+			resourcesInRegion.Resources = append(resourcesInRegion.Resources, eksClusters)
 		}
-		resourcesInRegion.Resources = append(resourcesInRegion.Resources, eksClusters)
 		// End EKS resources
 
 		account.Resources[region] = resourcesInRegion

--- a/aws/eks.go
+++ b/aws/eks.go
@@ -6,8 +6,32 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/gruntwork-cli/collections"
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 )
+
+// The regions that support EKS. Refer to
+// https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/
+var eksRegions = []string{
+	"us-east-1",
+	"us-east-2",
+	"us-west-2",
+	"eu-central-1",
+	"eu-west-1",
+	"eu-west-2",
+	"eu-west-3",
+	"eu-north-1",
+	"ap-southeast-1",
+	"ap-southeast-2",
+	"ap-northeast-1",
+	"ap-northeast-2",
+	"ap-south-1",
+}
+
+// eksSupportedRegion returns true if the provided region supports EKS
+func eksSupportedRegion(region string) bool {
+	return collections.ListContainsElement(eksRegions, region)
+}
 
 // getAllEksClusters returns a list of strings of EKS Cluster Names that uniquely identify each cluster.
 func getAllEksClusters(awsSession *session.Session, excludeAfter time.Time) ([]*string, error) {

--- a/aws/eks_test.go
+++ b/aws/eks_test.go
@@ -67,3 +67,17 @@ func TestNukeEksClusters(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, awsgo.StringValueSlice(eksClusterNames), *cluster.Name)
 }
+
+// Test that eksSupportedRegions allows the EKS regions but not the regions that don't
+func TestEksSupportedRegions(t *testing.T) {
+	unsupportedRegions := []string{
+		"us-west-1",
+		"ca-central-1",
+	}
+	for _, region := range unsupportedRegions {
+		assert.False(t, eksSupportedRegion(region))
+	}
+	for _, region := range eksRegions {
+		assert.True(t, eksSupportedRegion(region))
+	}
+}

--- a/aws/eks_utils_for_test.go
+++ b/aws/eks_utils_for_test.go
@@ -18,9 +18,7 @@ import (
 // getRandomEksSupportedRegion - Returns a random AWS region that supports EKS.
 // Refer to https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/
 func getRandomEksSupportedRegion(t *testing.T) string {
-	// Approve only regions where EKS and the EKS optimized Linux AMI are available
-	approvedRegions := []string{"us-west-2", "us-east-1", "us-east-2", "eu-west-1"}
-	return terraAws.GetRandomRegion(t, approvedRegions, []string{})
+	return terraAws.GetRandomRegion(t, eksRegions, []string{})
 }
 
 func createEksCluster(


### PR DESCRIPTION
I believe the latest cloud-nuke runs are failing because of this.