### PR TITLE
Update to latest CircleCi image; don't require tests to pass when building binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: /go/src/github.com/gruntwork-io/cloud-nuke
   docker:
-    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.13
+    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.16-go111module
 version: 2
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,6 @@ workflows:
           context:
             - Gruntwork Admin
       - build:
-          requires:
-            - test
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,4 @@
 defaults: &defaults
-  working_directory: /go/src/github.com/gruntwork-io/cloud-nuke
   docker:
     - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.16-go111module
 version: 2


### PR DESCRIPTION
This should pick up the latest versions of Go and the `build-go-binaries` script, which should build binaries for Darwin ARM 64. Hopefully, this fixes #190.

I've also updated the build to not require the tests to pass on release builds when publishing binaries. 