### PR TITLE
Optimising the look of the command outputs

### DIFF
--- a/commands/cli.go
+++ b/commands/cli.go
@@ -186,14 +186,14 @@ func awsNuke(c *cli.Context) error {
 	}
 
 	// Log which resource types will be nuked
-	logging.Logger.Info("The following resource types will be nuked:")
+	logging.Logger.Info(" -> The following resource types will be nuked:")
 	if len(resourceTypes) > 0 {
 		for _, resourceType := range resourceTypes {
-			logging.Logger.Infof("- %s", resourceType)
+			fmt.Println("^ ->",resourceType)
 		}
 	} else {
 		for _, resourceType := range allResourceTypes {
-			logging.Logger.Infof("- %s", resourceType)
+			fmt.Println("* ->",resourceType)
 		}
 	}
 
@@ -217,7 +217,7 @@ func awsNuke(c *cli.Context) error {
 		return errors.WithStackTrace(err)
 	}
 
-	logging.Logger.Infof("Retrieving active AWS resources in [%s]", strings.Join(targetRegions[:], ", "))
+	logging.Logger.Infof(" Retrieving active AWS resources in:\n[%s]", strings.Join(targetRegions[:], ", "))
 	account, err := aws.GetAllResources(targetRegions, *excludeAfter, resourceTypes, configObj)
 
 	if err != nil {
@@ -225,7 +225,7 @@ func awsNuke(c *cli.Context) error {
 	}
 
 	if len(account.Resources) == 0 {
-		logging.Logger.Infoln("Nothing to nuke, you're all good!")
+		fmt.Println("\n Nothing to nuke, you're all good!")
 		return nil
 	}
 


### PR DESCRIPTION
# Adding New Look and Feel of the CLI of the command execution

The new output will now look like :

![Screenshot from 2020-06-22 14-30-34](https://user-images.githubusercontent.com/33621094/85295836-1b1ea300-b4be-11ea-9026-b02067325aa0.png)

Tests are also passing:

![Screenshot from 2020-06-22 19-40-42](https://user-images.githubusercontent.com/33621094/85297389-50c48b80-b4c0-11ea-9c81-51067e487d1b.png)
