### PR TITLE
Exclude VPC from periodic nuking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,8 @@ jobs:
               --older-than 1h \
               --force \
               --config ./.circleci/nuke_config.yml \
-              --exclude-resource-type iam
+              --exclude-resource-type iam \
+              --exclude-resource-type vpc
           no_output_timeout: 1h
   nuke_sandbox:
     <<: *defaults
@@ -57,7 +58,8 @@ jobs:
               --older-than 24h \
               --force \
               --config ./.circleci/nuke_config.yml \
-              --exclude-resource-type iam
+              --exclude-resource-type iam \
+              --exclude-resource-type vpc
           no_output_timeout: 1h
   deploy:
     <<: *defaults


### PR DESCRIPTION
When we merged in https://github.com/gruntwork-io/cloud-nuke/pull/243, we started nuking VPCs in our accounts. Normally this isn't a problem, but there are two issues with this that make it disruptive to our test flow:

- The VPC feature doesn't honor the `--older-than` parameter, so it will start nuking all VPCs regardless of when they were created. This is disruptive to our tests as it can start nuking a VPC that is being used in testing.

- The VPC feature doesn't honor the config file, so we can't exclude certain VPCs. We have a VPC in our sandbox test account that we use for demos that we don't want nuked, and currently there isn't a way to exclude that from nuking consideration.

This PR updates our periodic nuking routine so that it excludes the VPCs for now, until we implement the above two features.