### PR TITLE
Fix Config file not including when there is a 'exclude' rule

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -79,27 +79,22 @@ func matches(name string, regexps []Expression) bool {
 	return false
 }
 
-// ShouldInclude - Checks if a name should be included according to the inclusion and exclusion rules
+// ShouldInclude - Checks if a resource's name should be included according to the inclusion and exclusion rules
 func ShouldInclude(name string, includeREs []Expression, excludeREs []Expression) bool {
-	shouldInclude := false
-
-	if len(includeREs) > 0 {
-		// If any include rules are specified,
-		// only check to see if an exclude rule matches when an include rule matches the user
-		if matches(name, includeREs) {
-			shouldInclude = true
-			if matches(name, excludeREs) {
-				shouldInclude = false
-			}
-		}
-	} else if len(excludeREs) > 0 {
-		// Only check to see if an exclude rule matches when there are no include rules defined
-		if matches(name, excludeREs) {
-			shouldInclude = false
-		}
+	// If no rules are defined, should always include
+	if len(includeREs) == 0 && len(excludeREs) == 0 {
+		return true
+		// If a rule that exclude matches, should not include
+	} else if matches(name, excludeREs) {
+		return false
+		// Given the 'name' is not in the 'exclude' list, should include if there is no 'include' list
+	} else if len(includeREs) == 0 {
+		return true
+		// Given there is a 'include' list, and 'name' is there, should include
+	} else if matches(name, includeREs) {
+		return true
+		// If it's not in the 'include' list, should not include
 	} else {
-		shouldInclude = true
+		return false
 	}
-
-	return shouldInclude
 }

--- a/config/config.go
+++ b/config/config.go
@@ -84,17 +84,14 @@ func ShouldInclude(name string, includeREs []Expression, excludeREs []Expression
 	// If no rules are defined, should always include
 	if len(includeREs) == 0 && len(excludeREs) == 0 {
 		return true
-		// If a rule that exclude matches, should not include
+	// If a rule that exclude matches, should not include
 	} else if matches(name, excludeREs) {
 		return false
-		// Given the 'name' is not in the 'exclude' list, should include if there is no 'include' list
+	// Given the 'name' is not in the 'exclude' list, should include if there is no 'include' list
 	} else if len(includeREs) == 0 {
 		return true
-		// Given there is a 'include' list, and 'name' is there, should include
-	} else if matches(name, includeREs) {
-		return true
-		// If it's not in the 'include' list, should not include
+	// Given there is a 'include' list, and 'name' is there, should include
 	} else {
-		return false
+		return matches(name, includeREs)
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -353,6 +353,7 @@ func TestShouldInclude_ExcludeWhenMatches(t *testing.T) {
 	assert.True(t, ShouldInclude("tf-state-bucket", includeREs, excludeREs),
 		"Should include when doesn't matches from the 'exclude' list")
 }
+
 func TestShouldInclude_IncludeWhenMatches(t *testing.T) {
 	include, err := regexp.Compile(`.*openvpn.*`)
 	require.NoError(t, err)
@@ -364,4 +365,21 @@ func TestShouldInclude_IncludeWhenMatches(t *testing.T) {
 		"Should include when matches the 'include' list")
 	assert.False(t, ShouldInclude("test-vpc-123", includeREs, excludeREs),
 		"Should not include when doesn't matches the 'include' list")
+}
+
+func TestShouldInclude_WhenMatchesIncludeAndExclude(t *testing.T) {
+	include, err := regexp.Compile(`test.*`)
+	require.NoError(t, err)
+	includeREs := []Expression { { RE: *include } }
+
+	exclude, err := regexp.Compile(`.*openvpn.*`)
+	require.NoError(t, err)
+	excludeREs := []Expression { { RE: *exclude } }
+
+	assert.True(t, ShouldInclude("test-eks-cluster-123", includeREs, excludeREs),
+		"Should include when matches the 'include' list but not matches the 'exclude' list")
+	assert.False(t, ShouldInclude("test-openvpn-123", includeREs, excludeREs),
+		"Should not include when matches 'exclude' list")
+	assert.False(t, ShouldInclude("terraform-tf-state", includeREs, excludeREs),
+		"Should not include when doesn't matches 'include' list")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -330,4 +331,37 @@ func TestConfigSecretsManager_FilterNames(t *testing.T) {
 	}
 
 	return
+}
+
+func TestShouldInclude_AllowWhenEmpty(t *testing.T) {
+	var includeREs []Expression
+	var excludeREs []Expression
+
+	assert.True(t, ShouldInclude("test-open-vpn", includeREs, excludeREs),
+		"Should include when both lists are empty")
+}
+
+func TestShouldInclude_ExcludeWhenMatches(t *testing.T) {
+	var includeREs []Expression
+
+	exclude, err := regexp.Compile(`test.*`)
+	require.NoError(t, err)
+	excludeREs := []Expression { { RE: *exclude } }
+
+	assert.False(t, ShouldInclude("test-openvpn-123", includeREs, excludeREs),
+		"Should not include when matches from the 'exclude' list")
+	assert.True(t, ShouldInclude("tf-state-bucket", includeREs, excludeREs),
+		"Should include when doesn't matches from the 'exclude' list")
+}
+func TestShouldInclude_IncludeWhenMatches(t *testing.T) {
+	include, err := regexp.Compile(`.*openvpn.*`)
+	require.NoError(t, err)
+	includeREs := []Expression { { RE: *include } }
+
+	var excludeREs []Expression
+
+	assert.True(t, ShouldInclude("test-openvpn-123", includeREs, excludeREs),
+		"Should include when matches the 'include' list")
+	assert.False(t, ShouldInclude("test-vpc-123", includeREs, excludeREs),
+		"Should not include when doesn't matches the 'include' list")
 }


### PR DESCRIPTION
Fixes #198.

Refactored the function `ShouldInclude` to behave properly when there is a `exclude` but no `include` config. I added a unit test to this function that catches the bug in question.