### PR TITLE
Fix source of panic in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: /go/src/github.com/gruntwork-io/cloud-nuke
-      - run: go run main.go aws --older-than 1h --force
+      - run:
+          command: go run main.go aws --older-than 1h --force
+          no_output_timeout: 1h
 
   nuke_sandbox:
     <<: *defaults
@@ -60,6 +62,7 @@ jobs:
           at: /go/src/github.com/gruntwork-io/cloud-nuke
       - run:
           command: export AWS_ACCESS_KEY_ID=$SANDBOX_AWS_ACCESS_KEY_ID && export AWS_SECRET_ACCESS_KEY=$SANDBOX_AWS_SECRET_ACCESS_KEY && go run main.go aws --older-than 24h --force
+          no_output_timeout: 1h
 
   deploy:
     <<: *defaults

--- a/aws/ec2_test.go
+++ b/aws/ec2_test.go
@@ -120,7 +120,7 @@ func runAndWaitForInstance(svc *ec2.EC2, name string, params *ec2.RunInstancesIn
 func createTestEC2Instance(t *testing.T, session *session.Session, name string, protected bool) ec2.Instance {
 	svc := ec2.New(session)
 
-	imageID, err := getAMIIdByName(svc, "amzn-ami-hvm-2017.09.1.20180115-x86_64-gp2")
+	imageID, err := getAMIIdByName(svc, "amzn-ami-hvm-2018.03.0.20190826-x86_64-gp2")
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}

--- a/aws/ec2_test.go
+++ b/aws/ec2_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -48,7 +49,12 @@ func getAMIIdByName(svc *ec2.EC2, name string) (string, error) {
 		return "", gruntworkerrors.WithStackTrace(err)
 	}
 
-	return *imagesResult.Images[0].ImageId, nil
+	if len(imagesResult.Images) == 0 {
+		return "", gruntworkerrors.WithStackTrace(fmt.Errorf("No images found with name %s", name))
+	}
+
+	image := imagesResult.Images[0]
+	return awsgo.StringValue(image.ImageId), nil
 }
 
 // runAndWaitForInstance - Given a preconstructed ec2.RunInstancesInput object,


### PR DESCRIPTION
We've had a few test failures where cloud-nuke panics:

- https://circleci.com/gh/gruntwork-io/cloud-nuke/16853
- https://circleci.com/gh/gruntwork-io/cloud-nuke/16865
- https://circleci.com/gh/gruntwork-io/cloud-nuke/16860

This is bad, because panic stops all test threads, even the ones unrelated to the cause of panic, meaning that we skip any cleanup routines we have in testing. Normally, this isn't an issue as we have `cloud-nuke` to handle the cleanup. However, some of the tests create termination protected EC2 instances to test cloud-nuke's functionality to ignore those, and if we don't clean those up, then nothing will.