### PR TITLE
Adding S3 nuke support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The currently supported functionality includes:
 - Deleting all ECS services in an AWS account
 - Deleting all EKS clusters in an AWS account
 - Deleting all RDS DB instances in an AWS account
+- Deleting all S3 buckets in an AWS account - except for buckets tagged with Key=cloud-nuke-excluded Value=true
 - Deleting all default VPCs in an AWS account
 - Revoking the default rules in the un-deletable default security group of a VPC
 

--- a/aws/s3.go
+++ b/aws/s3.go
@@ -1,0 +1,295 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+// getS3BucketRegion returns S3 Bucket region.
+func getS3BucketRegion(svc *s3.S3, bucketName *string) (string, error) {
+	input := &s3.GetBucketLocationInput{
+		Bucket: bucketName,
+	}
+
+	result, err := svc.GetBucketLocation(input)
+	if err != nil {
+		return "", err
+	}
+
+	if result.LocationConstraint == nil {
+		// GetBucketLocation returns nil for us-east-1
+		// https://github.com/aws/aws-sdk-go/issues/1687
+		return "us-east-1", nil
+	}
+	return *result.LocationConstraint, nil
+}
+
+// getS3BucketTags returns S3 Bucket tags.
+func getS3BucketTags(svc *s3.S3, bucketName *string) ([]map[string]string, error) {
+	input := &s3.GetBucketTaggingInput{
+		Bucket: bucketName,
+	}
+
+	tags := []map[string]string{}
+
+	result, err := svc.GetBucketTagging(input)
+	if err != nil {
+		return tags, err
+	}
+
+	for _, tagSet := range result.TagSet {
+		tags = append(tags, map[string]string{"Key": *tagSet.Key, "Value": *tagSet.Value})
+	}
+
+	return tags, err
+}
+
+// getAllS3Buckets lists and returns a map of per region AWS S3 buckets which were created before excludeAfter
+func getAllS3Buckets(session *session.Session, excludeAfter time.Time, bucketNameSubStr string) (map[string][]*string, error) {
+	svc := s3.New(session)
+
+	input := &s3.ListBucketsInput{}
+
+	output, err := svc.ListBuckets(input)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	var bucketNamesPerRegion = make(map[string][]*string)
+
+OUTER:
+	for _, bucket := range output.Buckets {
+		logging.Logger.Debugf("Checking - Bucket %s", *bucket.Name)
+
+		if len(bucketNameSubStr) > 0 {
+			if !strings.Contains(*bucket.Name, bucketNameSubStr) {
+				logging.Logger.Debugf("Skipping - Bucket %s - failed substring filter - %s", *bucket.Name, bucketNameSubStr)
+				continue
+			}
+		}
+
+		if !excludeAfter.After(*bucket.CreationDate) {
+			logging.Logger.Debugf("Skipping - Bucket %s - matched CreationDate filter", *bucket.Name)
+			continue
+		}
+
+		bucketTags, err := getS3BucketTags(svc, bucket.Name)
+		if len(bucketTags) > 0 {
+			for _, tagSet := range bucketTags {
+				if tagSet["Key"] == "cloud-nuke-excluded" && tagSet["Value"] == "true" {
+					logging.Logger.Infof("Skipping - Bucket %s - matched tag filter", *bucket.Name)
+					continue OUTER
+				}
+			}
+		}
+
+		bucketRegion, err := getS3BucketRegion(svc, bucket.Name)
+		if err != nil {
+			logging.Logger.Warnf("Skipping - Bucket %s - Failed to get bucket location.", *bucket.Name)
+			continue
+		}
+
+		if _, ok := bucketNamesPerRegion[bucketRegion]; !ok {
+			bucketNamesPerRegion[bucketRegion] = []*string{}
+		}
+
+		bucketNamesPerRegion[bucketRegion] = append(bucketNamesPerRegion[bucketRegion], bucket.Name)
+	}
+
+	return bucketNamesPerRegion, nil
+}
+
+func getS3BucketObjectVersions(svc *s3.S3, bucketName *string, objectKey *string) ([]*string, error) {
+	versions := []*string{}
+
+	err := svc.ListObjectVersionsPages(
+		&s3.ListObjectVersionsInput{
+			Bucket: bucketName,
+			Prefix: objectKey,
+		},
+		func(page *s3.ListObjectVersionsOutput, lastPage bool) (shouldContinue bool) {
+			for _, obj := range page.Versions {
+				versions = append(versions, obj.VersionId)
+			}
+			return true
+		},
+	)
+	return versions, err
+}
+
+func getS3BucketObjects(svc *s3.S3, bucketName *string, isVersioned bool) ([]*s3.ObjectIdentifier, error) {
+	identifiers := []*s3.ObjectIdentifier{}
+	hasError := false
+
+	err := svc.ListObjectsV2Pages(
+		&s3.ListObjectsV2Input{
+			Bucket:  bucketName,
+			MaxKeys: aws.Int64(3),
+		},
+
+		func(page *s3.ListObjectsV2Output, lastPage bool) (shouldContinue bool) {
+
+			for _, obj := range page.Contents {
+				if isVersioned {
+					versions, err := getS3BucketObjectVersions(svc, bucketName, obj.Key)
+					if err != nil {
+						logging.Logger.Warnf("Skipping - Bucket %s - object %s - failed to get version", *bucketName, err.Error())
+						hasError = true
+						return false
+					}
+
+					for _, version := range versions {
+						logging.Logger.Debugf("Bucket %s object %s version %s", *bucketName, *obj.Key, *version)
+						identifiers = append(identifiers, &s3.ObjectIdentifier{
+							Key:       obj.Key,
+							VersionId: version,
+						})
+					}
+					continue
+				}
+
+				logging.Logger.Debugf("Bucket %s object %s", *bucketName, *obj.Key)
+
+				identifiers = append(identifiers, &s3.ObjectIdentifier{
+					Key: obj.Key,
+				})
+			}
+			return true
+		},
+	)
+
+	if hasError {
+		return identifiers, fmt.Errorf("Bucket %s - get object versions failed - check logged errors", *bucketName)
+	}
+
+	return identifiers, err
+}
+
+func nukeAllS3BucketObjects(svc *s3.S3, bucketName *string, batchSize int) error {
+	versioningResult, err := svc.GetBucketVersioning(&s3.GetBucketVersioningInput{
+		Bucket: bucketName,
+	})
+	if err != nil {
+		return err
+	}
+
+	isVersioned := versioningResult.Status != nil && *versioningResult.Status == "Enabled"
+
+	objects, err := getS3BucketObjects(svc, bucketName, isVersioned)
+	if err != nil {
+		return err
+	}
+
+	totalObjects := len(objects)
+
+	if totalObjects == 0 {
+		logging.Logger.Infof("Bucket: %s - empty - skipping object deletion", *bucketName)
+		return nil
+	}
+
+	if batchSize <= 0 || batchSize > 1000 {
+		batchSize = 1000
+	}
+
+	logging.Logger.Infof("Deleting - Bucket: %s - objects: %d", *bucketName, totalObjects)
+
+	totalBatches := totalObjects / batchSize
+	if totalObjects%batchSize != 0 {
+		totalBatches = totalBatches + 1
+	}
+	batchCount := 1
+
+	// Batch the delete operation
+	for i := 0; i < len(objects); i += batchSize {
+		j := i + batchSize
+		if j > len(objects) {
+			j = len(objects)
+		}
+
+		logging.Logger.Debugf("Deleting - %d-%d objects of batch %d/%d - Bucket: %s", i+1, j, batchCount, totalBatches, *bucketName)
+
+		delObjects := objects[i:j]
+		_, err = svc.DeleteObjects(
+			&s3.DeleteObjectsInput{
+				Bucket: bucketName,
+				Delete: &s3.Delete{
+					Objects: delObjects,
+					Quiet:   aws.Bool(false),
+				},
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		logging.Logger.Infof("[OK] - %d-%d objects of batch %d/%d - Bucket: %s - deleted", i+1, j, batchCount, totalBatches, *bucketName)
+
+		batchCount++
+	}
+
+	return nil
+}
+
+func nukeEmptyS3Bucket(svc *s3.S3, bucketName *string, verifyBucketDeletion bool) error {
+	_, err := svc.DeleteBucket(&s3.DeleteBucketInput{
+		Bucket: bucketName,
+	})
+	if err != nil {
+		return err
+	}
+
+	if !verifyBucketDeletion {
+		return err
+	}
+
+	err = svc.WaitUntilBucketNotExists(&s3.HeadBucketInput{
+		Bucket: bucketName,
+	})
+	return err
+}
+
+// nukeAllS3Buckets deletes all S3 buckets passed as input
+func nukeAllS3Buckets(session *session.Session, bucketNames []*string, objectBatchSize int) (delCount int, err error) {
+	svc := s3.New(session)
+	verifyBucketDeletion := true
+
+	if len(bucketNames) == 0 {
+		logging.Logger.Infof("No S3 Buckets to nuke in region %s", *session.Config.Region)
+		return 0, nil
+	}
+
+	totalCount := len(bucketNames)
+
+	logging.Logger.Infof("Deleting - %d S3 Buckets in region %s", totalCount, *session.Config.Region)
+
+	for bucketIndex := 0; bucketIndex < totalCount; bucketIndex++ {
+
+		bucketName := bucketNames[bucketIndex]
+		logging.Logger.Debugf("Deleting - %d/%d - Bucket: %s", bucketIndex+1, totalCount, *bucketName)
+
+		err = nukeAllS3BucketObjects(svc, bucketName, objectBatchSize)
+		if err != nil {
+			logging.Logger.Errorf("[Failed] - %d/%d - Bucket: %s - object deletion error - %s", bucketIndex+1, totalCount, *bucketName, err)
+			continue
+		}
+
+		err = nukeEmptyS3Bucket(svc, bucketName, verifyBucketDeletion)
+		if err != nil {
+			logging.Logger.Errorf("[Failed] - %d/%d - Bucket: %s - bucket deletion error - %s", bucketIndex+1, totalCount, *bucketName, err)
+			continue
+		}
+
+		logging.Logger.Infof("[OK] - %d/%d - Bucket: %s - deleted", bucketIndex+1, totalCount, *bucketName)
+		delCount++
+	}
+
+	return delCount, nil
+}

--- a/aws/s3.go
+++ b/aws/s3.go
@@ -206,8 +206,8 @@ func nukeAllS3BucketObjects(svc *s3.S3, bucketName *string, batchSize int) error
 		return nil
 	}
 
-	if batchSize <= 0 || batchSize > 1000 {
-		batchSize = 1000
+	if batchSize < 1 || batchSize > 1000 {
+		return fmt.Errorf("Invalid batchsize - %d - should be between %d and %d ", batchSize, 1, 1000)
 	}
 
 	logging.Logger.Infof("Deleting - Bucket: %s - objects: %d", *bucketName, totalObjects)

--- a/aws/s3.go
+++ b/aws/s3.go
@@ -61,7 +61,9 @@ func hasValidTags(svc *s3.S3, bucket *s3.Bucket) (bool, string) {
 	bucketTags, err := getS3BucketTags(svc, bucket.Name)
 	if len(bucketTags) > 0 {
 		for _, tagSet := range bucketTags {
-			if tagSet["Key"] == "cloud-nuke-excluded" && tagSet["Value"] == "true" {
+			key := strings.ToLower(tagSet["Key"])
+			value := strings.ToLower(tagSet["Value"])
+			if key == "cloud-nuke-excluded" && value == "true" {
 				return false, "matched tag filter"
 			}
 		}

--- a/aws/s3_test.go
+++ b/aws/s3_test.go
@@ -206,7 +206,9 @@ func testListS3BucketsWrapper(t *testing.T, bucketTags []map[string]string, shou
 
 	if len(bucketTags) > 0 {
 		for _, tag := range bucketTags {
-			if tag["Key"] == "cloud-nuke-excluded" && tag["Value"] == "true" {
+			key := strings.ToLower(tag["Key"])
+			value := strings.ToLower(tag["Value"])
+			if key == "cloud-nuke-excluded" && value == "true" {
 				assert.NotContains(t, bucketNamesPerRegion[s.region], aws.String(s.bucketName))
 			}
 		}
@@ -227,6 +229,7 @@ func TestList_EmptyS3Bucket_WithoutFilterTag(t *testing.T) {
 }
 
 func TestList_EmptyS3Bucket_WithFilterTag(t *testing.T) {
+	// Test single filter key
 	testListS3BucketsWrapper(t, []map[string]string{
 		{
 			"Key":   "cloud-nuke-excluded",
@@ -234,6 +237,7 @@ func TestList_EmptyS3Bucket_WithFilterTag(t *testing.T) {
 		},
 	}, false)
 
+	// Test filter key with other keys + validate multi case filter key
 	testListS3BucketsWrapper(t, []map[string]string{
 		{
 			"Key":   "test-key-1",
@@ -244,8 +248,8 @@ func TestList_EmptyS3Bucket_WithFilterTag(t *testing.T) {
 			"Value": "test-value-2",
 		},
 		{
-			"Key":   "cloud-nuke-excluded",
-			"Value": "true",
+			"Key":   "ClouD-NukE-ExcludeD",
+			"Value": "TruE",
 		},
 	}, false)
 }

--- a/aws/s3_test.go
+++ b/aws/s3_test.go
@@ -1,0 +1,291 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestS3Bucket represents a test S3 bucket.
+type TestS3Bucket struct {
+	name        string
+	tags        []map[string]string
+	isVersioned bool
+}
+
+// SetupInfo has test case setup info.
+type SetupInfo struct {
+	region     string
+	session    *session.Session
+	svc        *s3.S3
+	bucketName string
+}
+
+// genTestsBucketName generates a test bucket name.
+func genTestBucketName() string {
+	// Call UniqueID twice because even if the nth test tries to reuse a name of the first test
+	// AWS S3 deletion operation might be in progress after nuking.
+	return strings.ToLower("cloud-nuke-test-" + util.UniqueID() + util.UniqueID())
+}
+
+// TestS3Bucket create creates a test bucket
+func (b TestS3Bucket) create(svc *s3.S3) error {
+	logging.Logger.Infof("Bucket: %s - creating", b.name)
+
+	_, err := svc.CreateBucket(&s3.CreateBucketInput{
+		Bucket: aws.String(b.name),
+	})
+	if err != nil {
+		return err
+	}
+
+	// Add default tag for testing
+	var awsTagSet []*s3.Tag
+	awsTagSet = append(awsTagSet, &s3.Tag{Key: aws.String("cloud-nuke-test"), Value: aws.String("true")})
+
+	for _, tagSet := range b.tags {
+		awsTagSet = append(awsTagSet, &s3.Tag{Key: aws.String(tagSet["Key"]), Value: aws.String(tagSet["Value"])})
+	}
+
+	input := &s3.PutBucketTaggingInput{
+		Bucket: aws.String(b.name),
+		Tagging: &s3.Tagging{
+			TagSet: awsTagSet,
+		},
+	}
+	_, err = svc.PutBucketTagging(input)
+	if err != nil {
+		return err
+	}
+
+	if b.isVersioned {
+		input := &s3.PutBucketVersioningInput{
+			Bucket: aws.String(b.name),
+			VersioningConfiguration: &s3.VersioningConfiguration{
+				Status: aws.String("Enabled"),
+			},
+		}
+		_, err = svc.PutBucketVersioning(input)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = svc.WaitUntilBucketExists(
+		&s3.HeadBucketInput{
+			Bucket: aws.String(b.name),
+		},
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b TestS3Bucket) addObject(s SetupInfo, fileName string, fileBody string) error {
+	logging.Logger.Infof("Bucket: %s - adding object: %s - content: %s", b.name, fileName, fileBody)
+
+	reader := strings.NewReader(fileBody)
+	uploader := s3manager.NewUploader(s.session)
+
+	_, err := uploader.Upload(&s3manager.UploadInput{
+		Bucket: aws.String(b.name),
+		Key:    aws.String(fileName),
+		Body:   reader,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// setupNukeTests sets up common operations for nuke S3 tests.
+func setupNukeTests(t *testing.T) SetupInfo {
+	var s SetupInfo
+
+	region, err := getRandomRegion()
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+	s.region = region
+	s.region = "us-east-2"
+
+	s.session, err = session.NewSession(&awsgo.Config{
+		Region: awsgo.String(s.region)},
+	)
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	s.svc = s3.New(s.session)
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	s.bucketName = genTestBucketName()
+	return s
+}
+
+func testListS3BucketsWrapper(t *testing.T, bucketTags []map[string]string) {
+	s := setupNukeTests(t)
+
+	// Even if we nuke the bucket during our test - this will serve as a test to nuke non-existent bucket
+	// + also as our cleanup call
+	defer nukeAllS3Buckets(s.session, []*string{aws.String(s.bucketName)}, 1000)
+
+	// Verify that - before creating bucket - it should not exist
+	bucketNamesPerRegion, err := getAllS3Buckets(s.session, time.Now().Add(1*time.Hour*-1), s.bucketName)
+	if err != nil {
+		assert.Failf(t, "Failed to list S3 Buckets", errors.WithStackTrace(err).Error())
+	} else {
+		assert.NotContains(t, bucketNamesPerRegion[s.region], s.bucketName)
+	}
+
+	// Create test bucket
+	bucket := TestS3Bucket{
+		name: s.bucketName,
+	}
+	if len(bucketTags) > 0 {
+		bucket.tags = bucketTags
+	}
+	err = bucket.create(s.svc)
+	if err != nil {
+		assert.Failf(t, "Failed to create test bucket", errors.WithStackTrace(err).Error())
+	}
+
+	bucketNamesPerRegion, err = getAllS3Buckets(s.session, time.Now().Add(1*time.Hour), s.bucketName)
+	if err != nil {
+		assert.Failf(t, "Failed to list S3 Buckets", errors.WithStackTrace(err).Error())
+	}
+
+	if len(bucketTags) > 0 {
+		if bucketTags[0]["Key"] == "cloud-nuke-excluded" && bucketTags[0]["Value"] == "true" {
+			assert.NotContains(t, bucketNamesPerRegion[s.region], aws.String(s.bucketName))
+			return
+		}
+	}
+	assert.Contains(t, bucketNamesPerRegion[s.region], aws.String(s.bucketName))
+}
+
+func TestListEmptyS3BucketWithoutFilterTag(t *testing.T) {
+	testListS3BucketsWrapper(t, []map[string]string{
+		{
+			"Key":   "testKey",
+			"Value": "testValue",
+		},
+	})
+}
+
+func TestListEmptyS3BucketWithFilterTag(t *testing.T) {
+	testListS3BucketsWrapper(t, []map[string]string{
+		{
+			"Key":   "cloud-nuke-excluded",
+			"Value": "true",
+		},
+	})
+}
+
+func TestNukeEmptyS3Bucket(t *testing.T) {
+	s := setupNukeTests(t)
+
+	// Create test bucket
+	bucket := TestS3Bucket{
+		name: s.bucketName,
+	}
+
+	err := bucket.create(s.svc)
+	if err != nil {
+		assert.Failf(t, "Failed to create test bucket", errors.WithStackTrace(err).Error())
+	}
+
+	defer nukeAllS3Buckets(s.session, []*string{aws.String(s.bucketName)}, 1000)
+
+	// Nuke the test bucket
+	_, err = nukeAllS3Buckets(s.session, []*string{aws.String(s.bucketName)}, 1000)
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	// Verify that - after nuking test bucket - it should not exist
+	bucketNamesPerRegion, err := getAllS3Buckets(s.session, time.Now().Add(1*time.Hour), s.bucketName)
+	if err != nil {
+		assert.Failf(t, "Failed to list S3 Buckets", errors.WithStackTrace(err).Error())
+	} else {
+		assert.NotContains(t, bucketNamesPerRegion[s.region], aws.String(s.bucketName))
+	}
+}
+
+func testNukeS3BucketWrapper(t *testing.T, isVersioned bool, objectCount int, objectBatchsize int) {
+	s := setupNukeTests(t)
+
+	// Create test bucket
+	bucket := TestS3Bucket{
+		name:        s.bucketName,
+		isVersioned: isVersioned,
+	}
+	err := bucket.create(s.svc)
+	if err != nil {
+		assert.Failf(t, "Failed to create test bucket", errors.WithStackTrace(err).Error())
+	}
+
+	defer nukeAllS3Buckets(s.session, []*string{aws.String(s.bucketName)}, 1000)
+
+	objectVersions := 1
+	if isVersioned {
+		objectVersions = 3
+	}
+
+	// Add two more versions of the same file
+	for i := 0; i < objectVersions; i++ {
+		for j := 0; j < objectCount; j++ {
+			fileName := fmt.Sprintf("l1/l2/l3/f%d.txt", j)
+			fileBody := fmt.Sprintf("%d-%d", i, j)
+			err := bucket.addObject(s, fileName, fileBody)
+			if err != nil {
+				assert.Failf(t, "Failed to add object to test bucket", errors.WithStackTrace(err).Error())
+			}
+		}
+	}
+
+	// Nuke the test bucket
+	_, err = nukeAllS3Buckets(s.session, []*string{aws.String(s.bucketName)}, objectBatchsize)
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	// Verify that - after nuking test bucket - it should not exist
+	bucketNamesPerRegion, err := getAllS3Buckets(s.session, time.Now().Add(1*time.Hour), s.bucketName)
+	if err != nil {
+		assert.Failf(t, "Failed to list S3 Buckets", errors.WithStackTrace(err).Error())
+	} else {
+		assert.NotContains(t, bucketNamesPerRegion[s.region], aws.String(s.bucketName))
+	}
+}
+
+func TestNukeS3BucketWithoutVersioningAllObjects(t *testing.T) {
+	testNukeS3BucketWrapper(t, false, 10, 1000)
+}
+
+func TestNukeS3BucketWithoutVersioningBatchObjects(t *testing.T) {
+	testNukeS3BucketWrapper(t, false, 10, 2)
+}
+
+func TestNukeS3BucketWithVersioningAllObjects(t *testing.T) {
+	testNukeS3BucketWrapper(t, true, 10, 1000)
+}
+
+func TestNukeS3BucketWithVersioningBatchObjects(t *testing.T) {
+	testNukeS3BucketWrapper(t, true, 10, 3)
+}

--- a/aws/s3_types.go
+++ b/aws/s3_types.go
@@ -1,0 +1,54 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+// S3Buckets - represents all S3 Buckets
+type S3Buckets struct {
+	Names []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (bucket S3Buckets) ResourceName() string {
+	return "s3"
+}
+
+// MaxBatchSize decides how many S3 buckets to delete in one call.
+func (bucket S3Buckets) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 500
+}
+
+// ObjectMaxBatchSize decides how many unique objects of an S3 bucket (object + version = unique object) to delete in one call.
+func (bucket S3Buckets) ObjectMaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 1000
+}
+
+// ResourceIdentifiers - The names of the S3 buckets
+func (bucket S3Buckets) ResourceIdentifiers() []string {
+	return bucket.Names
+}
+
+// Nuke - nuke 'em all!!!
+func (bucket S3Buckets) Nuke(session *session.Session, identifiers []string) error {
+	delCount, err := nukeAllS3Buckets(session, aws.StringSlice(identifiers), bucket.ObjectMaxBatchSize())
+
+	totalCount := len(identifiers)
+	if delCount > 0 {
+		logging.Logger.Infof("[OK] - %d/%d - S3 bucket(s) deleted in %s", delCount, totalCount, *session.Config.Region)
+	}
+	if delCount != totalCount {
+		logging.Logger.Errorf("[Failed] - %d/%d - S3 bucket(s) failed deletion in %s", totalCount-delCount, totalCount, *session.Config.Region)
+	}
+
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds support to delete S3 buckets as requested in https://github.com/gruntwork-io/cloud-nuke/issues/58 

It ensures that the AWS S3 list bucket operation - which lists all buckets irrespective of region - is not called multiple times for each region and uses cached entries as highlighted in the above issue discussion. 

Deletion also uses ```WaitUntilBucketNotExists``` to ensure bucket is deleted. It also supports edge cases where in bucket is deleted by some other means after listing but before deletion.

**Demo:**

1. Added s3 to list of resources

```
go run main.go aws --list-resource-types | grep s3

s3
```

2. Run S3 related tests:

```
go test -run S3 -v ./...

=== RUN   TestListS3Buckets
time="2020-02-29T22:52:35+08:00" level=info msg="Random region chosen: ap-northeast-1"
time="2020-02-29T22:52:42+08:00" level=info msg="Awaiting creation - Bucket: cloud-nuke-test-gnd7gn"
time="2020-02-29T22:52:47+08:00" level=info msg="Deleting - 1 S3 Buckets in region ap-northeast-1"
time="2020-02-29T22:52:47+08:00" level=info msg="Deleting - 1/1 - S3 Bucket: cloud-nuke-test-gnd7gn"
time="2020-02-29T22:52:48+08:00" level=info msg="Awaiting deletion - 1/1 - Bucket: cloud-nuke-test-gnd7gn"
time="2020-02-29T22:52:48+08:00" level=info msg="[OK] - 1/1 - Bucket: cloud-nuke-test-gnd7gn - deleted"
--- PASS: TestListS3Buckets (13.35s)
```

TestListS3Buckets - creates, verifies S3 bucket existence, deletes and verifies S3 bucket non existence. 

```
=== RUN   TestNukeS3Buckets
time="2020-02-29T22:52:52+08:00" level=info msg="Random region chosen: ca-central-1"
time="2020-02-29T22:52:55+08:00" level=info msg="Awaiting creation - Bucket: cloud-nuke-test-npymlv"
time="2020-02-29T22:52:56+08:00" level=info msg="Deleting - 1 S3 Buckets in region ca-central-1"
time="2020-02-29T22:52:56+08:00" level=info msg="Deleting - 1/1 - S3 Bucket: cloud-nuke-test-npymlv"
time="2020-02-29T22:52:57+08:00" level=info msg="Awaiting deletion - 1/1 - Bucket: cloud-nuke-test-npymlv"
time="2020-02-29T22:52:57+08:00" level=info msg="[OK] - 1/1 - Bucket: cloud-nuke-test-npymlv - deleted"
time="2020-02-29T22:53:14+08:00" level=info msg="Deleting - 1 S3 Buckets in region ca-central-1"
time="2020-02-29T22:53:15+08:00" level=info msg="S3 Bucket cloud-nuke-test-npymlv exists check error code - NotFound"
time="2020-02-29T22:53:15+08:00" level=warning msg="Failed to find bucket - cloud-nuke-test-npymlv - ignoring as bucket might be deleted."
--- PASS: TestNukeS3Buckets (27.44s)
PASS
```

TestNukeS3Buckets - creates, deletes and verifies S3 bucket deletion - it also tries to delete the same bucket twice to try out the case of bucket present during listing but deleted by some other means before deletion through cloud-nuke.

3. Run S3 deletion with dry run:

```
go run main.go aws --resource-type s3 --region ap-northeast-1 --dry-run


INFO[2020-02-29T23:00:41+08:00] Retrieving active AWS resources in [ap-northeast-1]
INFO[2020-02-29T23:00:41+08:00] Checking region [1/1]: ap-northeast-1
INFO[2020-02-29T23:00:46+08:00] The following AWS resources are going to be nuked:
INFO[2020-02-29T23:00:46+08:00] * test-bucket-1-ap-northeast-1

INFO[2020-02-29T23:00:46+08:00] * test-bucket-2-ap-northeast-1

INFO[2020-02-29T23:00:46+08:00] Not taking any action as dry-run set to true.
```

4. Run S3 deletion without dry-run:

```

go run main.go aws --resource-type s3 --region ap-northeast-1

INFO[2020-02-29T23:00:41+08:00] Retrieving active AWS resources in [ap-northeast-1]
INFO[2020-02-29T23:00:41+08:00] Checking region [1/1]: ap-northeast-1
INFO[2020-02-29T23:00:46+08:00] The following AWS resources are going to be nuked:
INFO[2020-02-29T23:00:46+08:00] * s3-test-bucket-1-ap-northeast-1

INFO[2020-02-29T23:00:46+08:00] * s3-test-bucket-2-ap-northeast-1


THE NEXT STEPS ARE DESTRUCTIVE AND COMPLETELY IRREVERSIBLE, PROCEED WITH CAUTION!!!

Are you sure you want to nuke all listed resources? Enter 'nuke' to confirm (or exit with ^C): nuke

INFO[2020-02-29T23:01:06+08:00] Terminating 2 resources in batches
INFO[2020-02-29T23:01:06+08:00] Deleting - 2 S3 Buckets in region ap-northeast-1
INFO[2020-02-29T23:01:07+08:00] Deleting - 1/2 - S3 Bucket: test-bucket-1
INFO[2020-02-29T23:01:08+08:00] Awaiting deletion - 1/2 - Bucket: test-bucket-1
INFO[2020-02-29T23:01:08+08:00] [OK] - 1/2 - Bucket: test-bucket-1 - deleted
INFO[2020-02-29T23:01:08+08:00] Deleting - 2/2 - S3 Bucket: test-bucket-2
INFO[2020-02-29T23:01:09+08:00] Awaiting deletion - 2/2 - Bucket: test-bucket-2
INFO[2020-02-29T23:01:09+08:00] [OK] - 2/2 - Bucket: test-bucket-2 - deleted
INFO[2020-02-29T23:01:09+08:00] [OK] - 2/2 - S3 bucket(s) deleted in ap-northeast-1
```