### PR TITLE
Log accurate number of AMIs deleted

### DIFF
--- a/aws/ami.go
+++ b/aws/ami.go
@@ -50,6 +50,7 @@ func nukeAllAMIs(session *session.Session, imageIds []*string) error {
 
 	logging.Logger.Infof("Deleting all AMIs in region %s", *session.Config.Region)
 
+	deletedCount := 0
 	for _, imageID := range imageIds {
 		params := &ec2.DeregisterImageInput{
 			ImageId: imageID,
@@ -59,10 +60,11 @@ func nukeAllAMIs(session *session.Session, imageIds []*string) error {
 		if err != nil {
 			logging.Logger.Errorf("[Failed] %s", err)
 		} else {
+			deletedCount++
 			logging.Logger.Infof("Deleted AMI: %s", *imageID)
 		}
 	}
 
-	logging.Logger.Infof("[OK] %d AMI(s) terminated in %s", len(imageIds), *session.Config.Region)
+	logging.Logger.Infof("[OK] %d AMI(s) terminated in %s", deletedCount, *session.Config.Region)
 	return nil
 }


### PR DESCRIPTION
### Description
[#161 ](https://github.com/gruntwork-io/cloud-nuke/issues/161)
Log the actual count of AMIs deleted.

### Tests
I tried running the tests, but my AWS educate account doesn't have enough permissions to run them properly.
Its a simple change though.