### PR TITLE
Use t3.micro for testing, since t2.micro is largely deprecated in most regions

### DIFF
--- a/aws/ec2_test.go
+++ b/aws/ec2_test.go
@@ -127,7 +127,7 @@ func createTestEC2Instance(t *testing.T, session *session.Session, name string, 
 
 	params := &ec2.RunInstancesInput{
 		ImageId:               awsgo.String(imageID),
-		InstanceType:          awsgo.String("t2.micro"),
+		InstanceType:          awsgo.String("t3.micro"),
 		MinCount:              awsgo.Int64(1),
 		MaxCount:              awsgo.Int64(1),
 		DisableApiTermination: awsgo.Bool(protected),

--- a/aws/ecs_utils_for_test.go
+++ b/aws/ecs_utils_for_test.go
@@ -67,7 +67,7 @@ func createEcsEC2Cluster(t *testing.T, awsSession *session.Session, name string,
 	}
 	params := &ec2.RunInstancesInput{
 		ImageId:               awsgo.String(imageID),
-		InstanceType:          awsgo.String("t2.micro"),
+		InstanceType:          awsgo.String("t3.micro"),
 		MinCount:              awsgo.Int64(1),
 		MaxCount:              awsgo.Int64(1),
 		DisableApiTermination: awsgo.Bool(false),


### PR DESCRIPTION
Everytime cloud nuke selects a new region (e.g `eu-north-1`), the tests fail because they don't support `t2.micro`. This fixes that by using `t3.micro` for testing.