### PR TITLE
Prompt for 'nuke' again on invalid responses

### DIFF
--- a/commands/cli.go
+++ b/commands/cli.go
@@ -268,6 +268,7 @@ func confirmationPrompt(prompt string, maxPrompts int) (bool, error) {
 
 	shellOptions := shell.ShellOptions{Logger: logging.Logger}
 
+	// retry prompt on invalid input so user can avoid rescanning all resources
 	prompts := 0
 	for prompts < maxPrompts {
 		input, err := shell.PromptUserForInput(prompt, &shellOptions)
@@ -278,10 +279,10 @@ func confirmationPrompt(prompt string, maxPrompts int) (bool, error) {
 
 		if strings.ToLower(input) == "nuke" {
 			return true, nil
-		} else {
-			fmt.Printf("Invalid value '%s' was entered.\n", input)
-			prompts++
 		}
+
+		fmt.Printf("Invalid value '%s' was entered.\n", input)
+		prompts++
 	}
 
 	return false, nil


### PR DESCRIPTION
Here is my take on addressing issue #26. Instead of exiting if the user types in an invalid input to the nuke prompt, the user will be notified that the input was invalid and prompted again. A note that you can exit with ^C is added as well.