### PR TITLE
Add support for nuking secrets manager secrets

### DIFF
--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -14,3 +14,11 @@ s3:
       - "^kafka-zk-standalone-[a-zA-Z0-9]{6}$"
       - "^zookeeper-cluster-test-[a-zA-Z0-9]{6}$"
       - "^terragrunt-test-bucket-[a-zA-Z0-9]{6}.*"
+
+SecretsManager:
+  include:
+    names_regex:
+      - "^test-name-[a-zA-Z0-9]{6}$"
+      - "^GruntworkSampleAppFrontendCA[a-zA-Z0-9]{6}$"
+      - "^GruntworkSampleAppBackendCA[a-zA-Z0-9]{6}$"
+      - "^RDSDBConfig[a-zA-Z0-9]{6}$"

--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -22,3 +22,5 @@ SecretsManager:
       - "^GruntworkSampleAppFrontendCA[a-zA-Z0-9]{6}$"
       - "^GruntworkSampleAppBackendCA[a-zA-Z0-9]{6}$"
       - "^RDSDBConfig[a-zA-Z0-9]{6}$"
+      - "ECRDeployRunnerTestSSHKey-[a-zA-Z0-9]{6}$"
+      - "ECRDeployRunnerTestGitPAT-[a-zA-Z0-9]{6}$"

--- a/README.md
+++ b/README.md
@@ -134,9 +134,22 @@ cloud-nuke aws --resource-type ec2 --dry-run
 
 For more granularity, such as being able to specify which resources to terminate using regular expressions or plain text, you can pass in a configuration file.
 
-_Note: Config file support is a new feature and only filtering s3 buckets and IAM Users by name using regular expressions is currently supported. We'll be adding more support in the future, and pull requests are welcome!_
+_Note: Config file support is a new feature and only filtering a handful of resources by name using regular expressions is currently supported. We'll be adding more support in the future, and pull requests are welcome!_
 
-#### S3 Buckets
+The following resources support the Config file:
+
+- S3 Buckets
+    - Resource type: `s3`
+    - Config key: `s3`
+- IAM Users
+    - Resource type: `iam`
+    - Config key: `IAMUsers`
+- Secrets Manager Secrets
+    - Resource type: `secretsmanager`
+    - Config key: `SecretsManagerSecrets`
+
+
+#### Example
 
 ```shell
 cloud-nuke aws --resource-type s3 --config path/to/file.yaml
@@ -151,6 +164,16 @@ s3:
     names_regex:
       - ^alb-.*-access-logs$
       - .*-prod-alb-.*
+```
+
+Similarly, you can adjust the config to delete only IAM users of a particular name by using the `IAMUsers` key. For
+example, in the following config, only IAM users that have the prefix `my-test-user-` in their username will be deleted.
+
+```
+IAMUsers:
+  include:
+    names_regex:
+      - ^my-test-user-.*
 ```
 
 #### Include and exclude together
