### PR TITLE
Feature to delete IAM resources(users, groups, policies)

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -216,6 +216,20 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End ASG Names
 
+		// IAM Users
+		iamUsers := IamUsers{}
+		if IsNukeable(iamUsers.ResourceName(), resourceTypes) {
+			userNames, err := getAllIAMUsers(session, excludeAfter)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+			if len(userNames) > 0 {
+				iamUsers.userNames = awsgo.StringValueSlice(userNames)
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, iamUsers)
+			}
+		}
+		// End IAM Users
+		
 		// Launch Configuration Names
 		configs := LaunchConfigs{}
 		if IsNukeable(configs.ResourceName(), resourceTypes) {
@@ -450,6 +464,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 func ListResourceTypes() []string {
 	resourceTypes := []string{
 		ASGroups{}.ResourceName(),
+		IamUsers{}.ResourceName(),
 		LaunchConfigs{}.ResourceName(),
 		LoadBalancers{}.ResourceName(),
 		LoadBalancersV2{}.ResourceName(),

--- a/aws/iam.go
+++ b/aws/iam.go
@@ -1,170 +1,264 @@
 package aws
 
 import (
-    "time"
+	"time"
 
-    awsgo "github.com/aws/aws-sdk-go/aws"
-    "github.com/aws/aws-sdk-go/aws/session"
-    "github.com/aws/aws-sdk-go/service/iam"
-    "github.com/gruntwork-io/cloud-nuke/logging"
-    "github.com/gruntwork-io/gruntwork-cli/errors"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
 )
 
 func getAllIAMUsers(session *session.Session, excludeAfter time.Time) ([]*string, error) {
-    svc := iam.New(session)
+	svc := iam.New(session)
 
-    result, err := svc.ListUsers(&iam.ListUsersInput{})
+	result, err := svc.ListUsers(&iam.ListUsersInput{})
 
-    if err != nil {
-        return nil, errors.WithStackTrace(err)
-    }
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
 
-    var users []*string
+	var users []*string
 
-    for _, user := range result.Users {
-        if user.CreateDate != nil && excludeAfter.After(awsgo.TimeValue(user.CreateDate)) {
-            users = append(users, user.UserName)
-        }
-    }
+	for _, user := range result.Users {
+		if user.CreateDate != nil && excludeAfter.After(awsgo.TimeValue(user.CreateDate)) {
+			users = append(users, user.UserName)
+		}
+	}
 
-    return users, nil
+	return users, nil
 }
 
 func nukeAllIamUsers(session *session.Session, users []*string) error {
-    svc := iam.New(session)
+	svc := iam.New(session)
 
-    if len(users) == 0 {
-        logging.Logger.Infof("No IAM Users to nuke in region %s", *session.Config.Region)
-        return nil
-    }
+	if len(users) == 0 {
+		logging.Logger.Infof("No IAM Users to nuke in region %s", *session.Config.Region)
+		return nil
+	}
 
-    logging.Logger.Infof("Deleting all IAM Users in region %s", *session.Config.Region)
-    deletedUsers := []*string{}
+	logging.Logger.Infof("Deleting all IAM Users in region %s", *session.Config.Region)
+	usersToDelete := []*string{}
 
-    for _, user := range users {
+	for _, user := range users {
 
-        // Delete User password
-        params := &iam.DeleteLoginProfileInput{
-            UserName: user,
-        }
+		// Delete Password
+		params := &iam.DeleteLoginProfileInput{
+			UserName: user,
+		}
 
-        _, err := svc.DeleteLoginProfile(params)
+		_, err := svc.DeleteLoginProfile(params)
 
-        if err != nil {
-            logging.Logger.Errorf("[Failed] %s: %s", user, err)
-        }
-
-        // Delete IAM User access Key pairs
-        keys_output, err := svc.ListAccessKeys(&iam.ListAccessKeysInput{
-            UserName: user,
-        })
-
-        if err != nil {
-            logging.Logger.Errorf("[Failed] %s: %s", keys_output, err)
-        }
-        
-        if len(keys_output.AccessKeyMetadata) > 0 {
-            for _, metadata := range keys_output.AccessKeyMetadata {
-                
-                _, err := svc.DeleteAccessKey(&iam.DeleteAccessKeyInput{
-                    AccessKeyId: metadata.AccessKeyId,
-                })
-    
-                if err != nil {
-                    logging.Logger.Errorf("[Failed] %s: %s", metadata, err)
-                }
-            }
-        }
-
-        // Delete IAM User Signing Certificates
-        certificates_output, err := svc.ListSigningCertificates(&iam.ListSigningCertificatesInput{
-            UserName: user,
-        })
-
-        if err != nil {
-            logging.Logger.Errorf("[Failed] %s: %s", certificates_output, err)
-        }
-        
-        if len(certificates_output.Certificates) > 0 {
-            for _, certificate := range certificates_output.Certificates {
-                
-                _, err := svc.DeleteSigningCertificate(&iam.DeleteSigningCertificateInput{
-                    CertificateId: certificate.CertificateId,
-                })
-
-                if err != nil {
-                    logging.Logger.Errorf("[Failed] %s: %s", certificate, err)
-                }
-            }
-        }
-
-        // Delete SSH public Keys
-		sshKeys_output, err := svc.ListSSHPublicKeys(&iam.ListSSHPublicKeysInput{})
-		
 		if err != nil {
-            logging.Logger.Errorf("[Failed] %s: %s", certificates_output, err)
-        }
-        
-        if len(sshKeys_output.SSHPublicKeys) > 0 {
-            for _, sshKey := range sshKeys_output.SSHPublicKeys {
-                _, err := svc.DeleteSSHPublicKey(&iam.DeleteSSHPublicKeyInput{
-                    SSHPublicKeyId: sshKey.SSHPublicKeyId,
-                    UserName: user,
-                })
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
 
-                if err != nil {
-                    logging.Logger.Errorf("[Failed] %s: %s", sshKey, err)
-                }
-            }
-        }
-
-        // Delete service-specific credential
-		credentials_output, err := svc.ListServiceSpecificCredentials(&iam.ListServiceSpecificCredentialsInput{})
-		if err != nil {
-            logging.Logger.Errorf("[Failed] %s: %s", certificates_output, err)
-        }
-        
-        if len(credentials_output.ServiceSpecificCredentials) > 0 {
-            for _ , credential := range credentials_output.ServiceSpecificCredentials {
-                _, err := svc.DeleteServiceSpecificCredential(&iam.DeleteServiceSpecificCredentialInput{
-                    ServiceSpecificCredentialId: credential.ServiceSpecificCredentialId,
-                })
-
-                if err != nil {
-                    logging.Logger.Errorf("[Failed] %s: %s", credential, err)
-                }
-            }
-        }
-
-        // Delete MFA Device 
-        mfaDevices_output, err := svc.ListMFADevices(&iam.ListMFADevicesInput{
-            UserName: user,
+		// Delete Access Keys
+		accessKeys, err := svc.ListAccessKeys(&iam.ListAccessKeysInput{
+			UserName: user,
 		})
-		
+
 		if err != nil {
-            logging.Logger.Errorf("[Failed] %s: %s", certificates_output, err)
-        }
-        
-        if len(mfaDevices_output.MFADevices) > 0 {
-            for _, mfaDevice := range mfaDevices_output.MFADevices {
-                // Before we delete the MFA device we have to deativate it first
-                _, err := svc.DeactivateMFADevice(&iam.DeactivateMFADeviceInput{
-                       SerialNumber: mfaDevice.SerialNumber,
-                       UserName: user,
-                })
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
 
-                if err != nil {
-                    logging.Logger.Errorf("[Failed] %s: %s", mfaDevice, err)
-                } else {
-                    _, err := svc.DeleteVirtualMFADevice(&iam.DeleteVirtualMFADeviceInput{
-                        SerialNumber: mfaDevice.SerialNumber,
-                    })
+		if len(accessKeys.AccessKeyMetadata) > 0 {
+			for _, metadata := range accessKeys.AccessKeyMetadata {
 
-                    if err != nil {
-                        logging.Logger.Errorf("[Failed] %s: %s", mfaDevice, err)
-                    }
-                }
-            }
-        }
-    }
+				_, err := svc.DeleteAccessKey(&iam.DeleteAccessKeyInput{
+					AccessKeyId: metadata.AccessKeyId,
+					UserName:    user,
+				})
+
+				if err != nil {
+					logging.Logger.Errorf("[Failed] %s: %s", awsgo.StringValue(metadata.AccessKeyId), err)
+				}
+			}
+		}
+
+		// Delete Signing Certificates
+		certificates, err := svc.ListSigningCertificates(&iam.ListSigningCertificatesInput{
+			UserName: user,
+		})
+
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
+
+		if len(certificates.Certificates) > 0 {
+			for _, certificate := range certificates.Certificates {
+
+				_, err := svc.DeleteSigningCertificate(&iam.DeleteSigningCertificateInput{
+					CertificateId: certificate.CertificateId,
+				})
+
+				if err != nil {
+					logging.Logger.Errorf("[Failed] %s: %s", awsgo.StringValue(certificate.CertificateId), err)
+				}
+			}
+		}
+
+		// Delete SSH public Keys
+		sshKeys, err := svc.ListSSHPublicKeys(&iam.ListSSHPublicKeysInput{})
+
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
+
+		if len(sshKeys.SSHPublicKeys) > 0 {
+			for _, sshKey := range sshKeys.SSHPublicKeys {
+				_, err := svc.DeleteSSHPublicKey(&iam.DeleteSSHPublicKeyInput{
+					SSHPublicKeyId: sshKey.SSHPublicKeyId,
+					UserName:       user,
+				})
+
+				if err != nil {
+					logging.Logger.Errorf("[Failed] %s: %s", awsgo.StringValue(sshKey.SSHPublicKeyId), err)
+				}
+			}
+		}
+
+		// Delete Git credentials
+		credentials, err := svc.ListServiceSpecificCredentials(&iam.ListServiceSpecificCredentialsInput{
+			UserName: user,
+		})
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
+
+		if len(credentials.ServiceSpecificCredentials) > 0 {
+			for _, credential := range credentials.ServiceSpecificCredentials {
+				_, err := svc.DeleteServiceSpecificCredential(&iam.DeleteServiceSpecificCredentialInput{
+					ServiceSpecificCredentialId: credential.ServiceSpecificCredentialId,
+				})
+
+				if err != nil {
+					logging.Logger.Errorf("[Failed] %s: %s", awsgo.StringValue(credential.ServiceSpecificCredentialId), err)
+				}
+			}
+		}
+
+		// Delete Multi-factor authentication (MFA) device
+		mfaDevices, err := svc.ListMFADevices(&iam.ListMFADevicesInput{
+			UserName: user,
+		})
+
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
+
+		if len(mfaDevices.MFADevices) > 0 {
+			for _, mfaDevice := range mfaDevices.MFADevices {
+				// To delete the MFA device we have to deativate it first
+				_, err := svc.DeactivateMFADevice(&iam.DeactivateMFADeviceInput{
+					SerialNumber: mfaDevice.SerialNumber,
+					UserName:     user,
+				})
+
+				if err != nil {
+					logging.Logger.Errorf("[Failed] %s: %s", mfaDevice.SerialNumber, err)
+
+				} else {
+					_, err := svc.DeleteVirtualMFADevice(&iam.DeleteVirtualMFADeviceInput{
+						SerialNumber: mfaDevice.SerialNumber,
+					})
+
+					if err != nil {
+						logging.Logger.Errorf("[Failed] %s: %s", awsgo.StringValue(mfaDevice.SerialNumber), err)
+					}
+				}
+			}
+		}
+
+		// Delete Inline policies
+		inlinePolicies, err := svc.ListUserPolicies(&iam.ListUserPoliciesInput{
+			UserName: user,
+		})
+
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
+
+		if len(inlinePolicies.PolicyNames) > 0 {
+			for _, inlinePolicy := range inlinePolicies.PolicyNames {
+				_, err := svc.DeleteUserPolicy(&iam.DeleteUserPolicyInput{
+					PolicyName: inlinePolicy,
+					UserName:   user,
+				})
+				if err != nil {
+					logging.Logger.Errorf("[Failed] %s: %s", awsgo.StringValue(inlinePolicy), err)
+				}
+			}
+		}
+
+		// Detach managed policies
+		managedPolicies, err := svc.ListAttachedUserPolicies(&iam.ListAttachedUserPoliciesInput{
+			UserName: user,
+		})
+
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
+
+		if len(managedPolicies.AttachedPolicies) > 0 {
+			for _, managedPolicy := range managedPolicies.AttachedPolicies {
+				_, err := svc.DetachUserPolicy(&iam.DetachUserPolicyInput{
+					PolicyArn: managedPolicy.PolicyArn,
+					UserName:  user,
+				})
+
+				if err != nil {
+					logging.Logger.Errorf("[Failed] %s: %s", awsgo.StringValue(managedPolicy.PolicyArn), err)
+				}
+			}
+		}
+
+		// Remove user from Group Memberships
+		userGroups, err := svc.ListGroupsForUser(&iam.ListGroupsForUserInput{
+			UserName: user,
+		})
+
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
+
+		if len(userGroups.Groups) > 0 {
+			for _, group := range userGroups.Groups {
+				_, err := svc.RemoveUserFromGroup(&iam.RemoveUserFromGroupInput{
+					GroupName: group.GroupName,
+					UserName:  user,
+				})
+
+				if err != nil {
+					logging.Logger.Errorf("[Failed] %s: %s", awsgo.StringValue(group.GroupName), err)
+				}
+			}
+		}
+
+	usersToDelete = append(usersToDelete, user)
+	}
+
+	deletedUsers := []*string{}
+	if len(usersToDelete) > 0 {
+		for _, user := range usersToDelete {
+
+			_, err := svc.DeleteUser(&iam.DeleteUserInput{
+				UserName: user,
+			})
+
+			if err != nil {
+				logging.Logger.Errorf("[Failed] %s", err)
+				return errors.WithStackTrace(err)
+			}
+			deletedUsers = append(deletedUsers, user)
+		}
+	}
+
+	if len(deletedUsers) != len(users) {
+		logging.Logger.Errorf("[Failed] - %d/%d - IAM User(s) failed deletion in %s", len(users)-len(deletedUsers), len(users), *session.Config.Region)
+	}
+
+	logging.Logger.Infof("[OK] %d IAM User(s) deleted in %s", len(deletedUsers), *session.Config.Region)
+	return nil
 }

--- a/aws/iam.go
+++ b/aws/iam.go
@@ -1,0 +1,170 @@
+package aws
+
+import (
+    "time"
+
+    awsgo "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/iam"
+    "github.com/gruntwork-io/cloud-nuke/logging"
+    "github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+func getAllIAMUsers(session *session.Session, excludeAfter time.Time) ([]*string, error) {
+    svc := iam.New(session)
+
+    result, err := svc.ListUsers(&iam.ListUsersInput{})
+
+    if err != nil {
+        return nil, errors.WithStackTrace(err)
+    }
+
+    var users []*string
+
+    for _, user := range result.Users {
+        if user.CreateDate != nil && excludeAfter.After(awsgo.TimeValue(user.CreateDate)) {
+            users = append(users, user.UserName)
+        }
+    }
+
+    return users, nil
+}
+
+func nukeAllIamUsers(session *session.Session, users []*string) error {
+    svc := iam.New(session)
+
+    if len(users) == 0 {
+        logging.Logger.Infof("No IAM Users to nuke in region %s", *session.Config.Region)
+        return nil
+    }
+
+    logging.Logger.Infof("Deleting all IAM Users in region %s", *session.Config.Region)
+    deletedUsers := []*string{}
+
+    for _, user := range users {
+
+        // Delete User password
+        params := &iam.DeleteLoginProfileInput{
+            UserName: user,
+        }
+
+        _, err := svc.DeleteLoginProfile(params)
+
+        if err != nil {
+            logging.Logger.Errorf("[Failed] %s: %s", user, err)
+        }
+
+        // Delete IAM User access Key pairs
+        keys_output, err := svc.ListAccessKeys(&iam.ListAccessKeysInput{
+            UserName: user,
+        })
+
+        if err != nil {
+            logging.Logger.Errorf("[Failed] %s: %s", keys_output, err)
+        }
+        
+        if len(keys_output.AccessKeyMetadata) > 0 {
+            for _, metadata := range keys_output.AccessKeyMetadata {
+                
+                _, err := svc.DeleteAccessKey(&iam.DeleteAccessKeyInput{
+                    AccessKeyId: metadata.AccessKeyId,
+                })
+    
+                if err != nil {
+                    logging.Logger.Errorf("[Failed] %s: %s", metadata, err)
+                }
+            }
+        }
+
+        // Delete IAM User Signing Certificates
+        certificates_output, err := svc.ListSigningCertificates(&iam.ListSigningCertificatesInput{
+            UserName: user,
+        })
+
+        if err != nil {
+            logging.Logger.Errorf("[Failed] %s: %s", certificates_output, err)
+        }
+        
+        if len(certificates_output.Certificates) > 0 {
+            for _, certificate := range certificates_output.Certificates {
+                
+                _, err := svc.DeleteSigningCertificate(&iam.DeleteSigningCertificateInput{
+                    CertificateId: certificate.CertificateId,
+                })
+
+                if err != nil {
+                    logging.Logger.Errorf("[Failed] %s: %s", certificate, err)
+                }
+            }
+        }
+
+        // Delete SSH public Keys
+		sshKeys_output, err := svc.ListSSHPublicKeys(&iam.ListSSHPublicKeysInput{})
+		
+		if err != nil {
+            logging.Logger.Errorf("[Failed] %s: %s", certificates_output, err)
+        }
+        
+        if len(sshKeys_output.SSHPublicKeys) > 0 {
+            for _, sshKey := range sshKeys_output.SSHPublicKeys {
+                _, err := svc.DeleteSSHPublicKey(&iam.DeleteSSHPublicKeyInput{
+                    SSHPublicKeyId: sshKey.SSHPublicKeyId,
+                    UserName: user,
+                })
+
+                if err != nil {
+                    logging.Logger.Errorf("[Failed] %s: %s", sshKey, err)
+                }
+            }
+        }
+
+        // Delete service-specific credential
+		credentials_output, err := svc.ListServiceSpecificCredentials(&iam.ListServiceSpecificCredentialsInput{})
+		if err != nil {
+            logging.Logger.Errorf("[Failed] %s: %s", certificates_output, err)
+        }
+        
+        if len(credentials_output.ServiceSpecificCredentials) > 0 {
+            for _ , credential := range credentials_output.ServiceSpecificCredentials {
+                _, err := svc.DeleteServiceSpecificCredential(&iam.DeleteServiceSpecificCredentialInput{
+                    ServiceSpecificCredentialId: credential.ServiceSpecificCredentialId,
+                })
+
+                if err != nil {
+                    logging.Logger.Errorf("[Failed] %s: %s", credential, err)
+                }
+            }
+        }
+
+        // Delete MFA Device 
+        mfaDevices_output, err := svc.ListMFADevices(&iam.ListMFADevicesInput{
+            UserName: user,
+		})
+		
+		if err != nil {
+            logging.Logger.Errorf("[Failed] %s: %s", certificates_output, err)
+        }
+        
+        if len(mfaDevices_output.MFADevices) > 0 {
+            for _, mfaDevice := range mfaDevices_output.MFADevices {
+                // Before we delete the MFA device we have to deativate it first
+                _, err := svc.DeactivateMFADevice(&iam.DeactivateMFADeviceInput{
+                       SerialNumber: mfaDevice.SerialNumber,
+                       UserName: user,
+                })
+
+                if err != nil {
+                    logging.Logger.Errorf("[Failed] %s: %s", mfaDevice, err)
+                } else {
+                    _, err := svc.DeleteVirtualMFADevice(&iam.DeleteVirtualMFADeviceInput{
+                        SerialNumber: mfaDevice.SerialNumber,
+                    })
+
+                    if err != nil {
+                        logging.Logger.Errorf("[Failed] %s: %s", mfaDevice, err)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/aws/iam_test.go
+++ b/aws/iam_test.go
@@ -1,0 +1,1 @@
+package aws

--- a/aws/iam_types.go
+++ b/aws/iam_types.go
@@ -1,42 +1,42 @@
 package aws
 
 import (
-    awsgo "github.com/aws/aws-sdk-go/aws"
-    "github.com/aws/aws-sdk-go/aws/session"
-    "github.com/gruntwork-io/gruntwork-cli/errors"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
 )
 
 // IAM - represents all users
 type IamUsers struct {
-    userNames []string
+	userNames []string
 }
 
 // ResourceName - the simple name of the aws resource
 func (userName IamUsers) ResourceName() string {
-    return "iam"
+	return "iam"
 }
 
 // ResourceIdentifiers - The IAM usernames
 func (userName IamUsers) ResourceIdentifiers() []string {
-    return userName.userNames
+	return userName.userNames
 }
 
 func (userName IamUsers) MaxBatchSize() int {
-    // Tentative batch size to ensure AWS doesn't throttle
-    return 200
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 200
 }
 
 // Nuke - nuke 'em all!!!
 func (userName IamUsers) Nuke(session *session.Session, identifiers []string) error {
-    if err := nukeAllIamUsers(session, awsgo.StringSlice(identifiers)); err != nil {
-        return errors.WithStackTrace(err)
-    }
+	if err := nukeAllIamUsers(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
 
-    return nil
+	return nil
 }
 
 type UserNameAvailableError struct{}
 
 func (e UserNameAvailableError) Error() string {
-    return "Username is not available"
+	return "Username is not available"
 }

--- a/aws/iam_types.go
+++ b/aws/iam_types.go
@@ -1,0 +1,42 @@
+package aws
+
+import (
+    awsgo "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+// IAM - represents all users
+type IamUsers struct {
+    userNames []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (userName IamUsers) ResourceName() string {
+    return "iam"
+}
+
+// ResourceIdentifiers - The IAM usernames
+func (userName IamUsers) ResourceIdentifiers() []string {
+    return userName.userNames
+}
+
+func (userName IamUsers) MaxBatchSize() int {
+    // Tentative batch size to ensure AWS doesn't throttle
+    return 200
+}
+
+// Nuke - nuke 'em all!!!
+func (userName IamUsers) Nuke(session *session.Session, identifiers []string) error {
+    if err := nukeAllIamUsers(session, awsgo.StringSlice(identifiers)); err != nil {
+        return errors.WithStackTrace(err)
+    }
+
+    return nil
+}
+
+type UserNameAvailableError struct{}
+
+func (e UserNameAvailableError) Error() string {
+    return "Username is not available"
+}


### PR DESCRIPTION
### Description
Adding support for deleting IAM resources(users, groups, policies).
Enable filtering/matching by tags.

### Related Issue
Closes: #116   

### Tasks

- [x] Get all IAM users
- [ ] Nuke/Delete collected IAM users
- [ ] Enable CLI configuration
- [ ] Add `iam` resource to list of resources
- [ ] Implement complex matching by names_regex
- [ ] Implement complex matching by tags_regex
- [ ] Get all IAM policies
- [ ] Nuke/Delete collected IAM policies
- [ ] Get all IAM groups
- [ ] Nuke/Delete collected IAM groups


