### PR TITLE
Fix regex formatting from nuke_config.yml

### DIFF
--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -14,8 +14,8 @@ s3:
       - "^kafka-zk-standalone-[a-zA-Z0-9]{6}$"
       - "^zookeeper-cluster-test-[a-zA-Z0-9]{6}$"
       - "^terragrunt-test-bucket-[a-zA-Z0-9]{6}.*"
-      - "[a-zA-Z0-9]{6}-service-test-s3-bucket"
-      - "[a-zA-Z0-9]{6}-ecs-service-test-s3-bucket"
+      - "^[a-zA-Z0-9]{6}-service-test-s3-bucket"
+      - "^[a-zA-Z0-9]{6}-ecs-service-test-s3-bucket"
 
 SecretsManager:
   include:


### PR DESCRIPTION
Build is current broken with the following error:
```
❯ houston exec phxops -- go run main.go aws \
  --older-than 1h \
  --force \
  --config ./.circleci/nuke_config.yml \
  --exclude-resource-type iam
ERROR: Error reading config - ./.circleci/nuke_config.yml - yaml: unmarshal errors:
  line 1: cannot unmarshal !!seq into string
exit status 1
ERROR: ErrorWithExitCode{ Err = exit status 1, ExitCode = 1 }
```