@@ -196,25 +219,6 @@ s3:
 ```
 -->
 
-#### IAM Users
-
-```shell
-cloud-nuke aws --resource-type iam --config path/to/file.yaml
-```
-
-Given this command, `cloud-nuke` will nuke _only_ IAM Users, as specified by the `--resource-type iam` option.
-
-The config file parameters are identical to the ones of `s3` with the only difference being the key name: `IAMUsers`.
-
-As an example, in the following config file, a user named `some-nice-user-name` would be deleted but a user named `interesting-user-name` would not.
-
-```yaml
-IAMUsers:
-  include:
-    names_regex:
-      - ^some-.*-user-name$
-      - .*-cool-name-.*
-```
 
 #### CLI options override config file options
 
@@ -228,11 +232,13 @@ Be careful when nuking and append the `--dry-run` option if you're unsure. Even 
 
 To find out what we options are supported in the config file today, consult this table. Resource types at the top level of the file that are supported are listed here.
 
-| resource type | support |
-|---------------|---------|
-| s3            | partial |
-| ec2 instance  | none    |
-| iam role      | none    |
+| resource type  | support |
+|----------------|---------|
+| s3             | partial |
+| iam            | partial |
+| secretsmanager | partial |
+| ec2 instance   | none    |
+| iam role       | none    |
 | ... (more to come) | none |
 
 
@@ -245,6 +251,27 @@ _Note: the fields without `_regex` suffixes refer to support for plain-text matc
 | names_regex | ✅      | ✅      |
 | tags        | none    | none    |
 | tags_regex  | none    | none    |
+
+##### iam resource type:
+_Note: the fields without `_regex` suffixes refer to support for plain-text matching against those fields._
+
+| field       | include | exclude |
+|-------------|---------|---------|
+| names       | none    | none    |
+| names_regex | ✅      | ✅      |
+| tags        | none    | none    |
+| tags_regex  | none    | none    |
+
+##### secretsmanager resource type:
+_Note: the fields without `_regex` suffixes refer to support for plain-text matching against those fields._
+
+| field       | include | exclude |
+|-------------|---------|---------|
+| names       | none    | none    |
+| names_regex | ✅      | ✅      |
+| tags        | none    | none    |
+| tags_regex  | none    | none    |
+
 
 ### Log level
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The following resources support the Config file:
     - Config key: `IAMUsers`
 - Secrets Manager Secrets
     - Resource type: `secretsmanager`
-    - Config key: `SecretsManagerSecrets`
+    - Config key: `SecretsManager`
 
 
 #### Example

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -503,6 +503,21 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End Lambda Functions
 
+		// Secrets Manager Secrets
+		secretsManagerSecrets := SecretsManagerSecrets{}
+		if IsNukeable(secretsManagerSecrets.ResourceName(), resourceTypes) {
+			secrets, err := getAllSecretsManagerSecrets(session, excludeAfter, configObj)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			if len(secrets) > 0 {
+				secretsManagerSecrets.SecretIDs = awsgo.StringValueSlice(secrets)
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, secretsManagerSecrets)
+			}
+		}
+		// End Secrets Manager Secrets
+
 		// S3 Buckets
 		s3Buckets := S3Buckets{}
 		if IsNukeable(s3Buckets.ResourceName(), resourceTypes) {
@@ -611,6 +626,7 @@ func ListResourceTypes() []string {
 		LambdaFunctions{}.ResourceName(),
 		S3Buckets{}.ResourceName(),
 		IAMUsers{}.ResourceName(),
+		SecretsManagerSecrets{}.ResourceName(),
 	}
 	sort.Strings(resourceTypes)
 	return resourceTypes

--- a/aws/secrets_manager.go
+++ b/aws/secrets_manager.go
@@ -1,0 +1,103 @@
+package aws
+
+import (
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	multierror "github.com/hashicorp/go-multierror"
+
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+func getAllSecretsManagerSecrets(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
+	svc := secretsmanager.New(session)
+
+	allSecrets := []*string{}
+	input := &secretsmanager.ListSecretsInput{}
+	err := svc.ListSecretsPages(
+		input,
+		func(page *secretsmanager.ListSecretsOutput, lastPage bool) bool {
+			for _, secret := range page.SecretList {
+				if shouldIncludeSecret(secret, excludeAfter, configObj) {
+					allSecrets = append(allSecrets, secret.ARN)
+				}
+			}
+			return !lastPage
+		},
+	)
+	return allSecrets, errors.WithStackTrace(err)
+}
+
+func shouldIncludeSecret(secret *secretsmanager.SecretListEntry, excludeAfter time.Time, configObj config.Config) bool {
+	if secret == nil {
+		return false
+	}
+
+	// reference time for excludeAfter is last accessed time, unless it was never accessed in which created time is
+	// used.
+	var referenceTime time.Time
+	if secret.LastAccessedDate == nil {
+		referenceTime = *secret.CreatedDate
+	} else {
+		referenceTime = *secret.LastAccessedDate
+	}
+	if excludeAfter.Before(referenceTime) {
+		return false
+	}
+
+	return config.ShouldInclude(
+		aws.StringValue(secret.Name),
+		configObj.SecretsManagerSecrets.IncludeRule.NamesRegExp,
+		configObj.SecretsManagerSecrets.ExcludeRule.NamesRegExp,
+	)
+}
+
+func nukeAllSecretsManagerSecrets(session *session.Session, identifiers []*string) error {
+	region := aws.StringValue(session.Config.Region)
+
+	svc := secretsmanager.New(session)
+
+	if len(identifiers) == 0 {
+		logging.Logger.Infof("No Secrets Manager Secrets to nuke in region %s", region)
+		return nil
+	}
+
+	// There is no bulk delete secrets API, so we delete the batch of secrets concurrently using go routines.
+	logging.Logger.Infof("Deleting Secrets Manager secrets in region %s", region)
+	wg := new(sync.WaitGroup)
+	wg.Add(len(identifiers))
+	errChans := make([]chan error, len(identifiers))
+	for i, secretID := range identifiers {
+		errChans[i] = make(chan error, 1)
+		go deleteSecretAsync(wg, errChans[i], svc, secretID)
+	}
+	wg.Wait()
+
+	// Collect all the errors from the async delete calls into a single error struct.
+	var allErrs *multierror.Error
+	for _, errChan := range errChans {
+		if err := <-errChan; err != nil {
+			allErrs = multierror.Append(allErrs, err)
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
+	}
+	return errors.WithStackTrace(allErrs.ErrorOrNil())
+}
+
+// deleteSecretAsync deletes the provided secrets manager secret. Intended to be run in a goroutine, using wait groups
+// and a return channel for errors.
+func deleteSecretAsync(wg *sync.WaitGroup, errChan chan error, svc *secretsmanager.SecretsManager, secretID *string) {
+	defer wg.Done()
+
+	input := &secretsmanager.DeleteSecretInput{
+		ForceDeleteWithoutRecovery: aws.Bool(true),
+		SecretId:                   secretID,
+	}
+	_, err := svc.DeleteSecret(input)
+	errChan <- err
+}

--- a/aws/secrets_manager_test.go
+++ b/aws/secrets_manager_test.go
@@ -1,0 +1,128 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	terraws "github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListSecretsManagerSecrets(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	secretName := fmt.Sprintf("test-cloud-nuke-secretsmanager-%s", random.UniqueId())
+	defer terraws.DeleteSecret(t, region, secretName, true)
+	arn := createSecretStringWithDefaultKey(t, region, secretName)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	secretARNPtrs, err := getAllSecretsManagerSecrets(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.Contains(t, aws.StringValueSlice(secretARNPtrs), arn)
+}
+
+func TestTimeFilterExclusionNewlyCreatedSecret(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	secretName := fmt.Sprintf("test-cloud-nuke-secretsmanager-%s", random.UniqueId())
+	defer terraws.DeleteSecret(t, region, secretName, true)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	// Assert user didn't exist
+	secretARNPtrs, err := getAllSecretsManagerSecrets(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	for _, secretARNPtr := range secretARNPtrs {
+		assert.NotContains(t, aws.StringValue(secretARNPtr), secretName)
+	}
+
+	// Creates a secret
+	arn := createSecretStringWithDefaultKey(t, region, secretName)
+
+	// Assert secret is picked up without filters
+	secretARNPtrsNewer, err := getAllSecretsManagerSecrets(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.Contains(t, aws.StringValueSlice(secretARNPtrsNewer), arn)
+
+	// Assert user doesn't appear when we look at users older than 1 Hour
+	olderThan := time.Now().Add(-1 * time.Hour)
+	secretARNPtrsOlder, err := getAllSecretsManagerSecrets(session, olderThan, config.Config{})
+	require.NoError(t, err)
+	assert.NotContains(t, aws.StringValueSlice(secretARNPtrsOlder), arn)
+}
+
+func TestNukeSecretOne(t *testing.T) {
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	secretName := fmt.Sprintf("test-cloud-nuke-secretsmanager-%s", random.UniqueId())
+	// We use the E version and ignore the error, as this is meant to be a stop gap deletion in case nuke has a bug.
+	defer terraws.DeleteSecretE(t, region, secretName, true)
+	arn := createSecretStringWithDefaultKey(t, region, secretName)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	require.NoError(
+		t,
+		nukeAllSecretsManagerSecrets(session, aws.StringSlice([]string{arn})),
+	)
+
+	// Make sure the secret is deleted.
+	_, err = terraws.GetSecretValueE(t, region, arn)
+	assert.Error(t, err)
+}
+
+func TestNukeSecretMoreThanOne(t *testing.T) {
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	secretNameBase := fmt.Sprintf("test-cloud-nuke-secretsmanager-%s", random.UniqueId())
+
+	secretArns := []string{}
+	for i := 0; i < 3; i++ {
+		secretName := fmt.Sprintf("%s-%d", secretNameBase, i)
+		// We use the E version and ignore the error, as this is meant to be a stop gap deletion in case nuke has a bug.
+		defer terraws.DeleteSecretE(t, region, secretName, true)
+		secretArns = append(secretArns, createSecretStringWithDefaultKey(t, region, secretName))
+	}
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	require.NoError(
+		t,
+		nukeAllSecretsManagerSecrets(session, aws.StringSlice(secretArns)),
+	)
+
+	// Make sure the secret is deleted.
+	for _, arn := range secretArns {
+		_, err = terraws.GetSecretValueE(t, region, arn)
+		assert.Error(t, err)
+	}
+}
+
+// Helper functions for driving the secrets manager tests
+
+// createSecretStringWithDefaultKey creates a new secret with a random value in Secrets Manager using the default
+// "aws/secretsmanager" KMS key and returns the secret ARN
+func createSecretStringWithDefaultKey(t *testing.T, awsRegion string, name string) string {
+	description := "Random secret created for cloud-nuke testing."
+	secretVal := random.UniqueId()
+	return terraws.CreateSecretStringWithDefaultKey(t, awsRegion, description, name, secretVal)
+}

--- a/aws/secrets_manager_types.go
+++ b/aws/secrets_manager_types.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+// SecretsManagerSecrets - represents all AWS secrets manager secrets that should be deleted.
+type SecretsManagerSecrets struct {
+	SecretIDs []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (secret SecretsManagerSecrets) ResourceName() string {
+	return "secretsmanager"
+}
+
+// ResourceIdentifiers - The instance ids of the ec2 instances
+func (secret SecretsManagerSecrets) ResourceIdentifiers() []string {
+	return secret.SecretIDs
+}
+
+func (secret SecretsManagerSecrets) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle. Note that secrets manager does not support bulk delete, so
+	// we will be deleting this many in parallel using go routines. We conservatively pick 10 here, both to limit
+	// overloading the runtime and to avoid AWS throttling with many API calls.
+	return 10
+}
+
+// Nuke - nuke 'em all!!!
+func (secret SecretsManagerSecrets) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllSecretsManagerSecrets(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -10,8 +10,9 @@ import (
 
 // Config - the config object we pass around
 type Config struct {
-	S3       ResourceType `yaml:"s3"`
-	IAMUsers ResourceType `yaml:"IAMUsers"`
+	S3                    ResourceType `yaml:"s3"`
+	IAMUsers              ResourceType `yaml:"IAMUsers"`
+	SecretsManagerSecrets ResourceType `yaml:"SecretsManager"`
 }
 
 type ResourceType struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,6 +12,7 @@ func emptyConfig() *Config {
 	return &Config{
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 
@@ -231,6 +232,99 @@ func TestConfigIAM_Users_FilterNames(t *testing.T) {
 	if len(configObj.IAMUsers.IncludeRule.NamesRegExp) == 0 ||
 		len(configObj.IAMUsers.ExcludeRule.NamesRegExp) == 0 {
 		assert.Fail(t, "ConfigObj should contain IAM names regexes, %+v\n", configObj)
+	}
+
+	return
+}
+
+// Secrets Manager Tests
+
+func TestConfigSecretsManager_Empty(t *testing.T) {
+	configFilePath := "./mocks/secrets_manager_empty.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should be empty, %+v\n", configObj.SecretsManagerSecrets)
+	}
+
+	return
+}
+
+func TestConfigSecretsManager_EmptyFilters(t *testing.T) {
+	configFilePath := "./mocks/secrets_manager_empty_filters.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should be empty, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigSecretsManager_EmptyRules(t *testing.T) {
+	configFilePath := "./mocks/secrets_manager_empty_rules.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should be empty, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigSecretsManager_IncludeNames(t *testing.T) {
+	configFilePath := "./mocks/secrets_manager_include_names.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should not be empty, %+v\n", configObj)
+	}
+
+	if len(configObj.SecretsManagerSecrets.IncludeRule.NamesRegExp) == 0 {
+		assert.Fail(t, "ConfigObj should contain secrets regexes, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigSecretsManager_ExcludeNames(t *testing.T) {
+	configFilePath := "./mocks/secrets_manager_exclude_names.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should not be empty, %+v\n", configObj)
+	}
+
+	if len(configObj.SecretsManagerSecrets.ExcludeRule.NamesRegExp) == 0 {
+		assert.Fail(t, "ConfigObj should contain secrets regexes, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigSecretsManager_FilterNames(t *testing.T) {
+	configFilePath := "./mocks/secrets_manager_filter_names.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should not be empty, %+v\n", configObj)
+	}
+
+	if len(configObj.SecretsManagerSecrets.IncludeRule.NamesRegExp) == 0 ||
+		len(configObj.SecretsManagerSecrets.ExcludeRule.NamesRegExp) == 0 {
+		assert.Fail(t, "ConfigObj should contain secrets regexes, %+v\n", configObj)
 	}
 
 	return

--- a/config/mocks/secrets_manager_cleanup.yaml
+++ b/config/mocks/secrets_manager_cleanup.yaml
@@ -1,0 +1,5 @@
+SecretsManager:
+  include:
+    names_regex:
+      - ^cloud-nuke-test-
+      - -cloud-nuke-test-

--- a/config/mocks/secrets_manager_empty.yaml
+++ b/config/mocks/secrets_manager_empty.yaml
@@ -1,0 +1,1 @@
+SecretsManager:

--- a/config/mocks/secrets_manager_empty_filters.yaml
+++ b/config/mocks/secrets_manager_empty_filters.yaml
@@ -1,0 +1,5 @@
+SecretsManager:
+  include:
+    names_regex:
+  exclude:
+    names_regex:

--- a/config/mocks/secrets_manager_empty_rules.yaml
+++ b/config/mocks/secrets_manager_empty_rules.yaml
@@ -1,0 +1,3 @@
+SecretsManager:
+  include:
+  exclude:

--- a/config/mocks/secrets_manager_exclude_names.yaml
+++ b/config/mocks/secrets_manager_exclude_names.yaml
@@ -1,0 +1,5 @@
+SecretsManager:
+  exclude:
+    names_regex:
+      - alice
+      - bob

--- a/config/mocks/secrets_manager_filter_names.yaml
+++ b/config/mocks/secrets_manager_filter_names.yaml
@@ -1,0 +1,9 @@
+SecretsManager:
+  include:
+    names_regex:
+      - ^cloud-nuke-*
+      - test
+  exclude:
+    names_regex:
+      - alice
+      - bob

--- a/config/mocks/secrets_manager_include_names.yaml
+++ b/config/mocks/secrets_manager_include_names.yaml
@@ -1,0 +1,5 @@
+SecretsManager:
+  include:
+    names_regex:
+      - ^cloud-nuke-*
+      - test

--- a/go.sum
+++ b/go.sum
@@ -233,7 +233,6 @@ github.com/gruntwork-io/go-commons v0.8.2 h1:2jrQH6ou6GxShXpNmxhVuVktp5E2so115nS
 github.com/gruntwork-io/go-commons v0.8.2/go.mod h1:aH1kYhkEgb7+RRMDVVKFXBBX0KfECzEhp1UYmU12oO4=
 github.com/gruntwork-io/gruntwork-cli v0.7.0 h1:YgSAmfCj9c61H+zuvHwKfYUwlMhu5arnQQLM4RH+CYs=
 github.com/gruntwork-io/gruntwork-cli v0.7.0/go.mod h1:jp6Z7NcLF2avpY8v71fBx6hds9eOFPELSuD/VPv7w00=
-github.com/gruntwork-io/gruntwork-cli v0.7.1 h1:F/GEuj3NiBY+qV+1RvFW7J7CN+8bzXvaYGRCCw7Hq7Y=
 github.com/gruntwork-io/kubergrunt v0.6.10/go.mod h1:AjSwJPP107t8pihDgJCWCG/RG92Q1oiRXL/OdR6OiaQ=
 github.com/gruntwork-io/terratest v0.30.0/go.mod h1:7dNmTD2zDKUEVqfmvcUU5c9mZi+986mcXNzhzqPYPg8=
 github.com/gruntwork-io/terratest v0.32.9 h1:ciWWJxISk06LAYImn6h1Vvir8hUz13VtwT2//fYCDcA=
@@ -247,7 +246,6 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl/v2 v2.8.2/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
-github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=


### PR DESCRIPTION
This includes support for nuking Secrets Manager secrets, including usage of the config file to restrict what secrets should be nuked, and an update to our config file to ensure that only test secrets manager secrets are deleted in our environment.

NOTE: This was prompted from our internal investigation in to the AWS bill (notes available in notion).