### PR TITLE
Add feature to delete RDS instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The currently supported functionality includes:
 - Deleting all Launch Configurations in an AWS account
 - Deleting all ECS services in an AWS account
 - Deleting all EKS clusters in an AWS account
-- Deleting all RDS instances in an AWS account
+- Deleting all RDS DB instances in an AWS account
 - Deleting all default VPCs in an AWS account
 - Revoking the default rules in the un-deletable default security group of a VPC
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The currently supported functionality includes:
 - Deleting all Launch Configurations in an AWS account
 - Deleting all ECS services in an AWS account
 - Deleting all EKS clusters in an AWS account
+- Deleting all RDS instances in an AWS account
 - Deleting all default VPCs in an AWS account
 - Revoking the default rules in the un-deletable default security group of a VPC
 

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -363,7 +363,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		dbInstances := DBInstances{}
 
 		if IsNukeable(dbInstances.ResourceName(), resourceTypes) {
-			instanceNames, err := getAllRdsInstances(session, region, excludeAfter)
+			instanceNames, err := getAllRdsInstances(session, excludeAfter)
 
 			if err != nil {
 				return nil, errors.WithStackTrace(err)

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -359,6 +359,23 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End EKS resources
 
+		// RDS DB resources
+		dbInstances := DBInstances{}
+
+		if IsNukeable(dbInstances.ResourceName(), resourceTypes) {
+			instanceNames, err := getAllRdsInstances(session, region, excludeAfter)
+
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			if len(instanceNames) > 0 {
+				dbInstances.InstanceNames = awsgo.StringValueSlice(instanceNames)
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, dbInstances)
+			}
+		}
+		// End RDS DB resources
+
 		if len(resourcesInRegion.Resources) > 0 {
 			account.Resources[region] = resourcesInRegion
 		}

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -382,6 +382,7 @@ func ListResourceTypes() []string {
 		Snapshots{}.ResourceName(),
 		ECSServices{}.ResourceName(),
 		EKSClusters{}.ResourceName(),
+		DBInstances{}.ResourceName(),
 	}
 	sort.Strings(resourceTypes)
 	return resourceTypes

--- a/aws/rds.go
+++ b/aws/rds.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 )
 
