### PR TITLE
Exclude transit gateway resources from nuking job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,10 @@ jobs:
               --older-than 1h \
               --force \
               --config ./.circleci/nuke_config.yml \
-              --exclude-resource-type iam
+              --exclude-resource-type iam \
+              --exclude-resource-type transit-gateway \
+              --exclude-resource-type transit-gateway-attachment \
+              --exclude-resource-type transit-gateway-route-table
           no_output_timeout: 1h
   nuke_sandbox:
     <<: *defaults
@@ -47,7 +50,10 @@ jobs:
               --older-than 24h \
               --force \
               --config ./.circleci/nuke_config.yml \
-              --exclude-resource-type iam
+              --exclude-resource-type iam \
+              --exclude-resource-type transit-gateway \
+              --exclude-resource-type transit-gateway-attachment \
+              --exclude-resource-type transit-gateway-route-table
           no_output_timeout: 1h
   deploy:
     <<: *defaults


### PR DESCRIPTION
There appears to be a bug in the implementation of the transit gateway nuking job that causes our account nuking CI job to fail. See [this failing build](https://app.circleci.com/pipelines/github/gruntwork-io/cloud-nuke/3272/workflows/466051ad-35fb-47b4-a5e4-5ba89d1db316/jobs/24002) for example.

Note that it does not appear to be IAM permission related, as the transit gateway related IAM permissions are all nested under `ec2`, which our CI user has full access to.

This PR disables nuking those resources until we can find a resolution.