### PR TITLE
Support Nuking CloudFormation StackSets and Stacks

### DIFF
--- a/aws/cloudformation.go
+++ b/aws/cloudformation.go
@@ -1,9 +1,15 @@
 package aws
 
 import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/go-commons/retry"
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/hashicorp/go-multierror"
 )
@@ -16,12 +22,12 @@ func getAllCloudFormationStacks(session *session.Session) ([]*string, error) {
 		return nil, errors.WithStackTrace(err)
 	}
 
-	var ids []*string
+	var names []*string
 	for _, stack := range stacks.Stacks {
-		ids = append(ids, stack.StackId)
+		names = append(names, stack.StackName)
 	}
 
-	return ids, nil
+	return names, nil
 }
 
 func getAllCloudFormationStacksSets(session *session.Session) ([]*string, error) {
@@ -32,29 +38,122 @@ func getAllCloudFormationStacksSets(session *session.Session) ([]*string, error)
 		return nil, errors.WithStackTrace(err)
 	}
 
-	var ids []*string
+	var names []*string
 	for _, set := range stacks.Summaries {
-		ids = append(ids, set.StackSetId)
+		names = append(names, set.StackSetName)
 	}
 
-	return ids, nil
+	return names, nil
 }
 
-func nukeAllCloudformationStacks(session *session.Session, ids []*string) error {
-	if len(ids) == 0 {
+func deleteCloudFormationStackSet(svc *cloudformation.CloudFormation, name *string) error {
+	if _, err := svc.DeleteStackSet(&cloudformation.DeleteStackSetInput{
+		StackSetName: name,
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func nukeAllCloudformationStacks(session *session.Session, identifiers []*string) error {
+	region := aws.StringValue(session.Config.Region)
+
+	if len(identifiers) == 0 {
 		logging.Logger.Info("No Cloudformation Stacks to nuke")
 		return nil
 	}
 
 	logging.Logger.Info("Deleting all Cloudformation Stacks")
 
-	deletedStacks := 0
 	svc := cloudformation.New(session)
-	multiErr := new(multierror.Error)
 
-	for _, id := ids {
-		if err := deleteCloudformation
+	wg := new(sync.WaitGroup)
+	wg.Add(len(identifiers))
+	errChans := make([]chan error, len(identifiers))
+	for i, ngwID := range identifiers {
+		errChans[i] = make(chan error, 1)
+		go deleteCloudformationStackAsync(wg, errChans[i], svc, ngwID)
+	}
+	wg.Wait()
+
+	// Collect all the errors from the async delete calls into a single error struct.
+	var allErrs *multierror.Error
+	for _, errChan := range errChans {
+		if err := <-errChan; err != nil {
+			allErrs = multierror.Append(allErrs, err)
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
+	}
+	finalErr := allErrs.ErrorOrNil()
+	if finalErr != nil {
+		return errors.WithStackTrace(finalErr)
+	}
+
+	err := retry.DoWithRetry(
+		logging.Logger,
+		"Waiting for all Cloudformation Stacks to be deleted.",
+		// Wait a maximum of 5 minutes: 10 seconds in between, up to 30 times
+		30, 10*time.Second,
+		func() error {
+			areDeleted, err := areAllCloudformationStacksDeleted(svc, identifiers)
+			if err != nil {
+				return errors.WithStackTrace(retry.FatalError{Underlying: err})
+			}
+			if areDeleted {
+				return nil
+			}
+			return fmt.Errorf("Not all Cloudformation Stacks deleted.")
+		},
+	)
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+	for _, stackName := range identifiers {
+		logging.Logger.Infof("[OK] Cloudformation Stack %s was deleted in %s", aws.StringValue(stackName), region)
+	}
+	return nil
+}
+
+func nukeAllCloudformationStackSets(session *session.Session, names []*string) error {
+	if len(names) == 0 {
+		logging.Logger.Info("No Cloudformation Stacks to nuke")
+		return nil
+	}
+
+	logging.Logger.Info("Deleting all Cloudformation Stacks")
+
+	deletedStackSets := 0
+	svc := cloudformation.New(session)
+
+	for _, name := range names {
+		if err := deleteCloudFormationStackSet(svc, name); err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+		} else {
+			deletedStackSets++
+		}
 	}
 
 	return nil
+}
+
+func deleteCloudformationStackAsync(wg *sync.WaitGroup, errChan chan error, svc *cloudformation.CloudFormation, stackName *string) {
+	defer wg.Done()
+
+	_, err := svc.DeleteStack(&cloudformation.DeleteStackInput{
+		StackName: stackName,
+	})
+
+	errChan <- err
+}
+
+func areAllCloudformationStacksDeleted(svc *cloudformation.CloudFormation, identifiers []*string) (bool, error) {
+	resp, err := svc.ListStacks(&cloudformation.ListStacksInput{})
+	if err != nil {
+		return false, err
+	}
+	if len(resp.StackSummaries) == 0 {
+		return true, nil
+	}
+	return true, nil
 }

--- a/aws/cloudformation.go
+++ b/aws/cloudformation.go
@@ -1,0 +1,60 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/hashicorp/go-multierror"
+)
+
+func getAllCloudFormationStacks(session *session.Session) ([]*string, error) {
+	svc := cloudformation.New(session)
+
+	stacks, err := svc.DescribeStacks(&cloudformation.DescribeStacksInput{})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	var ids []*string
+	for _, stack := range stacks.Stacks {
+		ids = append(ids, stack.StackId)
+	}
+
+	return ids, nil
+}
+
+func getAllCloudFormationStacksSets(session *session.Session) ([]*string, error) {
+	svc := cloudformation.New(session)
+
+	stacks, err := svc.ListStackSets(&cloudformation.ListStackSetsInput{})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	var ids []*string
+	for _, set := range stacks.Summaries {
+		ids = append(ids, set.StackSetId)
+	}
+
+	return ids, nil
+}
+
+func nukeAllCloudformationStacks(session *session.Session, ids []*string) error {
+	if len(ids) == 0 {
+		logging.Logger.Info("No Cloudformation Stacks to nuke")
+		return nil
+	}
+
+	logging.Logger.Info("Deleting all Cloudformation Stacks")
+
+	deletedStacks := 0
+	svc := cloudformation.New(session)
+	multiErr := new(multierror.Error)
+
+	for _, id := ids {
+		if err := deleteCloudformation
+	}
+
+	return nil
+}

--- a/aws/cloudformation_stacksets.go
+++ b/aws/cloudformation_stacksets.go
@@ -1,0 +1,123 @@
+package aws
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/go-commons/retry"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/hashicorp/go-multierror"
+)
+
+func getAllCloudFormationStacksSets(session *session.Session) ([]*string, error) {
+	svc := cloudformation.New(session)
+
+	stacks, err := svc.ListStackSets(&cloudformation.ListStackSetsInput{})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	var names []*string
+	for _, set := range stacks.Summaries {
+		names = append(names, set.StackSetName)
+	}
+
+	return names, nil
+}
+
+func nukeAllCloudformationStackSets(session *session.Session, identifiers []*string) error {
+	region := aws.StringValue(session.Config.Region)
+
+	if len(identifiers) == 0 {
+		logging.Logger.Info("No Cloudformation Stack Sets to nuke")
+		return nil
+	}
+
+	logging.Logger.Info("Deleting all Cloudformation Stack Sets")
+
+	svc := cloudformation.New(session)
+
+	wg := new(sync.WaitGroup)
+	wg.Add(len(identifiers))
+	errChans := make([]chan error, len(identifiers))
+	for i, ngwID := range identifiers {
+		errChans[i] = make(chan error, 1)
+		go deleteCloudformationStackSetAsync(wg, errChans[i], svc, ngwID)
+	}
+	wg.Wait()
+
+	// Collect all the errors from the async delete calls into a single error struct.
+	var allErrs *multierror.Error
+	for _, errChan := range errChans {
+		if err := <-errChan; err != nil {
+			allErrs = multierror.Append(allErrs, err)
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
+	}
+	finalErr := allErrs.ErrorOrNil()
+	if finalErr != nil {
+		return errors.WithStackTrace(finalErr)
+	}
+
+	err := retry.DoWithRetry(
+		logging.Logger,
+		"Waiting for all Cloudformation Stack Sets to be deleted.",
+		// Wait a maximum of 5 minutes: 10 seconds in between, up to 30 times
+		30, 10*time.Second,
+		func() error {
+			areDeleted, err := areAllCloudformationStackSetsDeleted(svc, identifiers)
+			if err != nil {
+				return errors.WithStackTrace(retry.FatalError{Underlying: err})
+			}
+			if areDeleted {
+				return nil
+			}
+			return fmt.Errorf("Not all Cloudformation Stack Sets deleted.")
+		},
+	)
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+	for _, setName := range identifiers {
+		logging.Logger.Infof("[OK] Cloudformation Stack Set %s was deleted in %s", aws.StringValue(setName), region)
+	}
+	return nil
+}
+
+func deleteCloudformationStackSetAsync(wg *sync.WaitGroup, errChan chan error, svc *cloudformation.CloudFormation, stackSetName *string) {
+	defer wg.Done()
+
+	_, err := svc.DeleteStackSet(&cloudformation.DeleteStackSetInput{
+		StackSetName: stackSetName,
+	})
+
+	errChan <- err
+}
+
+func areAllCloudformationStackSetsDeleted(svc *cloudformation.CloudFormation, identifiers []*string) (bool, error) {
+	resp, err := svc.ListStackSets(&cloudformation.ListStackSetsInput{})
+	if err != nil {
+		return false, err
+	}
+
+	if len(resp.Summaries) == 0 {
+		return true, nil
+	}
+
+	for _, set := range resp.Summaries {
+		if set == nil {
+			continue
+		}
+
+		if aws.StringValue(set.Status) != cloudformation.StackSetStatusDeleted {
+			return false, nil
+		}
+	}
+
+	return false, nil
+}

--- a/aws/cloudformation_types.go
+++ b/aws/cloudformation_types.go
@@ -1,0 +1,35 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+type CloudformationStacks struct {
+	StackIds []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (stack CloudformationStacks) ResourceName() string {
+	return "cf-stack"
+}
+
+// ResourceIdentifiers - The instance ids of the ec2 instances
+func (stack CloudformationStacks) ResourceIdentifiers() []string {
+	return stack.StackIds
+}
+
+func (stack CloudformationStacks) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 200
+}
+
+// Nuke - nuke 'em all!!!
+func (stack CloudformationStacks) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllCloudformationStacks(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/aws/cloudformation_types.go
+++ b/aws/cloudformation_types.go
@@ -7,7 +7,7 @@ import (
 )
 
 type CloudformationStacks struct {
-	StackIds []string
+	StackNames []string
 }
 
 // ResourceName - the simple name of the aws resource
@@ -17,7 +17,7 @@ func (stack CloudformationStacks) ResourceName() string {
 
 // ResourceIdentifiers - The instance ids of the ec2 instances
 func (stack CloudformationStacks) ResourceIdentifiers() []string {
-	return stack.StackIds
+	return stack.StackNames
 }
 
 func (stack CloudformationStacks) MaxBatchSize() int {
@@ -28,6 +28,34 @@ func (stack CloudformationStacks) MaxBatchSize() int {
 // Nuke - nuke 'em all!!!
 func (stack CloudformationStacks) Nuke(session *session.Session, identifiers []string) error {
 	if err := nukeAllCloudformationStacks(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+type CloudformationStackSets struct {
+	StackSetNames []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (set CloudformationStackSets) ResourceName() string {
+	return "cf-stackset"
+}
+
+// ResourceIdentifiers - The instance ids of the ec2 instances
+func (set CloudformationStackSets) ResourceIdentifiers() []string {
+	return set.StackSetNames
+}
+
+func (set CloudformationStackSets) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 200
+}
+
+// Nuke - nuke 'em all!!!
+func (set CloudformationStackSets) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllCloudformationStackSets(session, awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 


### PR DESCRIPTION
This implements the removal of StackSets and Stacks with wait groups to ensure that the status moves to DELETED before considering the item nuked.

**Note:** there is a chance that when targeting stacks only that if it's part of a StackSet it could trigger an error which will be logged.

- [ ] Update Documentation
- [ ] Update Tests
- [x] Update Code

These are issues that this PR potentially resolves.

- Potentially Resolves https://github.com/gruntwork-io/cloud-nuke/issues/95
- Potentially Resolves https://github.com/gruntwork-io/cloud-nuke/issues/149