-func getAllRdsInstances(session *session.Session, region string, excludeAfter time.Time) ([]*string, error) {
+func getAllRdsInstances(session *session.Session, excludeAfter time.Time) ([]*string, error) {
 	svc := rds.New(session)
 
 	result, err := svc.DescribeDBInstances(&rds.DescribeDBInstancesInput{})
@@ -35,7 +35,7 @@ func nukeAllRdsInstances(session *session.Session, names []*string) error {
 	svc := rds.New(session)
 
 	if len(names) == 0 {
-		logging.Logger.Infof("No RDS DB Instanceto nuke in region %s", *session.Config.Region)
+		logging.Logger.Infof("No RDS DB Instance to nuke in region %s", *session.Config.Region)
 		return nil
 	}
 
@@ -51,7 +51,7 @@ func nukeAllRdsInstances(session *session.Session, names []*string) error {
 		_, err := svc.DeleteDBInstance(params)
 
 		if err != nil {
-			logging.Logger.Errorf("[Failed] %s", err)
+			logging.Logger.Errorf("[Failed] %s: %s", *name, err)
 		} else {
 			deletedNames = append(deletedNames, name)
 			logging.Logger.Infof("Deleted RDS DB Instance: %s", awsgo.StringValue(name))

--- a/aws/rds.go
+++ b/aws/rds.go
@@ -72,7 +72,7 @@ func nukeAllRdsInstances(session *session.Session, names[]*string) error {
       logging.Logger.Errorf("[Failed] %s", err)
     } else {
       deletedNames = append(deletedNames, name)
-      logging.Logger.Infof("Deleted ELB: %s", *name)
+      logging.Logger.Infof("Deleted RDS: %s", *name)
     }
   }
 

--- a/aws/rds.go
+++ b/aws/rds.go
@@ -23,9 +23,9 @@ func getAllRdsInstances(session *session.Session, region string, excludeAfter ti
 	var names []*string
 
 	for _, database := range result.DBInstances {
-		//if excludeAfter.After(*database.InstanceCreateTime) {
-		names = append(names, database.DBInstanceIdentifier)
-		//}
+		if excludeAfter.After(*database.InstanceCreateTime) {
+		  names = append(names, database.DBInstanceIdentifier)
+		}
 	}
 
 	return names, nil

--- a/aws/rds.go
+++ b/aws/rds.go
@@ -23,7 +23,7 @@ func waitUntilRdsDeleted(svc *rds.RDS, input *rds.DescribeDBInstancesInput) erro
     }
 
     time.Sleep(1 * time.Second)
-    logging.Logger.Debug("Waiting for ELB to be deleted")
+    logging.Logger.Debug("Waiting for RDS to be deleted")
   }
 
   return RdsDeleteError{}

--- a/aws/rds.go
+++ b/aws/rds.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"context"
 	"time"
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
@@ -59,14 +58,10 @@ func nukeAllRdsInstances(session *session.Session, names []*string) error {
 		}
 	}
 
-	timeout := 240 * time.Second
-	ctx := awsgo.BackgroundContext()
-	ctx, _ = context.WithTimeout(ctx, timeout)
-
 	if len(deletedNames) > 0 {
 		for _, name := range deletedNames {
 
-			err := svc.WaitUntilDBInstanceDeletedWithContext(ctx, &rds.DescribeDBInstancesInput{
+			err := svc.WaitUntilDBInstanceDeleted(&rds.DescribeDBInstancesInput{
 				DBInstanceIdentifier: name,
 			})
 

--- a/aws/rds.go
+++ b/aws/rds.go
@@ -1,0 +1,95 @@
+package aws
+
+import (
+  "time"
+
+  awsgo "github.com/aws/aws-sdk-go/aws"
+  "github.com/aws/aws-sdk-go/aws/awserr"
+  "github.com/aws/aws-sdk-go/aws/session"
+  "github.com/aws/aws-sdk-go/service/rds"
+  "github.com/gruntwork-io/cloud-nuke/logging"
+  "github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+func waitUntilRdsDeleted(svc *rds.RDS, input *rds.DescribeDBInstancesInput) error {
+  for i := 0; i < 240; i++ {
+    _, err := svc.DescribeDBInstances(input)
+    if err != nil {
+      if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == "DBInstanceNotFound" {
+        return nil
+      }
+
+      return err
+    }
+
+    time.Sleep(1 * time.Second)
+    logging.Logger.Debug("Waiting for ELB to be deleted")
+  }
+
+  return RdsDeleteError{}
+}
+
+func getAllRdsInstances(session *session.Session, region string, excludeAfter time.Time) ([]*string, error) {
+  svc := rds.New(session)
+
+  result, err := svc.DescribeDBInstances(&rds.DescribeDBInstancesInput{})
+
+  if err != nil {
+    return nil, errors.WithStackTrace(err)
+  }
+
+  var names []*string
+
+  for _, database := range result.DBInstances {
+    //if excludeAfter.After(*database.InstanceCreateTime) {
+      names = append(names, database.DBInstanceIdentifier)
+  //}
+  }
+
+  return names, nil
+}
+
+func nukeAllRdsInstances(session *session.Session, names[]*string) error {
+  svc := rds.New(session)
+
+  if len(names) == 0 {
+    logging.Logger.Infof("No Relational Database Service to nuke in region %s", *session.Config.Region)
+    return nil
+  }
+
+  logging.Logger.Infof("Deleting all Relational Database Services in region %s", *session.Config.Region)
+  var deletedNames []*string
+
+  for _, name := range names {
+    params := &rds.DeleteDBInstanceInput{
+      DBInstanceIdentifier: name,
+      SkipFinalSnapshot: awsgo.Bool(true),
+    }
+
+    _, err := svc.DeleteDBInstance(params)
+
+    if err != nil {
+      logging.Logger.Errorf("[Failed] %s", err)
+    } else {
+      deletedNames = append(deletedNames, name)
+      logging.Logger.Infof("Deleted ELB: %s", *name)
+    }
+  }
+
+  if len(deletedNames) > 0 {
+    for _, name := range deletedNames {
+
+      err := waitUntilRdsDeleted(svc, &rds.DescribeDBInstancesInput{
+        DBInstanceIdentifier: name,
+      })
+
+      if err != nil {
+        logging.Logger.Errorf("[Failed] %s", err)
+        return errors.WithStackTrace(err)
+      }
+    }
+  }
+
+  logging.Logger.Infof("[OK] %d Relational Database Service(s) deleted in %s", len(deletedNames), *session.Config.Region)
+  return nil
+}

--- a/aws/rds.go
+++ b/aws/rds.go
@@ -1,95 +1,95 @@
 package aws
 
 import (
-  "time"
+	"time"
 
-  awsgo "github.com/aws/aws-sdk-go/aws"
-  "github.com/aws/aws-sdk-go/aws/awserr"
-  "github.com/aws/aws-sdk-go/aws/session"
-  "github.com/aws/aws-sdk-go/service/rds"
-  "github.com/gruntwork-io/cloud-nuke/logging"
-  "github.com/gruntwork-io/gruntwork-cli/errors"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
 )
 
 func waitUntilRdsDeleted(svc *rds.RDS, input *rds.DescribeDBInstancesInput) error {
-  for i := 0; i < 240; i++ {
-    _, err := svc.DescribeDBInstances(input)
-    if err != nil {
-      if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == "DBInstanceNotFound" {
-        return nil
-      }
+	for i := 0; i < 240; i++ {
+		_, err := svc.DescribeDBInstances(input)
+		if err != nil {
+			if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == "DBInstanceNotFound" {
+				return nil
+			}
 
-      return err
-    }
+			return err
+		}
 
-    time.Sleep(1 * time.Second)
-    logging.Logger.Debug("Waiting for RDS to be deleted")
-  }
+		time.Sleep(1 * time.Second)
+		logging.Logger.Debug("Waiting for RDS to be deleted")
+	}
 
-  return RdsDeleteError{}
+	return RdsDeleteError{}
 }
 
 func getAllRdsInstances(session *session.Session, region string, excludeAfter time.Time) ([]*string, error) {
-  svc := rds.New(session)
+	svc := rds.New(session)
 
-  result, err := svc.DescribeDBInstances(&rds.DescribeDBInstancesInput{})
+	result, err := svc.DescribeDBInstances(&rds.DescribeDBInstancesInput{})
 
-  if err != nil {
-    return nil, errors.WithStackTrace(err)
-  }
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
 
-  var names []*string
+	var names []*string
 
-  for _, database := range result.DBInstances {
-    //if excludeAfter.After(*database.InstanceCreateTime) {
-      names = append(names, database.DBInstanceIdentifier)
-  //}
-  }
+	for _, database := range result.DBInstances {
+		//if excludeAfter.After(*database.InstanceCreateTime) {
+		names = append(names, database.DBInstanceIdentifier)
+		//}
+	}
 
-  return names, nil
+	return names, nil
 }
 
-func nukeAllRdsInstances(session *session.Session, names[]*string) error {
-  svc := rds.New(session)
+func nukeAllRdsInstances(session *session.Session, names []*string) error {
+	svc := rds.New(session)
 
-  if len(names) == 0 {
-    logging.Logger.Infof("No Relational Database Service to nuke in region %s", *session.Config.Region)
-    return nil
-  }
+	if len(names) == 0 {
+		logging.Logger.Infof("No Relational Database Service to nuke in region %s", *session.Config.Region)
+		return nil
+	}
 
-  logging.Logger.Infof("Deleting all Relational Database Services in region %s", *session.Config.Region)
-  var deletedNames []*string
+	logging.Logger.Infof("Deleting all Relational Database Services in region %s", *session.Config.Region)
+	var deletedNames []*string
 
-  for _, name := range names {
-    params := &rds.DeleteDBInstanceInput{
-      DBInstanceIdentifier: name,
-      SkipFinalSnapshot: awsgo.Bool(true),
-    }
+	for _, name := range names {
+		params := &rds.DeleteDBInstanceInput{
+			DBInstanceIdentifier: name,
+			SkipFinalSnapshot:    awsgo.Bool(true),
+		}
 
-    _, err := svc.DeleteDBInstance(params)
+		_, err := svc.DeleteDBInstance(params)
 
-    if err != nil {
-      logging.Logger.Errorf("[Failed] %s", err)
-    } else {
-      deletedNames = append(deletedNames, name)
-      logging.Logger.Infof("Deleted RDS: %s", *name)
-    }
-  }
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+		} else {
+			deletedNames = append(deletedNames, name)
+			logging.Logger.Infof("Deleted RDS: %s", *name)
+		}
+	}
 
-  if len(deletedNames) > 0 {
-    for _, name := range deletedNames {
+	if len(deletedNames) > 0 {
+		for _, name := range deletedNames {
 
-      err := waitUntilRdsDeleted(svc, &rds.DescribeDBInstancesInput{
-        DBInstanceIdentifier: name,
-      })
+			err := waitUntilRdsDeleted(svc, &rds.DescribeDBInstancesInput{
+				DBInstanceIdentifier: name,
+			})
 
-      if err != nil {
-        logging.Logger.Errorf("[Failed] %s", err)
-        return errors.WithStackTrace(err)
-      }
-    }
-  }
+			if err != nil {
+				logging.Logger.Errorf("[Failed] %s", err)
+				return errors.WithStackTrace(err)
+			}
+		}
+	}
 
-  logging.Logger.Infof("[OK] %d Relational Database Service(s) deleted in %s", len(deletedNames), *session.Config.Region)
-  return nil
+	logging.Logger.Infof("[OK] %d Relational Database Service(s) deleted in %s", len(deletedNames), *session.Config.Region)
+	return nil
 }

--- a/aws/rds_test.go
+++ b/aws/rds_test.go
@@ -1,10 +1,9 @@
 package aws
 
 import (
+	"strings"
 	"testing"
 	"time"
-
-	"strings"
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -64,17 +63,17 @@ func createTestRDSInstance(t *testing.T, session *session.Session, name string) 
 func TestListRDS(t *testing.T) {
 	t.Parallel()
 
-	region, err := getRandomRegion()
-	if err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
+	region := "us-east-1" //, err := getRandomRegion()
+	//if err != nil {
+	//assert.Fail(t, errors.WithStackTrace(err).Error())
+	//}
 
 	session, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region)},
 	)
 
-	// rdsName := "cloud-nuke-test" + util.UniqueID()
-	// createTestRDSInstance(t, session, rdsName)
+	rdsName := "cloud-nuke-test" + util.UniqueID()
+	createTestRDSInstance(t, session, rdsName)
 
 	eds, err := getAllRdsInstances(session, region, time.Now())
 

--- a/aws/rds_test.go
+++ b/aws/rds_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func waitUntilRdsCreated(svc *rds.RDS, name *string) error {
@@ -52,10 +53,7 @@ func createTestRDSInstance(t *testing.T, session *session.Session, name string) 
 	}
 
 	_, err := svc.CreateDBInstance(params)
-
-	if err != nil {
-		assert.Fail(t, err.Error())
-	}
+	require.NoError(t, err)
 
 	waitUntilRdsCreated(svc, &name)
 }

--- a/aws/rds_test.go
+++ b/aws/rds_test.go
@@ -81,7 +81,7 @@ func TestListRDS(t *testing.T) {
 
 	assert.Contains(t, awsgo.StringValueSlice(rds), strings.ToLower(rdsName))
 
-	defer nukeAllRdsInstances(session, rds)
+	nukeAllRdsInstances(session, rds)
 
 	rdsNames, _ := getAllRdsInstances(session, time.Now().Add(1*time.Hour))
 

--- a/aws/rds_test.go
+++ b/aws/rds_test.go
@@ -1,92 +1,92 @@
 package aws
 
 import (
-  "testing"
-  "time"
+	"testing"
+	"time"
 
-  "strings"
+	"strings"
 
-  awsgo "github.com/aws/aws-sdk-go/aws"
-  "github.com/aws/aws-sdk-go/aws/session"
-  "github.com/aws/aws-sdk-go/service/rds"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/rds"
 
-  "github.com/gruntwork-io/cloud-nuke/util"
-  "github.com/gruntwork-io/cloud-nuke/logging"
-  "github.com/gruntwork-io/gruntwork-cli/errors"
-  "github.com/stretchr/testify/assert"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 func waitUntilRdsCreated(svc *rds.RDS, name *string) error {
-  input := &rds.DescribeDBInstancesInput{
-    DBInstanceIdentifier: name,
-  }
+	input := &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: name,
+	}
 
-  for i := 0; i < 240; i++ {
-    instance, err := svc.DescribeDBInstances(input)
-    status := instance.DBInstances[0].DBInstanceStatus
+	for i := 0; i < 240; i++ {
+		instance, err := svc.DescribeDBInstances(input)
+		status := instance.DBInstances[0].DBInstanceStatus
 
-    // If SkipFinalSnapshot = false on delete, should also wait for "backing-up" also to finish
-    if *status != "creating" {
-      return nil
-    }
+		// If SkipFinalSnapshot = false on delete, should also wait for "backing-up" also to finish
+		if *status != "creating" {
+			return nil
+		}
 
-    if err != nil {
-        return err
-    }
+		if err != nil {
+			return err
+		}
 
-    time.Sleep(1 * time.Second)
-    logging.Logger.Debug("Waiting for RDS to be created")
-  }
+		time.Sleep(1 * time.Second)
+		logging.Logger.Debug("Waiting for RDS to be created")
+	}
 
-  return RdsDeleteError{}
+	return RdsDeleteError{}
 }
 
 func createTestRDSInstance(t *testing.T, session *session.Session, name string) {
-  svc := rds.New(session)
-  params := &rds.CreateDBInstanceInput {
-    AllocatedStorage: awsgo.Int64(5),
-    DBInstanceClass: awsgo.String("db.m5.large"),
-    DBInstanceIdentifier: awsgo.String(name),
-    Engine: awsgo.String("postgres"),
-    MasterUsername: awsgo.String("gruntwork"),
-    MasterUserPassword: awsgo.String("password"),
-  }
+	svc := rds.New(session)
+	params := &rds.CreateDBInstanceInput{
+		AllocatedStorage:     awsgo.Int64(5),
+		DBInstanceClass:      awsgo.String("db.m5.large"),
+		DBInstanceIdentifier: awsgo.String(name),
+		Engine:               awsgo.String("postgres"),
+		MasterUsername:       awsgo.String("gruntwork"),
+		MasterUserPassword:   awsgo.String("password"),
+	}
 
-  _, err := svc.CreateDBInstance(params)
+	_, err := svc.CreateDBInstance(params)
 
-  if err != nil {
-    assert.Fail(t, err.Error())
-  }
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
 
-  waitUntilRdsCreated(svc, &name)
+	waitUntilRdsCreated(svc, &name)
 }
 
 func TestListRDS(t *testing.T) {
-  t. Parallel()
+	t.Parallel()
 
-  region, err := getRandomRegion()
-  if err != nil {
-    assert.Fail(t, errors.WithStackTrace(err).Error())
-  }
+	region, err := getRandomRegion()
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
 
-  session, err := session.NewSession(&awsgo.Config{
-    Region: awsgo.String(region)},
-  )
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
 
-  rdsName := "cloud-nuke-test" + util.UniqueID()
-  createTestRDSInstance(t, session, rdsName)
+	// rdsName := "cloud-nuke-test" + util.UniqueID()
+	// createTestRDSInstance(t, session, rdsName)
 
-  eds, err := getAllRdsInstances(session, region, time.Now())
+	eds, err := getAllRdsInstances(session, region, time.Now())
 
-  if err != nil {
-    assert.Failf(t, "Unable to fetch list of RDS", errors.WithStackTrace(err).Error())
-  }
+	if err != nil {
+		assert.Failf(t, "Unable to fetch list of RDS", errors.WithStackTrace(err).Error())
+	}
 
-  assert.Contains(t, awsgo.StringValueSlice(eds), strings.ToLower(rdsName))
+	assert.Contains(t, awsgo.StringValueSlice(eds), strings.ToLower(rdsName))
 
-  nukeAllRdsInstances(session, []*string{&rdsName})
+	nukeAllRdsInstances(session, eds)
 
-  rdsNames, err := getAllRdsInstances(session, region, time.Now().Add(1*time.Hour*-1))
+	rdsNames, err := getAllRdsInstances(session, region, time.Now().Add(1*time.Hour*-1))
 
-  assert.NotContains(t, awsgo.StringValueSlice(rdsNames), strings.ToLower(rdsName))
+	assert.NotContains(t, awsgo.StringValueSlice(rdsNames), strings.ToLower(rdsName))
 }

--- a/aws/rds_test.go
+++ b/aws/rds_test.go
@@ -1,0 +1,92 @@
+package aws
+
+import (
+  "testing"
+  "time"
+
+  "strings"
+
+  awsgo "github.com/aws/aws-sdk-go/aws"
+  "github.com/aws/aws-sdk-go/aws/session"
+  "github.com/aws/aws-sdk-go/service/rds"
+
+  // "github.com/gruntwork-io/cloud-nuke/util"
+  "github.com/gruntwork-io/cloud-nuke/logging"
+  "github.com/gruntwork-io/gruntwork-cli/errors"
+  "github.com/stretchr/testify/assert"
+)
+
+func waitUntilRdsCreated(svc *rds.RDS, name *string) error {
+  input := &rds.DescribeDBInstancesInput{
+    DBInstanceIdentifier: name,
+  }
+
+  for i := 0; i < 240; i++ {
+    instance, err := svc.DescribeDBInstances(input)
+    status := instance.DBInstances[0].DBInstanceStatus
+    logging.Logger.Info(*status)
+
+    if *status != "creating" {
+      return nil
+    }
+
+    if err != nil {
+        return err
+    }
+
+    time.Sleep(1 * time.Second)
+    logging.Logger.Debug("Waiting for RDS to be created")
+  }
+
+  return RdsDeleteError{}
+}
+
+func createTestRDSInstance(t *testing.T, session *session.Session, name string) {
+  svc := rds.New(session)
+  params := &rds.CreateDBInstanceInput {
+    AllocatedStorage: awsgo.Int64(5),
+    DBInstanceClass: awsgo.String("db.m5.large"),
+    DBInstanceIdentifier: awsgo.String(name),
+    Engine: awsgo.String("postgres"),
+    MasterUsername: awsgo.String("gruntwork"),
+    MasterUserPassword: awsgo.String("password"),
+  }
+
+  _, err := svc.CreateDBInstance(params)
+
+  if err != nil {
+    assert.Fail(t, err.Error())
+  }
+
+  waitUntilRdsCreated(svc, &name)
+}
+
+func TestListRDS(t *testing.T) {
+  t. Parallel()
+
+  region, err := getRandomRegion()
+  if err != nil {
+    assert.Fail(t, errors.WithStackTrace(err).Error())
+  }
+
+  session, err := session.NewSession(&awsgo.Config{
+    Region: awsgo.String(region)},
+  )
+
+  rdsName := "cloud-nuke-test" + util.UniqueID()
+  createTestRDSInstance(t, session, rdsName)
+
+  eds, err := getAllRdsInstances(session, region, time.Now())
+
+  if err != nil {
+    assert.Failf(t, "Unable to fetch list of RDS", errors.WithStackTrace(err).Error())
+  }
+
+  assert.Contains(t, awsgo.StringValueSlice(eds), strings.ToLower(rdsName))
+
+  nukeAllRdsInstances(session, []*string{&rdsName})
+
+  rdsNames, err := getAllRdsInstances(session, region, time.Now().Add(1*time.Hour*-1))
+
+  assert.NotContains(t, awsgo.StringValueSlice(rdsNames), strings.ToLower(rdsName))
+}

--- a/aws/rds_test.go
+++ b/aws/rds_test.go
@@ -61,10 +61,10 @@ func createTestRDSInstance(t *testing.T, session *session.Session, name string) 
 func TestListRDS(t *testing.T) {
 	t.Parallel()
 
-	region := "us-east-1" //, err := getRandomRegion()
-	//if err != nil {
-	//assert.Fail(t, errors.WithStackTrace(err).Error())
-	//}
+	region, err := getRandomRegion()
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
 
 	session, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region)},
@@ -73,17 +73,17 @@ func TestListRDS(t *testing.T) {
 	rdsName := "cloud-nuke-test" + util.UniqueID()
 	createTestRDSInstance(t, session, rdsName)
 
-	eds, err := getAllRdsInstances(session, time.Now())
+	rds, err := getAllRdsInstances(session, time.Now().Add(1*time.Hour))
 
 	if err != nil {
 		assert.Failf(t, "Unable to fetch list of RDS DB Instances", errors.WithStackTrace(err).Error())
 	}
 
-	assert.Contains(t, awsgo.StringValueSlice(eds), strings.ToLower(rdsName))
+	assert.Contains(t, awsgo.StringValueSlice(rds), strings.ToLower(rdsName))
 
-	nukeAllRdsInstances(session, eds)
+	defer nukeAllRdsInstances(session, rds)
 
-	rdsNames, err := getAllRdsInstances(session, time.Now().Add(1*time.Hour*-1))
+	rdsNames, _ := getAllRdsInstances(session, time.Now().Add(1*time.Hour))
 
 	assert.NotContains(t, awsgo.StringValueSlice(rdsNames), strings.ToLower(rdsName))
 }

--- a/aws/rds_test.go
+++ b/aws/rds_test.go
@@ -25,7 +25,7 @@ func waitUntilRdsCreated(svc *rds.RDS, name *string) error {
     instance, err := svc.DescribeDBInstances(input)
     status := instance.DBInstances[0].DBInstanceStatus
 
-    // If SkiFinalSnapshot = false on delete, should also wait for "backing-up" also to finish
+    // If SkipFinalSnapshot = false on delete, should also wait for "backing-up" also to finish
     if *status != "creating" {
       return nil
     }

--- a/aws/rds_test.go
+++ b/aws/rds_test.go
@@ -81,9 +81,11 @@ func TestListRDS(t *testing.T) {
 
 	assert.Contains(t, awsgo.StringValueSlice(rds), strings.ToLower(rdsName))
 
-	nukeAllRdsInstances(session, rds)
+	defer func() {
+		nukeAllRdsInstances(session, rds)
 
-	rdsNames, _ := getAllRdsInstances(session, time.Now().Add(1*time.Hour))
+		rdsNames, _ := getAllRdsInstances(session, time.Now().Add(1*time.Hour))
 
-	assert.NotContains(t, awsgo.StringValueSlice(rdsNames), strings.ToLower(rdsName))
+		assert.NotContains(t, awsgo.StringValueSlice(rdsNames), strings.ToLower(rdsName))
+	}()
 }

--- a/aws/rds_test.go
+++ b/aws/rds_test.go
@@ -10,7 +10,7 @@ import (
   "github.com/aws/aws-sdk-go/aws/session"
   "github.com/aws/aws-sdk-go/service/rds"
 
-  // "github.com/gruntwork-io/cloud-nuke/util"
+  "github.com/gruntwork-io/cloud-nuke/util"
   "github.com/gruntwork-io/cloud-nuke/logging"
   "github.com/gruntwork-io/gruntwork-cli/errors"
   "github.com/stretchr/testify/assert"
@@ -24,8 +24,8 @@ func waitUntilRdsCreated(svc *rds.RDS, name *string) error {
   for i := 0; i < 240; i++ {
     instance, err := svc.DescribeDBInstances(input)
     status := instance.DBInstances[0].DBInstanceStatus
-    logging.Logger.Info(*status)
 
+    // If SkiFinalSnapshot = false on delete, should also wait for "backing-up" also to finish
     if *status != "creating" {
       return nil
     }

--- a/aws/rds_test.go
+++ b/aws/rds_test.go
@@ -16,6 +16,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// There's a built-in function WaitUntilDBInstanceAvailable but
+// the times that it was tested, it wasn't returning anything so we'll leave with the
+// custom one.
 func waitUntilRdsCreated(svc *rds.RDS, name *string) error {
 	input := &rds.DescribeDBInstancesInput{
 		DBInstanceIdentifier: name,
@@ -38,7 +41,7 @@ func waitUntilRdsCreated(svc *rds.RDS, name *string) error {
 		logging.Logger.Debug("Waiting for RDS DB Instance to be created")
 	}
 
-	return RdsDeleteError{}
+	return RdsDeleteError{name: *name}
 }
 
 func createTestRDSInstance(t *testing.T, session *session.Session, name string) {

--- a/aws/rds_test.go
+++ b/aws/rds_test.go
@@ -73,7 +73,7 @@ func TestListRDS(t *testing.T) {
 	rdsName := "cloud-nuke-test" + util.UniqueID()
 	createTestRDSInstance(t, session, rdsName)
 
-	eds, err := getAllRdsInstances(session, region, time.Now())
+	eds, err := getAllRdsInstances(session, time.Now())
 
 	if err != nil {
 		assert.Failf(t, "Unable to fetch list of RDS DB Instances", errors.WithStackTrace(err).Error())
@@ -83,7 +83,7 @@ func TestListRDS(t *testing.T) {
 
 	nukeAllRdsInstances(session, eds)
 
-	rdsNames, err := getAllRdsInstances(session, region, time.Now().Add(1*time.Hour*-1))
+	rdsNames, err := getAllRdsInstances(session, time.Now().Add(1*time.Hour*-1))
 
 	assert.NotContains(t, awsgo.StringValueSlice(rdsNames), strings.ToLower(rdsName))
 }

--- a/aws/rds_types.go
+++ b/aws/rds_types.go
@@ -1,5 +1,38 @@
 package aws
 
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+type DBInstances struct {
+	InstanceNames []string
+}
+
+func (instance DBInstances) ResourceName() string {
+	return "rds"
+}
+
+// ResourceIdentifiers - The instance names of the rds db instances
+func (instance DBInstances) ResourceIdentifiers() []string {
+	return instance.InstanceNames
+}
+
+func (instance DBInstances) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 200
+}
+
+// Nuke - nuke 'em all!!!
+func (instance DBInstances) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllRdsInstances(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
 type RdsDeleteError struct{}
 
 func (e RdsDeleteError) Error() string {

--- a/aws/rds_types.go
+++ b/aws/rds_types.go
@@ -33,8 +33,10 @@ func (instance DBInstances) Nuke(session *session.Session, identifiers []string)
 	return nil
 }
 
-type RdsDeleteError struct{}
+type RdsDeleteError struct{
+	name string
+}
 
 func (e RdsDeleteError) Error() string {
-	return "RDS DB Instance was not deleted"
+	return "RDS DB Instance:" + e.name + "was not deleted"
 }

--- a/aws/rds_types.go
+++ b/aws/rds_types.go
@@ -3,6 +3,5 @@ package aws
 type RdsDeleteError struct{}
 
 func (e RdsDeleteError) Error() string {
-  return "RDS was not deleted"
+	return "RDS was not deleted"
 }
-

--- a/aws/rds_types.go
+++ b/aws/rds_types.go
@@ -1,0 +1,8 @@
+package aws
+
+type RdsDeleteError struct{}
+
+func (e RdsDeleteError) Error() string {
+  return "RDS was not deleted"
+}
+

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -25,7 +25,7 @@ func CreateCli(version string) *cli.App {
 	app.Commands = []cli.Command{
 		{
 			Name:   "aws",
-			Usage:  "BEWARE: DESTRUCTIVE OPERATION! Nukes AWS resources (ASG, ELB, ELBv2, EBS, EC2, AMI, Snapshots, Elastic IP).",
+			Usage:  "BEWARE: DESTRUCTIVE OPERATION! Nukes AWS resources (ASG, ELB, ELBv2, EBS, EC2, AMI, Snapshots, Elastic IP, RDS).",
 			Action: errors.WithPanicHandling(awsNuke),
 			Flags: []cli.Flag{
 				cli.StringSliceFlag{


### PR DESCRIPTION
Following #84.

From the first part:
- [X] Create a new RDS instance
- [X] The lookup for the instances based on region
- [X] Nuke the instance based on the lookup results (with SkipFinalSnapshot: true)
- [x] Run from CLI
- [x] Delete RDS remaining instances on AWS 
- [x] Add the RDS to be searchable by the --resource-type flag.
- [x] Get instances by age (older than xx)


