### PR TITLE
Adds new default enabled region i.e ap-northeast-3

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -26,6 +26,7 @@ var OptInNotRequiredRegions = []string{
 	"eu-west-3",
 	"eu-west-2",
 	"eu-west-1",
+	"ap-northeast-3",
 	"ap-northeast-2",
 	"ap-northeast-1",
 	"sa-east-1",


### PR DESCRIPTION
Following aws-cli displays list of default enabled regions in aws account.
```
aws ec2 describe-regions --profile xxx | jq '.Regions[].RegionName'

"eu-north-1"
"ap-south-1"
"eu-west-3"
"eu-west-2"
"eu-west-1"
"ap-northeast-3"
"ap-northeast-2"
"ap-northeast-1"
"sa-east-1"
"ca-central-1"
"ap-southeast-1"
"ap-southeast-2"
"eu-central-1"
"us-east-1"
"us-east-2"
"us-west-1"
"us-west-2"
```
