### PR TITLE
Fix for inactive ecs clusters

### DIFF
--- a/aws/ami_test.go
+++ b/aws/ami_test.go
@@ -121,7 +121,7 @@ func TestListAMIs(t *testing.T) {
 	assert.Contains(t, awsgo.StringValueSlice(amis), *image.ImageId)
 }
 
-func TestNukeAMIs(t *testing.T) {
+func g(t *testing.T) {
 	t.Parallel()
 
 	region, err := getRandomRegion()

--- a/aws/ami_test.go
+++ b/aws/ami_test.go
@@ -121,7 +121,7 @@ func TestListAMIs(t *testing.T) {
 	assert.Contains(t, awsgo.StringValueSlice(amis), *image.ImageId)
 }
 
-func g(t *testing.T) {
+func TestNukeAMIs(t *testing.T) {
 	t.Parallel()
 
 	region, err := getRandomRegion()

--- a/aws/ecs_cluster.go
+++ b/aws/ecs_cluster.go
@@ -67,7 +67,7 @@ func getAllEcsClustersOlderThan(awsSession *session.Session, region string, excl
 
 	clusterArns, err := getAllActiveEcsClusterArns(awsSession)
 	if err != nil {
-		logging.Logger.Errorf("Error getting all ECS clusters with `ACTIVE` status")
+		logging.Logger.Errorf("Error getting all ECS clusters with `ACTIVE` or `PROVISIONING` status")
 		return nil, errors.WithStackTrace(err)
 	}
 

--- a/aws/ecs_cluster.go
+++ b/aws/ecs_cluster.go
@@ -16,7 +16,7 @@ import (
 const activeEcsClusterStatus string = "ACTIVE"
 const provisioningEcsClusterStatus = "PROVISIONING"
 
-// filter out all active ecs clusters
+// Filter all active ecs clusters
 func getAllActiveEcsClusterArns(awsSession *session.Session) ([]*string, error) {
 	svc := ecs.New(awsSession)
 

--- a/aws/ecs_cluster.go
+++ b/aws/ecs_cluster.go
@@ -25,20 +25,10 @@ func getAllActiveEcsClusterArns(awsSession *session.Session) ([]*string, error) 
 		return nil, errors.WithStackTrace(err)
 	}
 
-	var result []*ecs.Cluster
-
-	for _, cluster := range allClusters {
-		input := &ecs.DescribeClustersInput{
-			Clusters: []*string{cluster},
-		}
-
-		describedClusters, describeErr := svc.DescribeClusters(input)
-		if describeErr != nil {
-			logging.Logger.Errorf("Error describing ECS clusters")
-			return nil, errors.WithStackTrace(describeErr)
-		}
-
-		result = append(result, describedClusters.Clusters...)
+	described, describeErr := describeEcsClusters(svc, allClusters)
+	if describeErr != nil {
+		logging.Logger.Errorf("Error describing ECS clusters")
+		return nil, errors.WithStackTrace(describeErr)
 	}
 
 	var filteredEcsClusterArns []*string
@@ -46,7 +36,7 @@ func getAllActiveEcsClusterArns(awsSession *session.Session) ([]*string, error) 
 	// Filter and return only `ACTIVE` state ECS Clusters.
 	// `cloud-nuke` needs to tag ECS Clusters it sees for the first time.
 	// Therefore to tag a cluster, that cluster must be in the `ACTIVE` state.
-	for _, cluster := range result {
+	for _, cluster := range described {
 		logging.Logger.Debugf("Status for ECS Cluster %s is %s", aws.StringValue(cluster.ClusterArn), aws.StringValue(cluster.Status))
 
 		if aws.StringValue(cluster.Status) == activeEcsClusterStatus {
@@ -56,6 +46,29 @@ func getAllActiveEcsClusterArns(awsSession *session.Session) ([]*string, error) 
 
 	return filteredEcsClusterArns, nil
 }
+
+func describeEcsClusters(svc *ecs.ECS, allClusters []*string) ([]*ecs.Cluster, error) {
+	var result []*ecs.Cluster
+	batches := split(aws.StringValueSlice(allClusters), 10)
+
+	for _, batch := range batches {
+		input := &ecs.DescribeClustersInput{
+			Clusters: awsgo.StringSlice(batch),
+		}
+
+		describedClusters, describeErr := svc.DescribeClusters(input)
+		if describeErr != nil {
+			logging.Logger.Errorf("Error describing ECS clusters from input %s: ", input)
+			return nil, errors.WithStackTrace(describeErr)
+		}
+
+		result = append(result, describedClusters.Clusters...)
+	}
+
+	return result, nil
+}
+
+
 
 func getAllEcsClustersOlderThan(awsSession *session.Session, region string, excludeAfter time.Time) ([]*string, error) {
 	awsSession, err := session.NewSession(&awsgo.Config{

--- a/aws/ecs_cluster_test.go
+++ b/aws/ecs_cluster_test.go
@@ -14,7 +14,8 @@ import (
 // Test we can create a cluster, tag it, and then find the tag
 func TestCanTagEcsClusters(t *testing.T) {
 	t.Parallel()
-	region, err := getRandomRegion()
+	region, regionErr := getRandomRegion()
+	require.NoError(t, regionErr)
 
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),
@@ -45,7 +46,8 @@ func TestCanTagEcsClusters(t *testing.T) {
 // Test we can get all ECS clusters younger than < X time based on tags
 func TestCanListAllEcsClustersOlderThan24hours(t *testing.T) {
 	t.Parallel()
-	region, err := getRandomRegion()
+	region, regionErr := getRandomRegion()
+	require.NoError(t, regionErr)
 
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),
@@ -76,7 +78,8 @@ func TestCanListAllEcsClustersOlderThan24hours(t *testing.T) {
 // Test we can nuke all ECS clusters older than 24hrs
 func TestCanNukeAllEcsClustersOlderThan24Hours(t *testing.T) {
 	t.Parallel()
-	region, err := getRandomRegion()
+	region, regionErr := getRandomRegion()
+	require.NoError(t, regionErr)
 
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),

--- a/aws/ecs_cluster_test.go
+++ b/aws/ecs_cluster_test.go
@@ -21,7 +21,7 @@ func TestCanTagEcsClusters(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	cluster := createEcsFargateCluster(t, awsSession, util.UniqueID())
+	cluster := createEcsFargateCluster(t, awsSession, "cloud-nuke-test-" + util.UniqueID())
 	defer deleteEcsCluster(awsSession, cluster)
 
 	tagValue := time.Now().UTC()
@@ -83,11 +83,11 @@ func TestCanNukeAllEcsClustersOlderThan24Hours(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	cluster1 := createEcsFargateCluster(t, awsSession, util.UniqueID())
+	cluster1 := createEcsFargateCluster(t, awsSession, "cloud-nuke-test-" + util.UniqueID())
 	defer deleteEcsCluster(awsSession, cluster1)
-	cluster2 := createEcsFargateCluster(t, awsSession, util.UniqueID())
+	cluster2 := createEcsFargateCluster(t, awsSession, "cloud-nuke-test-" + util.UniqueID())
 	defer deleteEcsCluster(awsSession, cluster2)
-	cluster3 := createEcsFargateCluster(t, awsSession, util.UniqueID())
+	cluster3 := createEcsFargateCluster(t, awsSession, "cloud-nuke-test-" + util.UniqueID())
 	defer deleteEcsCluster(awsSession, cluster3)
 
 	now := time.Now().UTC()

--- a/aws/ecs_cluster_test.go
+++ b/aws/ecs_cluster_test.go
@@ -14,8 +14,7 @@ import (
 // Test we can create a cluster, tag it, and then find the tag
 func TestCanTagEcsClusters(t *testing.T) {
 	t.Parallel()
-	region, regionErr := getRandomRegion()
-	require.NoError(t, regionErr)
+	region := getRandomFargateSupportedRegion()
 
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),
@@ -46,8 +45,7 @@ func TestCanTagEcsClusters(t *testing.T) {
 // Test we can get all ECS clusters younger than < X time based on tags
 func TestCanListAllEcsClustersOlderThan24hours(t *testing.T) {
 	t.Parallel()
-	region, regionErr := getRandomRegion()
-	require.NoError(t, regionErr)
+	region := getRandomFargateSupportedRegion()
 
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),
@@ -78,8 +76,7 @@ func TestCanListAllEcsClustersOlderThan24hours(t *testing.T) {
 // Test we can nuke all ECS clusters older than 24hrs
 func TestCanNukeAllEcsClustersOlderThan24Hours(t *testing.T) {
 	t.Parallel()
-	region, regionErr := getRandomRegion()
-	require.NoError(t, regionErr)
+	region := getRandomFargateSupportedRegion()
 
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),

--- a/aws/ecs_cluster_test.go
+++ b/aws/ecs_cluster_test.go
@@ -11,11 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const region = "eu-west-1"
-
 // Test we can create a cluster, tag it, and then find the tag
 func TestCanTagEcsClusters(t *testing.T) {
 	t.Parallel()
+	region, err := getRandomRegion()
 
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),
@@ -46,6 +45,7 @@ func TestCanTagEcsClusters(t *testing.T) {
 // Test we can get all ECS clusters younger than < X time based on tags
 func TestCanListAllEcsClustersOlderThan24hours(t *testing.T) {
 	t.Parallel()
+	region, err := getRandomRegion()
 
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),
@@ -76,7 +76,7 @@ func TestCanListAllEcsClustersOlderThan24hours(t *testing.T) {
 // Test we can nuke all ECS clusters older than 24hrs
 func TestCanNukeAllEcsClustersOlderThan24Hours(t *testing.T) {
 	t.Parallel()
-	t.Skip("Skipping temporarily - will be fixed as part of issue-145")
+	region, err := getRandomRegion()
 
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),


### PR DESCRIPTION
Hey, this PR is aiming to add filtering to ECS Clusters. The issue I was seeing is described here: https://github.com/gruntwork-io/cloud-nuke/issues/145

**Overview:** 
In some scenarios, the ECS Clusters TagResource function would be called while the cluster is not in `ACTIVE` state. This meant that the tests we have fail, and also the code itself was flawed. 

**It has now been updated:**
- `cloud-nuke ecscluster` will nuke ECS Clusters which are also set as `ACTIVE` or `PROVISIONING`
- `PROVISIONING` is also part of the condition, as the assumption is the cluster will be discoverable, and its state is going towards being `ACTIVE`
- all other states (`INACTIVE`, `DEPROVISIONING`, `FAILED`) are not relevant and therefore used in this functionality (you can't tag a cluster that's not active)

Additional changes:
- the tests now use a random region 
- the tests also now use a name for the clusters `cloud-nuke-test-XXXXX`