### PR TITLE
Remove contexts from scheduled builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,8 +96,6 @@ workflows:
       - nuke_phx_devops:
           requires:
             - test
-          context:
-            - Gruntwork Admin
   nightly:
     triggers:
       - schedule:
@@ -112,5 +110,3 @@ workflows:
       - nuke_sandbox:
           requires:
             - test
-          context:
-            - Gruntwork Admin


### PR DESCRIPTION
CircleCi builds that run on a schedule run on behalf of some CircleCi machine user, and that machine user does not have access to our CircleCi contexts. As a result, all the builds show up as "unauthorized":

<img width="838" alt="Screen Shot 2020-11-30 at 9 41 18 AM" src="https://user-images.githubusercontent.com/711908/100593381-42d92900-32f0-11eb-95b2-f22a61d64a84.png">
