### PR TITLE
Adding support for --log-level and concurrent S3 get

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ If you want to check what resources are going to be targeted without actually te
 cloud-nuke aws --resource-type ec2 --dry-run
 ```
 
+### Log level
+
+You can set the log level by specifying the `--log-level` flag as per [logrus](https://github.com/sirupsen/logrus) log levels:
+
+```shell
+cloud-nuke aws --log-level warn
+```
+
+Default value is - `info`. Acceptable values are `debug, info, warn, error, panic, fatal, trace` as per [logrus log level parser](https://github.com/sirupsen/logrus/blob/master/logrus.go#L25).
+
 ### Nuking only default security group rules
 When deleting defaults with `cloud-nuke defaults-aws`, use the `--sg-only` flag to delete only the default
 security group rules and not the default VPCs.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,13 @@ cloud-nuke aws --resource-type ec2 --dry-run
 You can set the log level by specifying the `--log-level` flag as per [logrus](https://github.com/sirupsen/logrus) log levels:
 
 ```shell
-cloud-nuke aws --log-level warn
+cloud-nuke aws --log-level debug
+```
+
+OR
+
+```shell
+LOG_LEVEL=debug cloud-nuke aws
 ```
 
 Default value is - `info`. Acceptable values are `debug, info, warn, error, panic, fatal, trace` as per [logrus log level parser](https://github.com/sirupsen/logrus/blob/master/logrus.go#L25).

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -415,7 +415,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			bucketNamesPerRegion, ok := resourcesCache["S3"]
 
 			if !ok {
-				bucketNamesPerRegion, err = getAllS3Buckets(session, excludeAfter, "")
+				bucketNamesPerRegion, err = getAllS3Buckets(session, excludeAfter, targetRegions, s3Buckets.MaxConcurrentGetSize(), "")
 				if err != nil {
 					return nil, errors.WithStackTrace(err)
 				}

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -415,7 +415,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			bucketNamesPerRegion, ok := resourcesCache["S3"]
 
 			if !ok {
-				bucketNamesPerRegion, err = getAllS3Buckets(session, excludeAfter, targetRegions, s3Buckets.MaxConcurrentGetSize(), "")
+				bucketNamesPerRegion, err = getAllS3Buckets(session, excludeAfter, targetRegions, "", s3Buckets.MaxConcurrentGetSize())
 				if err != nil {
 					return nil, errors.WithStackTrace(err)
 				}

--- a/aws/s3.go
+++ b/aws/s3.go
@@ -20,7 +20,7 @@ import (
 // getS3BucketRegion returns S3 Bucket region.
 func getS3BucketRegion(svc *s3.S3, bucketName string) (string, error) {
 	input := &s3.GetBucketLocationInput{
-		Bucket: &bucketName,
+		Bucket: aws.String(bucketName),
 	}
 
 	result, err := svc.GetBucketLocation(input)
@@ -39,7 +39,7 @@ func getS3BucketRegion(svc *s3.S3, bucketName string) (string, error) {
 // getS3BucketTags returns S3 Bucket tags.
 func getS3BucketTags(svc *s3.S3, bucketName string) ([]map[string]string, error) {
 	input := &s3.GetBucketTaggingInput{
-		Bucket: &bucketName,
+		Bucket: aws.String(bucketName),
 	}
 
 	tags := []map[string]string{}
@@ -197,7 +197,7 @@ func getBucketNamesPerRegion(svc *s3.S3, targetBuckets []*s3.Bucket, excludeAfte
 		if _, ok := bucketNamesPerRegion[bucketData.Region]; !ok {
 			bucketNamesPerRegion[bucketData.Region] = []*string{}
 		}
-		bucketNamesPerRegion[bucketData.Region] = append(bucketNamesPerRegion[bucketData.Region], &bucketData.Name)
+		bucketNamesPerRegion[bucketData.Region] = append(bucketNamesPerRegion[bucketData.Region], aws.String(bucketData.Name))
 	}
 	return bucketNamesPerRegion, nil
 }
@@ -205,8 +205,8 @@ func getBucketNamesPerRegion(svc *s3.S3, targetBuckets []*s3.Bucket, excludeAfte
 // getBucketInfo populates the local S3Bucket struct for the passed AWS bucket
 func getBucketInfo(svc *s3.S3, bucket *s3.Bucket, excludeAfter time.Time, regionClients map[string]*s3.S3, bucketCh chan<- *S3Bucket) {
 	var bucketData S3Bucket
-	bucketData.Name = *bucket.Name
-	bucketData.CreationDate = *bucket.CreationDate
+	bucketData.Name = aws.StringValue(bucket.Name)
+	bucketData.CreationDate = aws.TimeValue(bucket.CreationDate)
 
 	bucketRegion, err := getS3BucketRegion(svc, bucketData.Name)
 	if err != nil {

--- a/aws/s3.go
+++ b/aws/s3.go
@@ -185,6 +185,8 @@ func getBucketNamesPerRegion(svc *s3.S3, targetBuckets []*s3.Bucket, excludeAfte
 		close(bucketCh)
 	}()
 
+	// Start reading from the channel as soon as the data comes in - so that skip
+	// messages are shown to the user as soon as possible
 	for bucketData := range bucketCh {
 		if bucketData.Error != nil {
 			logging.Logger.Warnf("Skipping - Bucket %s - region - %s - error: %s", bucketData.Name, bucketData.Region, bucketData.Error)

--- a/aws/s3_types.go
+++ b/aws/s3_types.go
@@ -23,6 +23,12 @@ func (bucket S3Buckets) MaxBatchSize() int {
 	return 500
 }
 
+// MaxConcurrentGetSize decides how many S3 buckets to fetch in one call.
+func (bucket S3Buckets) MaxConcurrentGetSize() int {
+	// To speed up bucket fetch part.
+	return 100
+}
+
 // ObjectMaxBatchSize decides how many unique objects of an S3 bucket (object + version = unique object) to delete in one call.
 func (bucket S3Buckets) ObjectMaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gruntwork-io/gruntwork-cli/collections"
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/gruntwork-io/gruntwork-cli/shell"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -62,6 +63,12 @@ func CreateCli(version string) *cli.App {
 					Name:  "force",
 					Usage: "Skip nuke confirmation prompt. WARNING: this will automatically delete all resources without any confirmation",
 				},
+				cli.StringFlag{
+					Name:   "log-level",
+					Value:  "info",
+					Usage:  "Set log level",
+					EnvVar: "LOG_LEVEL",
+				},
 			},
 		}, {
 			Name:   "defaults-aws",
@@ -105,6 +112,14 @@ func parseDurationParam(paramValue string) (*time.Time, error) {
 }
 
 func awsNuke(c *cli.Context) error {
+	logLevel := c.String("log-level")
+
+	parsedLogLevel, err := logrus.ParseLevel(logLevel)
+	if err != nil {
+		return fmt.Errorf("Invalid log level - %s - %s", logLevel, err)
+	}
+	logging.Logger.Level = parsedLogLevel
+
 	allResourceTypes := aws.ListResourceTypes()
 
 	if c.Bool("list-resource-types") {


### PR DESCRIPTION
This PR adds the following features:

1. Support for --log-level flag on command line to control the logging.

**Demo**

```
go run main.go aws --resource-type s3 --log-level debug
```

or 

```
LOG_LEVEL=debug go run main.go aws --resource-type s3
```

Valid log types are mentioned in the corresponding readme change. 


2. Optimizing the `s3.getAllS3Buckets` function to get S3 bucket properties (region,tags) concurrently as opposed to getting for each one - this was added because running S3 bucket deletion for an account > 50 buckets was too slow and was taking around 1 sec per bucket to get its properties - which would lead to linear increase as per the number of buckets. 

`s3.getAllS3Buckets` now supports batchSize which is as per `aws.MaxConcurrentGetSize` in `s3_types.go` to get X buckets data concurrently (default value: 100)

**Demo**:

1. Before adding concurrent gets:

```
go run main.go aws --resource-type s3

