### PR TITLE
fix a bug where deleted nat gateways were included in nuke list

### DIFF
--- a/aws/nat_gateway.go
+++ b/aws/nat_gateway.go
@@ -44,6 +44,10 @@ func shouldIncludeNatGateway(ngw *ec2.NatGateway, excludeAfter time.Time, config
 		return false
 	}
 
+	if aws.StringValue(ngw.State) == ec2.NatGatewayStateDeleted {
+		return false
+	}
+
 	return config.ShouldInclude(
 		getNatGatewayName(ngw),
 		configObj.NatGateway.IncludeRule.NamesRegExp,


### PR DESCRIPTION
This fixes a bug where if the nat gateway was already deleted and in the deleted state, subsequent runs would still list it as needing to be deleted, however thankfully the AWS API would not error on subsequent runs, but it would appear that resources were not being cleaned up.