### PR TITLE
Add feature to delete RDS Clusters

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -359,9 +359,8 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End EKS resources
 
-		// RDS DB resources
+		// RDS DB Instances
 		dbInstances := DBInstances{}
-
 		if IsNukeable(dbInstances.ResourceName(), resourceTypes) {
 			instanceNames, err := getAllRdsInstances(session, excludeAfter)
 
@@ -374,7 +373,25 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 				resourcesInRegion.Resources = append(resourcesInRegion.Resources, dbInstances)
 			}
 		}
-		// End RDS DB resources
+		// End RDS DB Instances
+
+		// RDS DB Clusters
+		// These reference the Aurora Clusters, for the use it's the same resource (rds), but AWS
+		// has different abstractions for each.
+		dbClusters := DBInstances{}
+		if IsNukeable(dbClusters.ResourceName(), resourceTypes) {
+			clustersNames, err := getAllRdsClusters(session, excludeAfter)
+
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			if len(clustersNames) > 0 {
+				dbClusters.InstanceNames = awsgo.StringValueSlice(clustersNames)
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, dbClusters)
+			}
+		}
+		// End RDS DB Clusters
 
 		if len(resourcesInRegion.Resources) > 0 {
 			account.Resources[region] = resourcesInRegion

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -378,7 +378,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		// RDS DB Clusters
 		// These reference the Aurora Clusters, for the use it's the same resource (rds), but AWS
 		// has different abstractions for each.
-		dbClusters := DBInstances{}
+		dbClusters := DBClusters{}
 		if IsNukeable(dbClusters.ResourceName(), resourceTypes) {
 			clustersNames, err := getAllRdsClusters(session, excludeAfter)
 

--- a/aws/rds_cluster.go
+++ b/aws/rds_cluster.go
@@ -12,8 +12,8 @@ import (
 )
 
 func waitUntilRdsClusterDeleted(svc *rds.RDS, input *rds.DescribeDBClustersInput) error {
-	// wait up to 60 seconds
-	for i := 0; i < 60; i++ {
+	// wait up to 15 minutes
+	for i := 0; i < 900; i++ {
 		_, err := svc.DescribeDBClusters(input)
 		if err != nil {
 			if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == rds.ErrCodeDBClusterNotFoundFault  {

--- a/aws/rds_cluster.go
+++ b/aws/rds_cluster.go
@@ -13,7 +13,7 @@ import (
 
 func waitUntilRdsClusterDeleted(svc *rds.RDS, input *rds.DescribeDBClustersInput) error {
 	// wait up to 15 minutes
-	for i := 0; i < 900; i++ {
+	for i := 0; i < 90; i++ {
 		_, err := svc.DescribeDBClusters(input)
 		if err != nil {
 			if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == rds.ErrCodeDBClusterNotFoundFault  {
@@ -23,7 +23,7 @@ func waitUntilRdsClusterDeleted(svc *rds.RDS, input *rds.DescribeDBClustersInput
 			return err
 		}
 
-		time.Sleep(1 * time.Second)
+		time.Sleep(10 * time.Second)
 		logging.Logger.Debug("Waiting for RDS Cluster to be deleted")
 	}
 

--- a/aws/rds_cluster.go
+++ b/aws/rds_cluster.go
@@ -1,0 +1,97 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"time"
+
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+func waitUntilRdsClusterDeleted(svc *rds.RDS, input *rds.DescribeDBClustersInput) error {
+	// wait up to 60 seconds
+	for i := 0; i < 60; i++ {
+		_, err := svc.DescribeDBClusters(input)
+		if err != nil {
+			if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == rds.ErrCodeDBClusterNotFoundFault  {
+				return nil
+			}
+
+			return err
+		}
+
+		time.Sleep(1 * time.Second)
+		logging.Logger.Debug("Waiting for RDS Cluster to be deleted")
+	}
+
+	return RdsDeleteError{name: *input.DBClusterIdentifier}
+}
+
+
+func getAllRdsClusters(session *session.Session, excludeAfter time.Time) ([]*string, error) {
+	svc := rds.New(session)
+
+	result, err := svc.DescribeDBClusters(&rds.DescribeDBClustersInput{})
+
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	var names []*string
+
+	for _, database := range result.DBClusters {
+		if excludeAfter.After(*database.ClusterCreateTime) {
+		  names = append(names, database.DBClusterIdentifier)
+		}
+	}
+
+	return names, nil
+}
+
+func nukeAllRdsClusters(session *session.Session, names []*string) error {
+	svc := rds.New(session)
+
+	if len(names) == 0 {
+		logging.Logger.Infof("No RDS DB Cluster to nuke in region %s", *session.Config.Region)
+		return nil
+	}
+
+	logging.Logger.Infof("Deleting all RDS Clusters in region %s", *session.Config.Region)
+	deletedNames := []*string{}
+
+	for _, name := range names {
+		params := &rds.DeleteDBClusterInput{
+			DBClusterIdentifier: name,
+			SkipFinalSnapshot:    awsgo.Bool(true),
+		}
+
+		_, err := svc.DeleteDBCluster(params)
+
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s: %s", *name, err)
+		} else {
+			deletedNames = append(deletedNames, name)
+			logging.Logger.Infof("Deleted RDS DB Cluster: %s", awsgo.StringValue(name))
+		}
+	}
+
+	if len(deletedNames) > 0 {
+		for _, name := range deletedNames {
+
+			err := waitUntilRdsClusterDeleted(svc, &rds.DescribeDBClustersInput{
+				DBClusterIdentifier: name,
+			})
+
+			if err != nil {
+				logging.Logger.Errorf("[Failed] %s", err)
+				return errors.WithStackTrace(err)
+			}
+		}
+	}
+
+	logging.Logger.Infof("[OK] %d RDS DB Cluster(s) nuked in %s", len(deletedNames), *session.Config.Region)
+	return nil
+}

--- a/aws/rds_cluster_test.go
+++ b/aws/rds_cluster_test.go
@@ -26,8 +26,6 @@ func createTestRDSCluster(t *testing.T, session *session.Session, name string) {
 
 	_, err := svc.CreateDBCluster(params)
 	require.NoError(t, err)
-
-	//waitUntilRdsCreated(svc, &name)
 }
 
 func TestNukeRDSCluster(t *testing.T) {
@@ -56,7 +54,7 @@ func TestNukeRDSCluster(t *testing.T) {
 	rds, err := getAllRdsClusters(session, excludeAfter)
 
 	if err != nil {
-		assert.Failf(t, "Unable to fetch list of RDS DB Instances", errors.WithStackTrace(err).Error())
+		assert.Failf(t, "Unable to fetch list of RDS DB Clusters", errors.WithStackTrace(err).Error())
 	}
 
 	assert.Contains(t, awsgo.StringValueSlice(rds), strings.ToLower(rdsName))

--- a/aws/rds_cluster_test.go
+++ b/aws/rds_cluster_test.go
@@ -1,0 +1,63 @@
+package aws
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/rds"
+
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createTestRDSCluster(t *testing.T, session *session.Session, name string) {
+	svc := rds.New(session)
+	params := &rds.CreateDBClusterInput{
+		DBClusterIdentifier: awsgo.String(name),
+		Engine:               awsgo.String("aurora-mysql"),
+		MasterUsername:       awsgo.String("gruntwork"),
+		MasterUserPassword:   awsgo.String("password"),
+	}
+
+	_, err := svc.CreateDBCluster(params)
+	require.NoError(t, err)
+
+	//waitUntilRdsCreated(svc, &name)
+}
+
+func TestNukeRDSCluster(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, errors.WithStackTrace(err))
+
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
+
+	rdsName := "cloud-nuke-test" + util.UniqueID()
+	excludeAfter := time.Now().Add(1*time.Hour)
+
+	createTestRDSCluster(t, session, rdsName)
+
+	defer func() {
+		nukeAllRdsClusters(session, []*string{&rdsName})
+
+		rdsNames, _ := getAllRdsClusters(session, excludeAfter)
+
+		assert.NotContains(t, awsgo.StringValueSlice(rdsNames), strings.ToLower(rdsName))
+	}()
+
+	rds, err := getAllRdsClusters(session, excludeAfter)
+
+	if err != nil {
+		assert.Failf(t, "Unable to fetch list of RDS DB Instances", errors.WithStackTrace(err).Error())
+	}
+
+	assert.Contains(t, awsgo.StringValueSlice(rds), strings.ToLower(rdsName))
+}

--- a/aws/rds_cluster_types.go
+++ b/aws/rds_cluster_types.go
@@ -1,0 +1,35 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+type DBClusters struct {
+	InstanceNames []string
+}
+
+func (instance DBClusters) ResourceName() string {
+	return "rds"
+}
+
+// ResourceIdentifiers - The instance names of the rds db instances
+func (instance DBClusters) ResourceIdentifiers() []string {
+	return instance.InstanceNames
+}
+
+func (instance DBClusters) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 200
+}
+
+// Nuke - nuke 'em all!!!
+func (instance DBClusters) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllRdsClusters(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+


### PR DESCRIPTION
This is a complement of #86.

The previous PR was deleting all types of RDS but the Aurora.