### PR TITLE
Support AWS Config

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -642,6 +642,38 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End Dynamo DB tables
 
+		// ConfigService Rules
+		configServiceRules := ConfigService{}
+		if IsNukeable(configServiceRules.ResourceName(), resourceTypes) {
+			ruleNames, err := getAllConfigRules(session, region)
+
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			if len(ruleNames) > 0 {
+				configServiceRules.Rules = awsgo.StringValueSlice(ruleNames)
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, configServiceRules)
+			}
+		}
+		// End ConfigService Rules
+
+		// ConfigService Recorders
+		configServiceRecorders := ConfigServiceRecorders{}
+		if IsNukeable(configServiceRecorders.ResourceName(), resourceTypes) {
+			ruleNames, err := getAllConfigRecorders(session, region)
+
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			if len(ruleNames) > 0 {
+				configServiceRecorders.Rules = awsgo.StringValueSlice(ruleNames)
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, configServiceRecorders)
+			}
+		}
+		// End ConfigService Recorders
+
 		if len(resourcesInRegion.Resources) > 0 {
 			account.Resources[region] = resourcesInRegion
 		}

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -749,6 +749,8 @@ func ListResourceTypes() []string {
 		CloudWatchDashboards{}.ResourceName(),
 		AccessAnalyzer{}.ResourceName(),
 		DynamoDB{}.ResourceName(),
+		ConfigService{}.ResourceName(),
+		ConfigServiceRecorders{}.ResourceName(),
 	}
 	sort.Strings(resourceTypes)
 	return resourceTypes

--- a/aws/config.go
+++ b/aws/config.go
@@ -1,0 +1,124 @@
+package aws
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/configservice"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/hashicorp/go-multierror"
+)
+
+// Returns a formatted string of ConfigRules
+func getAllConfigRecorders(session *session.Session, region string) ([]*string, error) {
+	svc := configservice.New(session)
+	result, err := svc.DescribeConfigurationRecorders(&configservice.DescribeConfigurationRecordersInput{})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	var names []*string
+	for _, recorder := range result.ConfigurationRecorders {
+		names = append(names, recorder.Name)
+	}
+
+	return names, nil
+}
+
+// Returns a formatted string of ConfigRules
+func getAllConfigRules(session *session.Session, region string) ([]*string, error) {
+	svc := configservice.New(session)
+	result, err := svc.DescribeConfigRules(&configservice.DescribeConfigRulesInput{})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	var ruleNames []*string
+	for _, rule := range result.ConfigRules {
+		if strings.Contains(*rule.ConfigRuleArn, "aws-service-rule") {
+			continue
+		}
+		ruleNames = append(ruleNames, rule.ConfigRuleName)
+	}
+
+	return ruleNames, nil
+}
+
+func deleteConfigRule(svc *configservice.ConfigService, ruleName *string) error {
+	_, err := svc.DeleteConfigRule(&configservice.DeleteConfigRuleInput{
+		ConfigRuleName: ruleName,
+	})
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+// Delete all GuardDuty Detectors
+func nukeAllConfigRules(session *session.Session, ruleNames []*string) error {
+	if len(ruleNames) == 0 {
+		logging.Logger.Info("No Config Rules to nuke")
+		return nil
+	}
+
+	logging.Logger.Info("Deleting all Config Rules")
+
+	deletedUsers := 0
+	svc := configservice.New(session)
+	multiErr := new(multierror.Error)
+
+	for _, name := range ruleNames {
+		err := deleteConfigRule(svc, name)
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+			multierror.Append(multiErr, err)
+		} else {
+			deletedUsers++
+			logging.Logger.Infof("Deleted Config Rule: %s", *name)
+		}
+	}
+
+	logging.Logger.Infof("[OK] %d Config Rule(s) terminated", deletedUsers)
+	return multiErr.ErrorOrNil()
+}
+
+func deleteConfigRecorder(svc *configservice.ConfigService, recorderName *string) error {
+	_, err := svc.DeleteConfigurationRecorder(&configservice.DeleteConfigurationRecorderInput{
+		ConfigurationRecorderName: recorderName,
+	})
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+// Delete all Config Service Recorders
+func nukeAllConfigRecorders(session *session.Session, recorders []*string) error {
+	if len(recorders) == 0 {
+		logging.Logger.Info("No Config Recorders to nuke")
+		return nil
+	}
+
+	logging.Logger.Info("Deleting all Config Recorders")
+
+	deletedUsers := 0
+	svc := configservice.New(session)
+	multiErr := new(multierror.Error)
+
+	for _, name := range recorders {
+		err := deleteConfigRecorder(svc, name)
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+			multierror.Append(multiErr, err)
+		} else {
+			deletedUsers++
+			logging.Logger.Infof("Deleted Config Recorder: %s", *name)
+		}
+	}
+
+	logging.Logger.Infof("[OK] %d Config Recorder(s) terminated", deletedUsers)
+	return multiErr.ErrorOrNil()
+}

--- a/aws/config_types.go
+++ b/aws/config_types.go
@@ -1,0 +1,65 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+// ConfigService - represents all ConfigService on the AWS Account
+type ConfigService struct {
+	Rules []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (u ConfigService) ResourceName() string {
+	return "config-rules"
+}
+
+// ResourceIdentifiers - The IAM UserNames
+func (u ConfigService) ResourceIdentifiers() []string {
+	return u.Rules
+}
+
+// Tentative batch size to ensure AWS doesn't throttle
+func (u ConfigService) MaxBatchSize() int {
+	return 200
+}
+
+// Nuke - nuke 'em all!!!
+func (u ConfigService) Nuke(session *session.Session, detectors []string) error {
+	if err := nukeAllConfigRules(session, awsgo.StringSlice(detectors)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+// ConfigServiceRecorders - represents all ConfigServiceRecorders on the AWS Account
+type ConfigServiceRecorders struct {
+	Rules []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (u ConfigServiceRecorders) ResourceName() string {
+	return "config-recorders"
+}
+
+// ResourceIdentifiers - The IAM UserNames
+func (u ConfigServiceRecorders) ResourceIdentifiers() []string {
+	return u.Rules
+}
+
+// Tentative batch size to ensure AWS doesn't throttle
+func (u ConfigServiceRecorders) MaxBatchSize() int {
+	return 200
+}
+
+// Nuke - nuke 'em all!!!
+func (u ConfigServiceRecorders) Nuke(session *session.Session, detectors []string) error {
+	if err := nukeAllConfigRecorders(session, awsgo.StringSlice(detectors)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This implements nuking AWS Config Rules, but excludes any generated internally by AWS that can't be removed. These generally are prefixed with `aws-service-rule`

- Resolves https://github.com/gruntwork-io/cloud-nuke/issues/69