### PR TITLE
Fix source of panic in RDS module

### DIFF
--- a/aws/eip_test.go
+++ b/aws/eip_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createTestEIPAddress(t *testing.T, session *session.Session, name string) ec2.Address {
@@ -155,9 +156,7 @@ func TestListEIPAddress(t *testing.T) {
 	defer nukeAllEIPAddresses(session, []*string{address.AllocationId})
 
 	allocationIds, err := getAllEIPAddresses(session, region, time.Now().Add(1*time.Hour*-1))
-	if err != nil {
-		assert.Fail(t, "Unable to fetch list of EIP Addresses")
-	}
+	require.NoError(t, err)
 
 	assert.NotContains(t, awsgo.StringValueSlice(allocationIds), awsgo.StringValue(address.AllocationId))
 

--- a/aws/rds.go
+++ b/aws/rds.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
-	// "github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/gruntwork-io/cloud-nuke/logging"
@@ -23,8 +22,8 @@ func getAllRdsInstances(session *session.Session, excludeAfter time.Time) ([]*st
 	var names []*string
 
 	for _, database := range result.DBInstances {
-		if excludeAfter.After(*database.InstanceCreateTime) {
-		  names = append(names, database.DBInstanceIdentifier)
+		if database.InstanceCreateTime != nil && excludeAfter.After(awsgo.TimeValue(database.InstanceCreateTime)) {
+			names = append(names, database.DBInstanceIdentifier)
 		}
 	}
 


### PR DESCRIPTION
One of our recent nuking builds panicked when looking up RDS instances. Looking at the stack trace (https://circleci.com/gh/gruntwork-io/cloud-nuke/16971), it looks like the cause was an RDS instance with `InstanceCreateTime` set to `nil`. Not sure when this is `nil`, but nonetheless added the requisite guards to avoid it in the future.

Also ran `go fmt` and removed dead code (commented out import).