### PR TITLE
Ignore errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ Simply running `cloud-nuke aws` will start the process of cleaning up your cloud
 
 In AWS, to delete only the default resources, run `cloud-nuke defaults-aws`. This will remove the default VPCs in each region, and will also revoke the ingress and egress rules associated with the default security group in each VPC. Note that the default security group itself is unable to be deleted.
 
+### Ignore errors
+
+By default `cloud-nuke` will halt processing if it encounters any error with nuking a region or resource, instead of
+continuing to process additional resources. If you wish to ignore errors and have `cloud-nuke` continue processing even
+when there is an error with one of the resources/regions, pass in the `--ignore-errors` flag:
+
+```
+cloud-nuke aws --ignore-errors
+```
+
 ### Nuke resources in certain regions
 
 When using `cloud-nuke aws`, you can use the `--region` flag to target resources in certain regions for deletion. For example the following command will nuke resources only in `ap-south-1` and `ap-south-2` regions:

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -253,15 +253,15 @@ func awsNuke(c *cli.Context) error {
 		return nil
 	}
 
+	options := aws.NukeOptions{
+		Regions:      regions,
+		IgnoreErrors: c.Bool("ignore-errors"),
+	}
 	if !c.Bool("force") {
 		prompt := "\nAre you sure you want to nuke all listed resources? Enter 'nuke' to confirm (or exit with ^C): "
 		proceed, err := confirmationPrompt(prompt, 2)
 		if err != nil {
 			return err
-		}
-		options := aws.NukeOptions{
-			Regions:      regions,
-			IgnoreErrors: c.Bool("ignore-errors"),
 		}
 		if proceed {
 			if err := aws.NukeAllResources(account, options); err != nil {

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -61,6 +61,10 @@ func CreateCli(version string) *cli.App {
 					Usage: "Dry run without taking any action.",
 				},
 				cli.BoolFlag{
+					Name:  "ignore-errors",
+					Usage: "Ignore errors for each resource. When passed in, cloud-nuke will continue to nuke all resources even if one of the resources fails with an error. This will aggregate all errors at the end.",
+				},
+				cli.BoolFlag{
 					Name:  "force",
 					Usage: "Skip nuke confirmation prompt. WARNING: this will automatically delete all resources without any confirmation",
 				},
@@ -255,8 +259,12 @@ func awsNuke(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
+		options := aws.NukeOptions{
+			Regions:      regions,
+			IgnoreErrors: c.Bool("ignore-errors"),
+		}
 		if proceed {
-			if err := aws.NukeAllResources(account, regions); err != nil {
+			if err := aws.NukeAllResources(account, options); err != nil {
 				return err
 			}
 		}
@@ -268,7 +276,7 @@ func awsNuke(c *cli.Context) error {
 		}
 
 		fmt.Println()
-		if err := aws.NukeAllResources(account, regions); err != nil {
+		if err := aws.NukeAllResources(account, options); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
By default `cloud-nuke` will halt processing if it encounters any error with nuking a region or resource, instead of
continuing to process additional resources. This PR introduces a new CLI flag (`--ignore-errrors`) to inform `cloud-nuke` to ignore errors and continue processing, but aggregate the errors at the end so the overall command still exists with a non-zero exit code.