### PR TITLE
Nuke gruntwork S3 buckets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,9 +92,7 @@ workflows:
             branches:
               only: master
     jobs:
-      - nuke_phx_devops:
-          requires:
-            - test
+      - nuke_phx_devops
   nightly:
     triggers:
       - schedule:
@@ -103,6 +101,4 @@ workflows:
             branches:
               only: master
     jobs:
-      - nuke_sandbox:
-          requires:
-            - test
+      - nuke_sandbox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
             go run main.go aws \
               --older-than 1h \
               --force \
-              --exclude-resource-type s3 \
+              --config ./.circleci/nuke_config.yml \
               --exclude-resource-type iam
           no_output_timeout: 1h
   nuke_sandbox:
@@ -46,7 +46,7 @@ jobs:
             go run main.go aws \
               --older-than 24h \
               --force \
-              --exclude-resource-type s3 \
+              --config ./.circleci/nuke_config.yml \
               --exclude-resource-type iam
           no_output_timeout: 1h
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,6 @@ workflows:
             branches:
               only: master
     jobs:
-      - test
       - nuke_phx_devops:
           requires:
             - test
@@ -104,7 +103,6 @@ workflows:
             branches:
               only: master
     jobs:
-      - test
       - nuke_sandbox:
           requires:
             - test

--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -1,3 +1,5 @@
+# This is a config file specifically for Gruntwork sandbox accounts to only clean up S3 buckets that we know for sure
+# are used for testing.
 s3:
   include:
     names_regex:

--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -1,0 +1,14 @@
+s3:
+  include:
+    names_regex:
+      - "^cloudfront-example-[a-zA-Z0-9]{6}\\.gruntwork\\.in.*"
+      - "^gruntwork-terratest-[a-zA-Z0-9]{6}$"
+      - "^gw-cis-aws-config-all-regions-[a-zA-Z0-9]{6}-.*"
+      - "^gruntwork-test-[a-zA-Z0-9]{6}-config-test$"
+      - "^houston-static-[a-zA-Z0-9]{12}.*"
+      - "^cloud-nuke-test-[a-zA-Z0-9]{12}.*"
+      - "^cloud-nuke-test-[a-zA-Z0-9]{6}-bucket$"
+      - "^alb-alb-[a-zA-Z0-9]{6}-access-logs$"
+      - "^kafka-zk-standalone-[a-zA-Z0-9]{6}$"
+      - "^zookeeper-cluster-test-[a-zA-Z0-9]{6}$"
+      - "^terragrunt-test-bucket-[a-zA-Z0-9]{6}.*"


### PR DESCRIPTION
This updates the CircleCI config to run nuke jobs for S3 buckets. To avoid deleting buckets that we expect to use, this adds a config file with the regex list that we have been using in the `aws-gc.py` script.

Note that I also updated the nuke jobs to not depend on the tests passing. It seems unnecessary to continuously run tests for every nuke job, especially since they are fairly slow. Not to mention that they are flaky and transiently fail, causing us to skip a nuke cycle.