### PR TITLE
Add ECS config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ The following resources support the Config file:
 - OpenSearch Domains
     - Resource type: `opensearch`
     - Config key: `OpenSearchDomain`
+- ECS Services
+    - Resource type: `ecsserv`
+    - Config key: `ECSService`
+- ECS Clusters
+    - Resource type: `ecscluster`
+    - Config key: `ECSCluster`
 
 
 #### Example
@@ -256,6 +262,8 @@ To find out what we options are supported in the config file today, consult this
 |--------------------|-------|-------------|------|------------|
 | s3                 | none  | ✅          | none | none       |
 | iam                | none  | ✅          | none | none       |
+| ecsserv            | none  | ✅          | none | none       |
+| ecscluster         | none  | ✅          | none | none       |
 | secretsmanager     | none  | ✅          | none | none       |
 | nat-gateway        | none  | ✅          | none | none       |
 | accessanalyzer     | none  | ✅          | none | none       |

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -457,7 +457,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 				return nil, errors.WithStackTrace(err)
 			}
 			if len(clusterArns) > 0 {
-				serviceArns, serviceClusterMap, err := getAllEcsServices(session, clusterArns, excludeAfter)
+				serviceArns, serviceClusterMap, err := getAllEcsServices(session, clusterArns, excludeAfter, configObj)
 				if err != nil {
 					return nil, errors.WithStackTrace(err)
 				}
@@ -469,7 +469,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 
 		ecsClusters := ECSClusters{}
 		if IsNukeable(ecsClusters.ResourceName(), resourceTypes) {
-			ecsClusterArns, err := getAllEcsClustersOlderThan(session, excludeAfter)
+			ecsClusterArns, err := getAllEcsClustersOlderThan(session, excludeAfter, configObj)
 			if err != nil {
 				return nil, errors.WithStackTrace(err)
 			}

--- a/aws/dynamodb.go
+++ b/aws/dynamodb.go
@@ -14,14 +14,14 @@ import (
 func getAllDynamoTables(session *session.Session, excludeAfter time.Time, db DynamoDB) ([]*string, error) {
 	var tableNames []*string
 	svc := dynamodb.New(session)
-	
+
 	var lastTableName *string
 	// Run count is used for pagination if the list tables exceeds max value
 	// Tells loop to rerun
 	var PaginationRunCount = 1
 	for PaginationRunCount > 0 {
 		result, err := svc.ListTables(&dynamodb.ListTablesInput{ExclusiveStartTableName: lastTableName, Limit: aws.Int64(int64(DynamoDB.MaxBatchSize(db)))})
-		
+
 		lastTableName = result.LastEvaluatedTableName
 		if err != nil {
 			if aerr, ok := err.(awserr.Error); ok {

--- a/aws/dynamodb_test.go
+++ b/aws/dynamodb_test.go
@@ -53,7 +53,7 @@ func createTestDynamoTables(t *testing.T, tableName, region string) {
 
 }
 
-func getTableStatus(TableName string, region string ) *string {
+func getTableStatus(TableName string, region string) *string {
 	awsSession, err := session.NewSession(&aws.Config{
 		Region: aws.String(region)},
 	)

--- a/aws/ecs_cluster.go
+++ b/aws/ecs_cluster.go
@@ -7,6 +7,7 @@ import (
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/go-commons/errors"
 )
@@ -15,12 +16,12 @@ import (
 // For more details on other valid status values: https://docs.aws.amazon.com/sdk-for-go/api/service/ecs/#Cluster
 const activeEcsClusterStatus string = "ACTIVE"
 
-// Used in this context to limit the amount of clustes passed as input to the DescribeClusters function call
+// Used in this context to limit the amount of clusters passed as input to the DescribeClusters function call
 // For more details on this, please read here: https://docs.aws.amazon.com/cli/latest/reference/ecs/describe-clusters.html#options
 const describeClustersRequestBatchSize = 100
 
 // Filter all active ecs clusters
-func getAllActiveEcsClusterArns(awsSession *session.Session) ([]*string, error) {
+func getAllActiveEcsClusterArns(awsSession *session.Session, configObj config.Config) ([]*string, error) {
 	svc := ecs.New(awsSession)
 
 	allClusters, err := getAllEcsClusters(awsSession)
@@ -43,13 +44,8 @@ func getAllActiveEcsClusterArns(awsSession *session.Session) ([]*string, error) 
 			return nil, errors.WithStackTrace(describeErr)
 		}
 
-		// Filter out invalid state ECS Clusters (will return only `ACTIVE` state clusters)
-		// `cloud-nuke` needs to tag ECS Clusters it sees for the first time.
-		// Therefore to tag a cluster, that cluster must be in the `ACTIVE` state.
 		for _, cluster := range describedClusters.Clusters {
-			logging.Logger.Debugf("Status for ECS Cluster %s is %s", aws.StringValue(cluster.ClusterArn), aws.StringValue(cluster.Status))
-
-			if aws.StringValue(cluster.Status) == activeEcsClusterStatus {
+			if shouldIncludeECSCluster(cluster, configObj) {
 				filteredEcsClusterArns = append(filteredEcsClusterArns, cluster.ClusterArn)
 			}
 		}
@@ -58,8 +54,28 @@ func getAllActiveEcsClusterArns(awsSession *session.Session) ([]*string, error) 
 	return filteredEcsClusterArns, nil
 }
 
-func getAllEcsClustersOlderThan(awsSession *session.Session, excludeAfter time.Time) ([]*string, error) {
-	clusterArns, err := getAllActiveEcsClusterArns(awsSession)
+func shouldIncludeECSCluster(cluster *ecs.Cluster, configObj config.Config) bool {
+	if cluster == nil {
+		return false
+	}
+
+	// Filter out invalid state ECS Clusters (will return only `ACTIVE` state clusters)
+	// `cloud-nuke` needs to tag ECS Clusters it sees for the first time.
+	// Therefore to tag a cluster, that cluster must be in the `ACTIVE` state.
+	logging.Logger.Debugf("Status for ECS Cluster %s is %s", aws.StringValue(cluster.ClusterArn), aws.StringValue(cluster.Status))
+	if aws.StringValue(cluster.Status) != activeEcsClusterStatus {
+		return false
+	}
+
+	return config.ShouldInclude(
+		awsgo.StringValue(cluster.ClusterName),
+		configObj.ECSCluster.IncludeRule.NamesRegExp,
+		configObj.ECSCluster.ExcludeRule.NamesRegExp,
+	)
+}
+
+func getAllEcsClustersOlderThan(awsSession *session.Session, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
+	clusterArns, err := getAllActiveEcsClusterArns(awsSession, configObj)
 	if err != nil {
 		logging.Logger.Errorf("Error getting all ECS clusters with `ACTIVE` status")
 		return nil, errors.WithStackTrace(err)

--- a/aws/ecs_cluster_test.go
+++ b/aws/ecs_cluster_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"regexp"
 	"testing"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"regexp"
 )
 
 // Test we can create a cluster, tag it, and then find the tag

--- a/aws/ecs_cluster_test.go
+++ b/aws/ecs_cluster_test.go
@@ -6,10 +6,13 @@ import (
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"regexp"
 )
 
 // Test we can create a cluster, tag it, and then find the tag
@@ -114,4 +117,79 @@ func TestCanNukeAllEcsClustersOlderThan24Hours(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, awsgo.StringValueSlice(allLeftClusterArns), awsgo.StringValue(cluster2.ClusterArn))
+}
+
+// Test the config file filtering works as expected
+func TestShouldIncludeECSCluster(t *testing.T) {
+	mockCluster := &ecs.Cluster{
+		ClusterName: awsgo.String("cloud-nuke-test"),
+		Status:      awsgo.String("ACTIVE"),
+	}
+
+	mockClusterInactive := &ecs.Cluster{
+		ClusterName: awsgo.String("cloud-nuke-test"),
+		Status:      awsgo.String("INACTIVE"),
+	}
+
+	mockExpression, err := regexp.Compile("^cloud-nuke-*")
+	if err != nil {
+		logging.Logger.Fatalf("There was an error compiling regex expression %v", err)
+	}
+
+	mockExcludeConfig := config.Config{
+		ECSCluster: config.ResourceType{
+			ExcludeRule: config.FilterRule{
+				NamesRegExp: []config.Expression{
+					{
+						RE: *mockExpression,
+					},
+				},
+			},
+		},
+	}
+
+	mockIncludeConfig := config.Config{
+		ECSCluster: config.ResourceType{
+			IncludeRule: config.FilterRule{
+				NamesRegExp: []config.Expression{
+					{
+						RE: *mockExpression,
+					},
+				},
+			},
+		},
+	}
+
+	cases := []struct {
+		Name     string
+		Cluster  *ecs.Cluster
+		Config   config.Config
+		Expected bool
+	}{
+		{
+			Name:     "ConfigExclude",
+			Cluster:  mockCluster,
+			Config:   mockExcludeConfig,
+			Expected: false,
+		},
+		{
+			Name:     "ConfigInclude",
+			Cluster:  mockCluster,
+			Config:   mockIncludeConfig,
+			Expected: true,
+		},
+		{
+			Name:     "ConfigIncludeInactive",
+			Cluster:  mockClusterInactive,
+			Config:   mockIncludeConfig,
+			Expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			result := shouldIncludeECSCluster(c.Cluster, c.Config)
+			assert.Equal(t, c.Expected, result)
+		})
+	}
 }

--- a/aws/ecs_cluster_test.go
+++ b/aws/ecs_cluster_test.go
@@ -6,6 +6,7 @@ import (
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,7 +68,7 @@ func TestCanListAllEcsClustersOlderThan24hours(t *testing.T) {
 	require.NoError(t, err2)
 
 	last24Hours := now.Add(time.Hour * time.Duration(-24))
-	filteredClusterArns, err := getAllEcsClustersOlderThan(awsSession, last24Hours)
+	filteredClusterArns, err := getAllEcsClustersOlderThan(awsSession, last24Hours, config.Config{})
 	require.NoError(t, err)
 
 	assert.Contains(t, awsgo.StringValueSlice(filteredClusterArns), awsgo.StringValue(cluster1.ClusterArn))
@@ -103,7 +104,7 @@ func TestCanNukeAllEcsClustersOlderThan24Hours(t *testing.T) {
 	require.NoError(t, err3)
 
 	last24Hours := now.Add(time.Hour * time.Duration(-24))
-	filteredClusterArns, err := getAllEcsClustersOlderThan(awsSession, last24Hours)
+	filteredClusterArns, err := getAllEcsClustersOlderThan(awsSession, last24Hours, config.Config{})
 	require.NoError(t, err)
 
 	nukeErr := nukeEcsClusters(awsSession, filteredClusterArns)

--- a/aws/ecs_service_test.go
+++ b/aws/ecs_service_test.go
@@ -12,13 +12,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const region = "ap-south-1"
-
 // Test that we can find ECS services that are running Fargate tasks
 func TestListECSFargateServices(t *testing.T) {
 	t.Parallel()
 
-	//region := getRandomFargateSupportedRegion()
+	region := getRandomFargateSupportedRegion()
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),
 	})
@@ -64,7 +62,7 @@ func TestListECSFargateServices(t *testing.T) {
 func TestNukeECSFargateServices(t *testing.T) {
 	t.Parallel()
 
-	//region := getRandomFargateSupportedRegion()
+	region := getRandomFargateSupportedRegion()
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),
 	})
@@ -104,7 +102,7 @@ func TestNukeECSFargateServices(t *testing.T) {
 func TestListECSEC2Services(t *testing.T) {
 	t.Parallel()
 
-	//region := getRandomFargateSupportedRegion()
+	region := getRandomFargateSupportedRegion()
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),
 	})
@@ -169,7 +167,7 @@ func TestListECSEC2Services(t *testing.T) {
 func TestNukeECSEC2Services(t *testing.T) {
 	t.Parallel()
 
-	//region := getRandomFargateSupportedRegion()
+	region := getRandomFargateSupportedRegion()
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),
 	})

--- a/aws/ecs_service_test.go
+++ b/aws/ecs_service_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"regexp"
 	"testing"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/stretchr/testify/assert"
-	"regexp"
 )
 
 // Test that we can find ECS services that are running Fargate tasks

--- a/aws/ecs_service_test.go
+++ b/aws/ecs_service_test.go
@@ -6,16 +6,19 @@ import (
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/stretchr/testify/assert"
 )
 
+const region = "ap-south-1"
+
 // Test that we can find ECS services that are running Fargate tasks
 func TestListECSFargateServices(t *testing.T) {
 	t.Parallel()
 
-	region := getRandomFargateSupportedRegion()
+	//region := getRandomFargateSupportedRegion()
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),
 	})
@@ -40,7 +43,7 @@ func TestListECSFargateServices(t *testing.T) {
 	ecsServiceClusterMap[*service.ServiceArn] = *cluster.ClusterArn
 	defer nukeAllEcsServices(awsSession, ecsServiceClusterMap, []*string{service.ServiceArn})
 
-	ecsServiceArns, newEcsServiceClusterMap, err := getAllEcsServices(awsSession, []*string{cluster.ClusterArn}, time.Now().Add(1*time.Hour*-1))
+	ecsServiceArns, newEcsServiceClusterMap, err := getAllEcsServices(awsSession, []*string{cluster.ClusterArn}, time.Now().Add(1*time.Hour*-1), config.Config{})
 	if err != nil {
 		assert.Failf(t, "Unable to fetch list of services: %s", err.Error())
 	}
@@ -48,7 +51,7 @@ func TestListECSFargateServices(t *testing.T) {
 	_, exists := newEcsServiceClusterMap[*service.ServiceArn]
 	assert.False(t, exists)
 
-	ecsServiceArns, newEcsServiceClusterMap, err = getAllEcsServices(awsSession, []*string{cluster.ClusterArn}, time.Now().Add(1*time.Hour))
+	ecsServiceArns, newEcsServiceClusterMap, err = getAllEcsServices(awsSession, []*string{cluster.ClusterArn}, time.Now().Add(1*time.Hour), config.Config{})
 	if err != nil {
 		assert.Failf(t, "Unable to fetch list of services: %s", err.Error())
 	}
@@ -61,7 +64,7 @@ func TestListECSFargateServices(t *testing.T) {
 func TestNukeECSFargateServices(t *testing.T) {
 	t.Parallel()
 
-	region := getRandomFargateSupportedRegion()
+	//region := getRandomFargateSupportedRegion()
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),
 	})
@@ -90,7 +93,7 @@ func TestNukeECSFargateServices(t *testing.T) {
 		assert.Fail(t, err.Error())
 	}
 
-	ecsServiceArns, _, err := getAllEcsServices(awsSession, []*string{cluster.ClusterArn}, time.Now().Add(1*time.Hour))
+	ecsServiceArns, _, err := getAllEcsServices(awsSession, []*string{cluster.ClusterArn}, time.Now().Add(1*time.Hour), config.Config{})
 	if err != nil {
 		assert.Failf(t, "Unable to fetch list of services: %s", err.Error())
 	}
@@ -101,7 +104,7 @@ func TestNukeECSFargateServices(t *testing.T) {
 func TestListECSEC2Services(t *testing.T) {
 	t.Parallel()
 
-	region := getRandomFargateSupportedRegion()
+	//region := getRandomFargateSupportedRegion()
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),
 	})
@@ -145,7 +148,7 @@ func TestListECSEC2Services(t *testing.T) {
 	defer nukeAllEcsServices(awsSession, ecsServiceClusterMap, []*string{service.ServiceArn})
 	// END prepare resources
 
-	ecsServiceArns, newEcsServiceClusterMap, err := getAllEcsServices(awsSession, []*string{cluster.ClusterArn}, time.Now().Add(1*time.Hour*-1))
+	ecsServiceArns, newEcsServiceClusterMap, err := getAllEcsServices(awsSession, []*string{cluster.ClusterArn}, time.Now().Add(1*time.Hour*-1), config.Config{})
 	if err != nil {
 		assert.Failf(t, "Unable to fetch list of services: %s", err.Error())
 	}
@@ -153,7 +156,7 @@ func TestListECSEC2Services(t *testing.T) {
 	_, exists := newEcsServiceClusterMap[*service.ServiceArn]
 	assert.False(t, exists)
 
-	ecsServiceArns, newEcsServiceClusterMap, err = getAllEcsServices(awsSession, []*string{cluster.ClusterArn}, time.Now().Add(1*time.Hour))
+	ecsServiceArns, newEcsServiceClusterMap, err = getAllEcsServices(awsSession, []*string{cluster.ClusterArn}, time.Now().Add(1*time.Hour), config.Config{})
 	if err != nil {
 		assert.Failf(t, "Unable to fetch list of services: %s", err.Error())
 	}
@@ -166,7 +169,7 @@ func TestListECSEC2Services(t *testing.T) {
 func TestNukeECSEC2Services(t *testing.T) {
 	t.Parallel()
 
-	region := getRandomFargateSupportedRegion()
+	//region := getRandomFargateSupportedRegion()
 	awsSession, err := session.NewSession(&awsgo.Config{
 		Region: awsgo.String(region),
 	})
@@ -211,7 +214,7 @@ func TestNukeECSEC2Services(t *testing.T) {
 
 	err = nukeAllEcsServices(awsSession, ecsServiceClusterMap, []*string{service.ServiceArn})
 
-	ecsServiceArns, _, err := getAllEcsServices(awsSession, []*string{cluster.ClusterArn}, time.Now().Add(1*time.Hour))
+	ecsServiceArns, _, err := getAllEcsServices(awsSession, []*string{cluster.ClusterArn}, time.Now().Add(1*time.Hour), config.Config{})
 	if err != nil {
 		assert.Failf(t, "Unable to fetch list of services: %s", err.Error())
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,8 @@ type Config struct {
 	AccessAnalyzer        ResourceType `yaml:"AccessAnalyzer"`
 	CloudWatchDashboard   ResourceType `yaml:"CloudWatchDashboard"`
 	OpenSearchDomain      ResourceType `yaml:"OpenSearchDomain"`
+	ECSService            ResourceType `yaml:"ECSService"`
+	ECSCluster            ResourceType `yaml:"ECSCluster"`
 }
 
 type ResourceType struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,6 +18,8 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 
@@ -330,6 +332,192 @@ func TestConfigSecretsManager_FilterNames(t *testing.T) {
 	if len(configObj.SecretsManagerSecrets.IncludeRule.NamesRegExp) == 0 ||
 		len(configObj.SecretsManagerSecrets.ExcludeRule.NamesRegExp) == 0 {
 		assert.Fail(t, "ConfigObj should contain secrets regexes, %+v\n", configObj)
+	}
+
+	return
+}
+
+// ECS Service Tests
+
+func TestConfigECSService_Empty(t *testing.T) {
+	configFilePath := "./mocks/ecs_service_empty.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should be empty, %+v\n", configObj.ECSService)
+	}
+
+	return
+}
+
+func TestConfigECSService_EmptyFilters(t *testing.T) {
+	configFilePath := "./mocks/ecs_service_empty_filters.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should be empty, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigECSService_EmptyRules(t *testing.T) {
+	configFilePath := "./mocks/ecs_service_empty_rules.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should be empty, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigECSService_IncludeNames(t *testing.T) {
+	configFilePath := "./mocks/ecs_service_include_names.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should not be empty, %+v\n", configObj)
+	}
+
+	if len(configObj.ECSService.IncludeRule.NamesRegExp) == 0 {
+		assert.Fail(t, "ConfigObj should contain ECS service regexes, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigECSService_ExcludeNames(t *testing.T) {
+	configFilePath := "./mocks/ecs_service_exclude_names.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should not be empty, %+v\n", configObj)
+	}
+
+	if len(configObj.ECSService.ExcludeRule.NamesRegExp) == 0 {
+		assert.Fail(t, "ConfigObj should contain ECS service regexes, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigECSService_FilterNames(t *testing.T) {
+	configFilePath := "./mocks/ecs_service_filter_names.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should not be empty, %+v\n", configObj)
+	}
+
+	if len(configObj.ECSService.IncludeRule.NamesRegExp) == 0 ||
+		len(configObj.ECSService.ExcludeRule.NamesRegExp) == 0 {
+		assert.Fail(t, "ConfigObj should contain ECS service regexes, %+v\n", configObj)
+	}
+
+	return
+}
+
+// ECS Cluster Tests
+
+func TestConfigECSCluster_Empty(t *testing.T) {
+	configFilePath := "./mocks/ecs_cluster_empty.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should be empty, %+v\n", configObj.ECSCluster)
+	}
+
+	return
+}
+
+func TestConfigECSCluster_EmptyFilters(t *testing.T) {
+	configFilePath := "./mocks/ecs_cluster_empty_filters.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should be empty, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigECSCluster_EmptyRules(t *testing.T) {
+	configFilePath := "./mocks/ecs_cluster_empty_rules.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should be empty, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigECSCluster_IncludeNames(t *testing.T) {
+	configFilePath := "./mocks/ecs_cluster_include_names.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should not be empty, %+v\n", configObj)
+	}
+
+	if len(configObj.ECSCluster.IncludeRule.NamesRegExp) == 0 {
+		assert.Fail(t, "ConfigObj should contain ECS Cluster regexes, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigECSCluster_ExcludeNames(t *testing.T) {
+	configFilePath := "./mocks/ecs_cluster_exclude_names.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should not be empty, %+v\n", configObj)
+	}
+
+	if len(configObj.ECSCluster.ExcludeRule.NamesRegExp) == 0 {
+		assert.Fail(t, "ConfigObj should contain ECS Cluster regexes, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigECSCluster_FilterNames(t *testing.T) {
+	configFilePath := "./mocks/ecs_cluster_filter_names.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should not be empty, %+v\n", configObj)
+	}
+
+	if len(configObj.ECSCluster.IncludeRule.NamesRegExp) == 0 ||
+		len(configObj.ECSCluster.ExcludeRule.NamesRegExp) == 0 {
+		assert.Fail(t, "ConfigObj should contain ECS Cluster regexes, %+v\n", configObj)
 	}
 
 	return

--- a/config/mocks/ecs_cluster_cleanup.yaml
+++ b/config/mocks/ecs_cluster_cleanup.yaml
@@ -1,0 +1,5 @@
+ECSCluster:
+  include:
+    names_regex:
+      - ^cloud-nuke-test-
+      - -cloud-nuke-test-

--- a/config/mocks/ecs_cluster_empty.yaml
+++ b/config/mocks/ecs_cluster_empty.yaml
@@ -1,0 +1,1 @@
+ECSCluster:

--- a/config/mocks/ecs_cluster_empty_filters.yaml
+++ b/config/mocks/ecs_cluster_empty_filters.yaml
@@ -1,0 +1,5 @@
+ECSCluster:
+  include:
+    names_regex:
+  exclude:
+    names_regex:

--- a/config/mocks/ecs_cluster_empty_rules.yaml
+++ b/config/mocks/ecs_cluster_empty_rules.yaml
@@ -1,0 +1,3 @@
+ECSCluster:
+  include:
+  exclude:

--- a/config/mocks/ecs_cluster_exclude_names.yaml
+++ b/config/mocks/ecs_cluster_exclude_names.yaml
@@ -1,0 +1,5 @@
+ECSCluster:
+  exclude:
+    names_regex:
+      - alice
+      - bob

--- a/config/mocks/ecs_cluster_filter_names.yaml
+++ b/config/mocks/ecs_cluster_filter_names.yaml
@@ -1,0 +1,9 @@
+ECSCluster:
+  include:
+    names_regex:
+      - ^cloud-nuke-*
+      - test
+  exclude:
+    names_regex:
+      - alice
+      - bob

--- a/config/mocks/ecs_cluster_include_names.yaml
+++ b/config/mocks/ecs_cluster_include_names.yaml
@@ -1,0 +1,5 @@
+ECSCluster:
+  include:
+    names_regex:
+      - ^cloud-nuke-*
+      - test

--- a/config/mocks/ecs_service_cleanup.yaml
+++ b/config/mocks/ecs_service_cleanup.yaml
@@ -1,0 +1,5 @@
+ECSService:
+  include:
+    names_regex:
+      - ^cloud-nuke-test-
+      - -cloud-nuke-test-

--- a/config/mocks/ecs_service_empty.yaml
+++ b/config/mocks/ecs_service_empty.yaml
@@ -1,0 +1,1 @@
+ECSService:

--- a/config/mocks/ecs_service_empty_filters.yaml
+++ b/config/mocks/ecs_service_empty_filters.yaml
@@ -1,0 +1,5 @@
+ECSService:
+  include:
+    names_regex:
+  exclude:
+    names_regex:

--- a/config/mocks/ecs_service_empty_rules.yaml
+++ b/config/mocks/ecs_service_empty_rules.yaml
@@ -1,0 +1,3 @@
+ECSService:
+  include:
+  exclude:

--- a/config/mocks/ecs_service_exclude_names.yaml
+++ b/config/mocks/ecs_service_exclude_names.yaml
@@ -1,0 +1,5 @@
+ECSService:
+  exclude:
+    names_regex:
+      - alice
+      - bob

--- a/config/mocks/ecs_service_filter_names.yaml
+++ b/config/mocks/ecs_service_filter_names.yaml
@@ -1,0 +1,9 @@
+ECSService:
+  include:
+    names_regex:
+      - ^cloud-nuke-*
+      - test
+  exclude:
+    names_regex:
+      - alice
+      - bob

--- a/config/mocks/ecs_service_include_names.yaml
+++ b/config/mocks/ecs_service_include_names.yaml
@@ -1,0 +1,5 @@
+ECSService:
+  include:
+    names_regex:
+      - ^cloud-nuke-*
+      - test


### PR DESCRIPTION
Add support to filter ECS Clusters and Services by name in config file.

Test output:
https://gist.github.com/brandonstrohmeyer/e3bc64ebf9d2ac98c055ec48fc7180f2