### PR TITLE
Remove context from test jobs too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,9 +90,7 @@ workflows:
             branches:
               only: master
     jobs:
-      - test:
-          context:
-            - Gruntwork Admin
+      - test
       - nuke_phx_devops:
           requires:
             - test
@@ -104,9 +102,7 @@ workflows:
             branches:
               only: master
     jobs:
-      - test:
-          context:
-            - Gruntwork Admin
+      - test
       - nuke_sandbox:
           requires:
             - test


### PR DESCRIPTION
In #154, I accidentally missed removing the context from the `test` jobs in the scheduled workflows 🤦