### PR TITLE
#227 Fix for TestListSecretsManagerSecrets TestTimeFilterExclusionNewlyCreatedSecret

### DIFF
--- a/aws/secrets_manager_test.go
+++ b/aws/secrets_manager_test.go
@@ -20,7 +20,7 @@ func TestListSecretsManagerSecrets(t *testing.T) {
 	region, err := getRandomRegion()
 	require.NoError(t, err)
 
-	secretName := fmt.Sprintf("test-cloud-nuke-secretsmanager-%s", random.UniqueId())
+	secretName := fmt.Sprintf("test-cloud-nuke-secretsmanager-list-%s", random.UniqueId())
 	defer terraws.DeleteSecret(t, region, secretName, true)
 	arn := createSecretStringWithDefaultKey(t, region, secretName)
 
@@ -38,7 +38,7 @@ func TestTimeFilterExclusionNewlyCreatedSecret(t *testing.T) {
 	region, err := getRandomRegion()
 	require.NoError(t, err)
 
-	secretName := fmt.Sprintf("test-cloud-nuke-secretsmanager-%s", random.UniqueId())
+	secretName := fmt.Sprintf("test-cloud-nuke-secretsmanager-exclusion-%s", random.UniqueId())
 	defer terraws.DeleteSecret(t, region, secretName, true)
 
 	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
@@ -72,7 +72,7 @@ func TestNukeSecretOne(t *testing.T) {
 	region, err := getRandomRegion()
 	require.NoError(t, err)
 
-	secretName := fmt.Sprintf("test-cloud-nuke-secretsmanager-%s", random.UniqueId())
+	secretName := fmt.Sprintf("test-cloud-nuke-secretsmanager-one-%s", random.UniqueId())
 	// We use the E version and ignore the error, as this is meant to be a stop gap deletion in case nuke has a bug.
 	defer terraws.DeleteSecretE(t, region, secretName, true)
 	arn := createSecretStringWithDefaultKey(t, region, secretName)
@@ -96,7 +96,7 @@ func TestNukeSecretMoreThanOne(t *testing.T) {
 	region, err := getRandomRegion()
 	require.NoError(t, err)
 
-	secretNameBase := fmt.Sprintf("test-cloud-nuke-secretsmanager-%s", random.UniqueId())
+	secretNameBase := fmt.Sprintf("test-cloud-nuke-secretsmanager-more-than-one-%s", random.UniqueId())
 
 	secretArns := []string{}
 	for i := 0; i < 3; i++ {

--- a/aws/secrets_manager_test.go
+++ b/aws/secrets_manager_test.go
@@ -2,10 +2,11 @@ package aws
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/cloud-nuke/logging"
-	"github.com/gruntwork-io/go-commons/collections"
 	"testing"
 	"time"
+
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/go-commons/collections"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/aws/secrets_manager_test.go
+++ b/aws/secrets_manager_test.go
@@ -23,7 +23,6 @@ func TestListSecretsManagerSecrets(t *testing.T) {
 	t.Parallel()
 
 	region, err := getRandomRegion()
-	region = "ap-northeast-3"
 	require.NoError(t, err)
 
 	secretName := fmt.Sprintf("test-cloud-nuke-secretsmanager-list-%s", random.UniqueId())


### PR DESCRIPTION
Included changes:
  * separated secret name for each test
  * added retries to check if created secret is available, instead of fixed 15s waiting 

Result:
<img width="1401" alt="Screenshot 2021-12-07 at 23 04 51" src="https://user-images.githubusercontent.com/10694338/145105977-ad1f6ab6-9960-412b-b346-27ad24d58240.png">

Fixes:
#227