### PR TITLE
Attempt to stabilize build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,7 @@ jobs:
               --older-than 1h \
               --force \
               --config ./.circleci/nuke_config.yml \
-              --exclude-resource-type iam \
-              --exclude-resource-type transit-gateway \
-              --exclude-resource-type transit-gateway-attachment \
-              --exclude-resource-type transit-gateway-route-table
+              --exclude-resource-type iam
           no_output_timeout: 1h
   nuke_sandbox:
     <<: *defaults
@@ -49,10 +46,7 @@ jobs:
               --older-than 24h \
               --force \
               --config ./.circleci/nuke_config.yml \
-              --exclude-resource-type iam \
-              --exclude-resource-type transit-gateway \
-              --exclude-resource-type transit-gateway-attachment \
-              --exclude-resource-type transit-gateway-route-table
+              --exclude-resource-type iam
           no_output_timeout: 1h
   deploy:
     <<: *defaults

--- a/aws/rds_cluster_test.go
+++ b/aws/rds_cluster_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/rds"
@@ -16,6 +17,8 @@ import (
 )
 
 func createTestRDSCluster(t *testing.T, session *session.Session, name string) {
+	t.Logf("Creating RDS Cluster in region %s", aws.StringValue(session.Config.Region))
+
 	svc := rds.New(session)
 	params := &rds.CreateDBClusterInput{
 		DBClusterIdentifier: awsgo.String(name),


### PR DESCRIPTION
- Remove exclusion for transit gateway. Not sure why we had some exclusions there for our nuke jobs, since we don't use transit gateway internally.
- Add logging to find the regions where the RDS cluster test fails (I had a few builds where it failed, but couldn't discern the region).