### PR TITLE
Attempt to stabilize tests

### DIFF
--- a/aws/ecs_utils_for_test.go
+++ b/aws/ecs_utils_for_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/gruntwork-cli/collections"
 	gruntworkerrors "github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // We black list us-east-1e because this zone is frequently out of capacity
@@ -108,9 +109,12 @@ func createEcsService(t *testing.T, awsSession *session.Session, serviceName str
 		createServiceParams.SetNetworkConfiguration(networkConfiguration)
 	}
 	result, err := svc.CreateService(createServiceParams)
-	if err != nil {
-		assert.Fail(t, gruntworkerrors.WithStackTrace(err).Error())
-	}
+	require.NoError(t, err)
+	err = svc.WaitUntilServicesStable(&ecs.DescribeServicesInput{
+		Cluster:  cluster.ClusterArn,
+		Services: []*string{result.Service.ServiceArn},
+	})
+	require.NoError(t, err)
 	return *result.Service
 }
 

--- a/aws/elbv2_test.go
+++ b/aws/elbv2_test.go
@@ -15,7 +15,14 @@ import (
 )
 
 func getSubnetsInDifferentAZs(t *testing.T, session *session.Session) (*ec2.Subnet, *ec2.Subnet) {
-	subnetOutput, err := ec2.New(session).DescribeSubnets(&ec2.DescribeSubnetsInput{})
+	subnetOutput, err := ec2.New(session).DescribeSubnets(&ec2.DescribeSubnetsInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name:   awsgo.String("default-for-az"),
+				Values: []*string{awsgo.String("true")},
+			},
+		},
+	})
 	require.NoError(t, err)
 	require.True(t, len(subnetOutput.Subnets) >= 2)
 


### PR DESCRIPTION
This is an attempt at stabilizing the tests:

- [This build](https://circleci.com/gh/gruntwork-io/cloud-nuke/9036) appeared to have failed because it picked some malformed subnets. Upon checking `getSubnetsInDifferentAZs`, it looked like it was pulling in all subnets for the region, so I added in a filter to only get the default subnets to see if that makes the build more consistent.
- [This build](https://circleci.com/gh/gruntwork-io/cloud-nuke/9020) failed because the ECS service could not be found when draining. I am guessing this is an eventual consistency issue, so added a wait right after creating the ECS service.