### PR TITLE
Updated go.mod version 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gruntwork-io/cloud-nuke
 
-go 1.13
+go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.42.4


### PR DESCRIPTION
Noticed that `go.mod` references to go 1.13 but in CI/CD is used go 1.16