### PR TITLE
Add feature to delete Lambda Functions

### DIFF
--- a/aws/lambda.go
+++ b/aws/lambda.go
@@ -1,0 +1,67 @@
+package aws
+
+import (
+	"time"
+
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+func getAllLambdaFunctions(session *session.Session, excludeAfter time.Time) ([]*string, error) {
+	svc := lambda.New(session)
+
+	result, err := svc.ListFunctions(nil)
+
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	var names []*string
+
+	for _, lambda := range result.Functions {
+		layout := "2006-01-02T15:04:05.000+0000"
+		lastModifiedDateTime, err := time.Parse(layout, *lambda.LastModified)
+		if err != nil {
+			return nil, err
+		}
+
+		if lambda.LastModified != nil && excludeAfter.After(lastModifiedDateTime) {
+			names = append(names, lambda.FunctionName)
+		}
+	}
+
+	return names, nil
+}
+
+func nukeAllLambdaFunctions(session *session.Session, names []*string) error {
+	svc := lambda.New(session)
+
+	if len(names) == 0 {
+		logging.Logger.Infof("No Lambda Functions to nuke in region %s", *session.Config.Region)
+		return nil
+	}
+
+	logging.Logger.Infof("Deleting all Lambda Functions in region %s", *session.Config.Region)
+	deletedNames := []*string{}
+
+	for _, name := range names {
+		params := &lambda.DeleteFunctionInput{
+			FunctionName: name,
+		}
+
+		_, err := svc.DeleteFunction(params)
+
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s: %s", *name, err)
+		} else {
+			deletedNames = append(deletedNames, name)
+			logging.Logger.Infof("Deleted Lambda Function: %s", awsgo.StringValue(name))
+		}
+	}
+
+	logging.Logger.Infof("[OK] %d Lambda Function(s) deleted in %s", len(deletedNames), *session.Config.Region)
+	return nil
+}

