### PR TITLE
Memory efficient s3 delete

### DIFF
--- a/aws/s3.go
+++ b/aws/s3.go
@@ -314,7 +314,6 @@ func emptyBucket(svc *s3.S3, bucketName *string, isVersioned bool, batchSize int
 	// Since the error may happen in the inner function handler for the pager, we need a function scoped variable that
 	// the inner function can set when there is an error.
 	var errOut error
-	errOut = nil
 	pageId := 1
 
 	// Handle versioned buckets.

--- a/aws/s3.go
+++ b/aws/s3.go
@@ -357,7 +357,8 @@ func emptyBucket(svc *s3.S3, bucketName *string, isVersioned bool, batchSize int
 	// Handle non versioned buckets.
 	err := svc.ListObjectsV2Pages(
 		&s3.ListObjectsV2Input{
-			Bucket: bucketName,
+			Bucket:  bucketName,
+			MaxKeys: aws.Int64(int64(batchSize)),
 		},
 		func(page *s3.ListObjectsV2Output, lastPage bool) (shouldContinue bool) {
 			logging.Logger.Debugf("Deleting object page %d (%d objects) from bucket %s", pageId, len(page.Contents), aws.StringValue(bucketName))

--- a/aws/s3_test.go
+++ b/aws/s3_test.go
@@ -426,7 +426,7 @@ func TestNukeS3Bucket(t *testing.T) {
 				TestNukeS3BucketArgs{
 					isVersioned:       isVersioned,
 					checkDeleteMarker: false,
-					objectCount:       10,
+					objectCount:       30,
 					objectBatchsize:   5,
 					shouldNuke:        true,
 					shouldError:       false,

--- a/aws/s3_test.go
+++ b/aws/s3_test.go
@@ -188,7 +188,11 @@ func testListS3Bucket(t *testing.T, args TestListS3BucketArgs) {
 	// to delete
 	defer func() {
 		_, err := nukeAllS3Buckets(awsParams.awsSession, []*string{aws.String(bucketName)}, 1000)
-		assert.NoError(t, err)
+		if args.shouldError {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
 	}()
 
 	// Verify that - before creating bucket - it should not exist

--- a/aws/s3_test.go
+++ b/aws/s3_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -185,7 +186,10 @@ func testListS3Bucket(t *testing.T, args TestListS3BucketArgs) {
 	// Please note that we are passing the same session that was used to create the bucket
 	// This is required so that the defer cleanup call always gets the right bucket region
 	// to delete
-	defer nukeAllS3Buckets(awsParams.awsSession, []*string{aws.String(bucketName)}, 1000)
+	defer func() {
+		_, err := nukeAllS3Buckets(awsParams.awsSession, []*string{aws.String(bucketName)}, 1000)
+		assert.NoError(t, err)
+	}()
 
 	// Verify that - before creating bucket - it should not exist
 	//
@@ -194,7 +198,7 @@ func testListS3Bucket(t *testing.T, args TestListS3BucketArgs) {
 	// AWS_DEFAULT_REGION set to region x but the bucket is in region y.
 	bucketNamesPerRegion, err := getAllS3Buckets(awsSession, time.Now().Add(1*time.Hour*-1), targetRegions, bucketName, args.batchSize, config.Config{})
 	if args.shouldError {
-		require.Error(t, err, "Did not fail for invalid batch size")
+		require.Error(t, err)
 		logging.Logger.Debugf("SUCCESS: Did not list buckets due to invalid batch size - %s - %s", bucketName, err.Error())
 		return
 	}
@@ -306,6 +310,7 @@ type TestNukeS3BucketArgs struct {
 	objectCount       int
 	objectBatchsize   int
 	shouldNuke        bool
+	shouldError       bool
 }
 
 // testNukeS3Bucket - generates the test function for TestNukeS3Bucket
@@ -352,11 +357,13 @@ func testNukeS3Bucket(t *testing.T, args TestNukeS3BucketArgs) {
 		}
 	}
 
-	defer nukeAllS3Buckets(awsParams.awsSession, []*string{aws.String(bucketName)}, 1000)
-
 	// Nuke the test bucket
 	delCount, err := nukeAllS3Buckets(awsParams.awsSession, []*string{aws.String(bucketName)}, args.objectBatchsize)
-	require.NoError(t, err, "Failed to nuke s3 buckets")
+	if args.shouldError {
+		require.Error(t, err)
+	} else {
+		require.NoError(t, err)
+	}
 
 	// If we should not nuke the bucket then deleted bucket count should be 0
 	if !args.shouldNuke {
@@ -398,8 +405,9 @@ func TestNukeS3Bucket(t *testing.T) {
 					isVersioned:       isVersioned,
 					checkDeleteMarker: false,
 					objectCount:       0,
-					objectBatchsize:   0,
+					objectBatchsize:   1,
 					shouldNuke:        true,
+					shouldError:       false,
 				},
 			},
 			{
@@ -410,6 +418,7 @@ func TestNukeS3Bucket(t *testing.T) {
 					objectCount:       10,
 					objectBatchsize:   1000,
 					shouldNuke:        true,
+					shouldError:       false,
 				},
 			},
 			{
@@ -420,6 +429,7 @@ func TestNukeS3Bucket(t *testing.T) {
 					objectCount:       10,
 					objectBatchsize:   5,
 					shouldNuke:        true,
+					shouldError:       false,
 				},
 			},
 			{
@@ -430,6 +440,7 @@ func TestNukeS3Bucket(t *testing.T) {
 					objectCount:       2,
 					objectBatchsize:   1001,
 					shouldNuke:        false,
+					shouldError:       true,
 				},
 			},
 			{
@@ -440,6 +451,7 @@ func TestNukeS3Bucket(t *testing.T) {
 					objectCount:       2,
 					objectBatchsize:   0,
 					shouldNuke:        false,
+					shouldError:       true,
 				},
 			},
 		}
@@ -505,7 +517,8 @@ func TestFilterS3Bucket_Config(t *testing.T) {
 	cleanupBuckets, err := getAllS3Buckets(awsParams.awsSession, time.Now().Add(1*time.Hour), []string{awsParams.region}, "", 100, *configObj)
 	require.NoError(t, err, "Failed to list S3 Buckets in ca-central-1")
 
-	nukeAllS3Buckets(awsParams.awsSession, cleanupBuckets[awsParams.region], 1000)
+	_, err = nukeAllS3Buckets(awsParams.awsSession, cleanupBuckets[awsParams.region], 1000)
+	require.NoError(t, err)
 
 	// Create test buckets in ca-central-1
 	var bucketTags []map[string]string
@@ -563,7 +576,10 @@ func TestFilterS3Bucket_Config(t *testing.T) {
 	}
 
 	// Clean up test buckets
-	defer nukeAllS3Buckets(awsParams.awsSession, aws.StringSlice(bucketNames), 1000)
+	defer func() {
+		_, err := nukeAllS3Buckets(awsParams.awsSession, aws.StringSlice(bucketNames), 1000)
+		assert.NoError(t, err)
+	}()
 	t.Run("config tests", func(t *testing.T) {
 		for _, tc := range testCases {
 			// Capture the range variable as per https://blog.golang.org/subtests

--- a/util/errors.go
+++ b/util/errors.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MultiErr is a meta error that can be used to track multiple errors in a routine (e.g., for loop) so that you can
+// return all the errors in aggregate.
+type MultiErr struct {
+	errors []error
+}
+
+func (err *MultiErr) IsEmpty() bool {
+	return len(err.errors) == 0
+}
+
+// NOTE: this must be a pointer method so that the errors list is updated on the same object
+func (err *MultiErr) Add(newErr error) {
+	if err.errors == nil {
+		err.errors = []error{}
+	}
+	err.errors = append(err.errors, newErr)
+}
+
+func (err *MultiErr) Error() string {
+	out := []string{}
+	for _, childErr := range err.errors {
+		out = append(out, childErr.Error())
+	}
+	return fmt.Sprintf("Encountered multiple errors:\n%s", strings.Join(out, "\n"))
+}


### PR DESCRIPTION
This fixes a few bugs in the s3 deletion routine:

- `cloud-nuke` can crash with OOM if there are too many objects in the bucket. This is because it loads all the objects into memory before starting to delete them. **This was fixed by combining the deletion routine with the pager.**

- No error was returned if there was an error emptying the bucket. This led to confusing error messages where it may have failed to empty the bucket, but cloud-nuke exits because it can't delete the bucket itself. **This was fixed by updating the routine to return a combined error for all the buckets**

- Tests were not checking errors in the nuke routine, so it would exit with a pass even when the nuking failed.