INFO[2020-04-04T21:10:19+05:30] The following resources types will be nuked:
INFO[2020-04-04T21:10:19+05:30] - s3
INFO[2020-04-04T21:10:21+05:30] Retrieving active AWS resources in [eu-north-1, ap-south-1, eu-west-3, eu-west-2, eu-west-1, ap-northeast-2, ap-northeast-1, sa-east-1, ca-central-1, ap-southeast-1, ap-southeast-2, eu-central-1, us-east-1, us-east-2, us-west-1, us-west-2]
INFO[2020-04-04T21:10:21+05:30] Checking region [1/16]: eu-north-1
DEBU[2020-04-04T21:10:23+05:30] Checking - Bucket bucket-1
DEBU[2020-04-04T21:10:26+05:30] Checking - Bucket bucket-2
DEBU[2020-04-04T21:10:33+05:30] Checking - Bucket bucket-3
DEBU[2020-04-04T21:10:39+05:30] Checking - Bucket bucket-4
```

The "Checking -" log - gets bucket region, checks for valid tags and decides if the bucket should be deleted or not. This serial check slows down for accounts having large number of buckets i.e at least n seconds for n buckets.

2. After adding concurrent gets:

```
go run main.go aws --resource-type s3 --log-level debug
INFO[2020-04-04T21:13:50+05:30] The following resources types will be nuked:
INFO[2020-04-04T21:13:50+05:30] - s3
INFO[2020-04-04T21:13:52+05:30] Retrieving active AWS resources in [eu-north-1, ap-south-1, eu-west-3, eu-west-2, eu-west-1, ap-northeast-2, ap-northeast-1, sa-east-1, ca-central-1, ap-southeast-1, ap-southeast-2, eu-central-1, us-east-1, us-east-2, us-west-1, us-west-2]
INFO[2020-04-04T21:13:52+05:30] Checking region [1/16]: eu-north-1
DEBU[2020-04-04T21:13:57+05:30] S3 - creating session - region eu-north-1
DEBU[2020-04-04T21:13:57+05:30] S3 - creating session - region ap-south-1
DEBU[2020-04-04T21:13:57+05:30] S3 - creating session - region eu-west-3
DEBU[2020-04-04T21:13:57+05:30] S3 - creating session - region eu-west-2
DEBU[2020-04-04T21:13:57+05:30] S3 - creating session - region eu-west-1
DEBU[2020-04-04T21:13:57+05:30] S3 - creating session - region ap-northeast-2
DEBU[2020-04-04T21:13:57+05:30] S3 - creating session - region ap-northeast-1
.
.
.
INFO[2020-04-04T21:13:57+05:30] Getting - 1-88 buckets of batch 1/1
```

This run creates S3 bucket sessions in advance (required as each bucket needs its region's session object and we have to create them per region sessions in advance to avoid creating them multiple times).

The log **Getting 1-88 buckets of batch 1/1** gets 88 buckets data in parallel subject to limit imposed by `MaxConcurrentGetSize` in `s3_types.go` and completes in 5-8 seconds as opposed to minimum of 88 seconds for 88 buckets when get operation is serial. 

 