--- a/aws/lambda_test.go
+++ b/aws/lambda_test.go
@@ -1,0 +1,158 @@
+package aws
+
+import (
+	"archive/zip"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createZipFile(filename string, file string) error {
+	err := ioutil.WriteFile(file, []byte("package test"), 0755)
+
+	newZipFile, _ := os.Create(filename)
+	defer newZipFile.Close()
+
+	zipWriter := zip.NewWriter(newZipFile)
+	defer zipWriter.Close()
+
+	err = addFileToZip(zipWriter, file)
+	if err != nil {
+		return err
+	}
+
+	err = removeFile(file)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func removeFile(zipFileName string) error {
+	err := os.Remove(zipFileName)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func addFileToZip(zipWriter *zip.Writer, filename string) error {
+	fileToZip, err := os.Open(filename)
+	defer fileToZip.Close()
+
+	info, err := fileToZip.Stat()
+
+	header, err := zip.FileInfoHeader(info)
+	if err != nil {
+		return err
+	}
+
+	header.Name = filename
+	header.Method = zip.Deflate
+
+	writer, err := zipWriter.CreateHeader(header)
+	_, err = io.Copy(writer, fileToZip)
+	return err
+}
+
+func createTestLambdaFunction(t *testing.T, session *session.Session, name string) {
+	svc := lambda.New(session)
+
+	uniqueTestID := "cloud-nuke-test-" + util.UniqueID()
+	roleName := uniqueTestID + "-role"
+	bucketName := uniqueTestID + "-bucket"
+	zipFileName := uniqueTestID + ".zip"
+	goFileName := uniqueTestID + ".go"
+
+	// Prepare resources
+	// Create the IAM roles for Lambda function
+	role := createLambdaRole(t, session, roleName)
+	defer deleteLambdaRole(session, role)
+
+	// IAM resources are slow to propagate, so give it some
+	// time
+	time.Sleep(15 * time.Second)
+
+	svcs3 := s3.New(session)
+	svcs3.CreateBucket(&s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+
+	createZipFile(zipFileName, goFileName)
+	defer removeFile(zipFileName)
+
+	// Upload Zip
+	reader := strings.NewReader(zipFileName)
+	uploader := s3manager.NewUploader(session)
+	uploader.Upload(&s3manager.UploadInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(zipFileName),
+		Body:   reader,
+	})
+
+	runTime := "go1.x"
+	contents, err := ioutil.ReadFile(zipFileName)
+	createCode := &lambda.FunctionCode{
+		ZipFile: contents,
+	}
+	params := &lambda.CreateFunctionInput{
+		Code:         createCode,
+		FunctionName: &name,
+		Handler:      awsgo.String(goFileName),
+		Role:         role.Arn,
+		Runtime:      &runTime,
+	}
+
+	_, err = svc.CreateFunction(params)
+	require.NoError(t, err)
+}
+
+func TestNukeLambdaFunction(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+
+	require.NoError(t, errors.WithStackTrace(err))
+
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
+
+	lambdaFunctionName := "cloud-nuke-test-" + util.UniqueID()
+	excludeAfter := time.Now().Add(1 * time.Hour)
+
+	createTestLambdaFunction(t, session, lambdaFunctionName)
+
+	defer func() {
+		nukeAllLambdaFunctions(session, []*string{&lambdaFunctionName})
+
+		lambdaFunctionNames, _ := getAllLambdaFunctions(session, excludeAfter)
+
+		assert.NotContains(t, awsgo.StringValueSlice(lambdaFunctionNames), lambdaFunctionName)
+	}()
+
+	lambdaFunctions, err := getAllLambdaFunctions(session, excludeAfter)
+
+	if err != nil {
+		assert.Failf(t, "Unable to fetch list of Lambda Functions", errors.WithStackTrace(err).Error())
+	}
+
+	assert.Contains(t, awsgo.StringValueSlice(lambdaFunctions), lambdaFunctionName)
+
+}

--- a/aws/lambda_utils_for_test.go
+++ b/aws/lambda_utils_for_test.go
@@ -1,0 +1,108 @@
+package aws
+
+import (
+	"testing"
+
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	gruntworkerrors "github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func createLambdaRole(t *testing.T, awsSession *session.Session, roleName string) iam.Role {
+	svc := iam.New(awsSession)
+	createRoleParams := &iam.CreateRoleInput{
+		AssumeRolePolicyDocument: awsgo.String(LAMBDA_ASSUME_ROLE_POLICY),
+		RoleName:                 awsgo.String(roleName),
+	}
+
+	result, err := svc.CreateRole(createRoleParams)
+	if err != nil {
+		assert.Fail(t, gruntworkerrors.WithStackTrace(err).Error())
+	}
+	putRolePolicyParams := &iam.PutRolePolicyInput{
+		RoleName:       awsgo.String(roleName),
+		PolicyDocument: awsgo.String(LAMBDA_ROLE_POLICY),
+		PolicyName:     awsgo.String(roleName + "Policy"),
+	}
+	_, err = svc.PutRolePolicy(putRolePolicyParams)
+	if err != nil {
+		assert.Fail(t, gruntworkerrors.WithStackTrace(err).Error())
+	}
+	return *result.Role
+}
+
+func deleteLambdaRole(awsSession *session.Session, role iam.Role) error {
+	svc := iam.New(awsSession)
+	listRolePoliciesParams := &iam.ListRolePoliciesInput{
+		RoleName: role.RoleName,
+	}
+	result, err := svc.ListRolePolicies(listRolePoliciesParams)
+	if err != nil {
+		return gruntworkerrors.WithStackTrace(err)
+	}
+	for _, policyName := range result.PolicyNames {
+		deleteRolePolicyParams := &iam.DeleteRolePolicyInput{
+			RoleName:   role.RoleName,
+			PolicyName: policyName,
+		}
+		_, err := svc.DeleteRolePolicy(deleteRolePolicyParams)
+		if err != nil {
+			return gruntworkerrors.WithStackTrace(err)
+		}
+	}
+	deleteRoleParams := &iam.DeleteRoleInput{
+		RoleName: role.RoleName,
+	}
+	_, err = svc.DeleteRole(deleteRoleParams)
+	if err != nil {
+		return gruntworkerrors.WithStackTrace(err)
+	}
+	return nil
+}
+
+const LAMBDA_ASSUME_ROLE_POLICY = `{
+	"Version": "2012-10-17",
+	"Statement": [
+	  {
+		"Effect": "Allow",
+		"Principal": {
+		  "Service": "lambda.amazonaws.com"
+		},
+		"Action": "sts:AssumeRole"
+	  }
+	]
+  }`
+
+const LAMBDA_ROLE_POLICY = `{
+	"Version": "2012-10-17",
+	"Statement": [
+	  {
+		"Effect": "Allow",
+		"Action": [
+			"lambda:CreateFunction",
+			"lambda:ListVersionsByFunction",
+			"lambda:GetLayerVersion",
+			"lambda:PublishLayerVersion",
+			"lambda:DeleteProvisionedConcurrencyConfig",
+			"lambda:InvokeAsync",
+			"lambda:GetAccountSettings",
+			"lambda:GetFunctionConfiguration",
+			"lambda:GetProvisionedConcurrencyConfig",
+			"lambda:ListTags",
+			"lambda:DeleteLayerVersion",
+			"lambda:PutFunctionEventInvokeConfig",
+			"lambda:DeleteFunctionEventInvokeConfig",
+			"lambda:DeleteFunction",
+			"lambda:ListFunctions",
+			"lambda:GetEventSourceMapping",
+			"lambda:InvokeFunction",
+			"lambda:GetFunction"
+		],
+		"Resource": [
+		  "*"
+		]
+	  }
+	]
+  }`


### PR DESCRIPTION
This PR implements the feature to delete Lambda Functions based on its "LastModified" date, as proposed in https://github.com/gruntwork-io/cloud-nuke/issues/67.