### PR TITLE
Failing tests fixes

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -113,6 +113,31 @@ func getRandomRegion() (string, error) {
 	return allRegions[randIndex], nil
 }
 
+func getRandomRegionWithExclusions(regionsToExclude []string) (string, error) {
+	allRegions, err := GetEnabledRegions()
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+	rand.Seed(time.Now().UnixNano())
+
+	// exclude from "allRegions"
+	var exclusions = make(map[string]string)
+	for _, region := range regionsToExclude {
+		exclusions[region] = region
+	}
+	// filter regions
+	var updatedRegions []string
+	for _, region := range allRegions {
+		_, excluded := exclusions[region]
+		if !excluded {
+			updatedRegions = append(updatedRegions, region)
+		}
+	}
+	randIndex := rand.Intn(len(updatedRegions))
+	logging.Logger.Infof("Random region chosen: %s", updatedRegions[randIndex])
+	return updatedRegions[randIndex], nil
+}
+
 func split(identifiers []string, limit int) [][]string {
 	if limit < 0 {
 		limit = -1 * limit

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -103,16 +103,10 @@ func GetEnabledRegions() ([]string, error) {
 }
 
 func getRandomRegion() (string, error) {
-	allRegions, err := GetEnabledRegions()
-	if err != nil {
-		return "", errors.WithStackTrace(err)
-	}
-	rand.Seed(time.Now().UnixNano())
-	randIndex := rand.Intn(len(allRegions))
-	logging.Logger.Infof("Random region chosen: %s", allRegions[randIndex])
-	return allRegions[randIndex], nil
+	return getRandomRegionWithExclusions([]string{})
 }
 
+// getRandomRegionWithExclusions - return random from enabled regions, excluding regions from the argument
 func getRandomRegionWithExclusions(regionsToExclude []string) (string, error) {
 	allRegions, err := GetEnabledRegions()
 	if err != nil {

--- a/aws/opensearch_test.go
+++ b/aws/opensearch_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Excluded regions which doesn't include "t3.small.search" instances
-var excludedOpenSearchDomains = []string{
+var ExcludedOpenSearchDomains = []string{
 	"ap-northeast-3",
 }
 
@@ -23,7 +23,7 @@ var excludedOpenSearchDomains = []string{
 func TestCanTagOpenSearchDomains(t *testing.T) {
 	t.Parallel()
 
-	region, err := getRandomRegionWithExclusions(excludedOpenSearchDomains)
+	region, err := getRandomRegionWithExclusions(ExcludedOpenSearchDomains)
 	require.NoError(t, err)
 
 	awsSession, err := session.NewSession(&awsgo.Config{
@@ -56,7 +56,7 @@ func TestCanTagOpenSearchDomains(t *testing.T) {
 func TestCanListAllOpenSearchDomainsOlderThan24hours(t *testing.T) {
 	t.Parallel()
 
-	region, err := getRandomRegionWithExclusions(excludedOpenSearchDomains)
+	region, err := getRandomRegionWithExclusions(ExcludedOpenSearchDomains)
 	require.NoError(t, err)
 
 	awsSession, err := session.NewSession(&awsgo.Config{
@@ -90,7 +90,7 @@ func TestCanListAllOpenSearchDomainsOlderThan24hours(t *testing.T) {
 func TestCanNukeOpenSearchDomain(t *testing.T) {
 	t.Parallel()
 
-	region, err := getRandomRegionWithExclusions(excludedOpenSearchDomains)
+	region, err := getRandomRegionWithExclusions(ExcludedOpenSearchDomains)
 	require.NoError(t, err)
 
 	awsSession, err := session.NewSession(&awsgo.Config{

--- a/aws/opensearch_test.go
+++ b/aws/opensearch_test.go
@@ -14,11 +14,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Excluded regions which doesn't include "t3.small.search" instances
+var excludedOpenSearchDomains = []string{
+	"ap-northeast-3",
+}
+
 // Test we can create an OpenSearch Domain, tag it, and then find the tag
 func TestCanTagOpenSearchDomains(t *testing.T) {
 	t.Parallel()
 
-	region, err := getRandomRegion()
+	region, err := getRandomRegionWithExclusions(excludedOpenSearchDomains)
 	require.NoError(t, err)
 
 	awsSession, err := session.NewSession(&awsgo.Config{
@@ -51,7 +56,7 @@ func TestCanTagOpenSearchDomains(t *testing.T) {
 func TestCanListAllOpenSearchDomainsOlderThan24hours(t *testing.T) {
 	t.Parallel()
 
-	region, err := getRandomRegion()
+	region, err := getRandomRegionWithExclusions(excludedOpenSearchDomains)
 	require.NoError(t, err)
 
 	awsSession, err := session.NewSession(&awsgo.Config{
@@ -85,7 +90,7 @@ func TestCanListAllOpenSearchDomainsOlderThan24hours(t *testing.T) {
 func TestCanNukeOpenSearchDomain(t *testing.T) {
 	t.Parallel()
 
-	region, err := getRandomRegion()
+	region, err := getRandomRegionWithExclusions(excludedOpenSearchDomains)
 	require.NoError(t, err)
 
 	awsSession, err := session.NewSession(&awsgo.Config{

--- a/aws/transit_gateway_test.go
+++ b/aws/transit_gateway_test.go
@@ -213,7 +213,7 @@ func createTestTransitGatewayVpcAttachment(t *testing.T, session *session.Sessio
 
 	vpc := vpcs.Vpcs[0]
 
-	subnets := getVpcSubnets(t, session, awsgo.StringValue(vpc.VpcId))
+	subnets := getVpcSubnetsDistinctByAz(t, session, awsgo.StringValue(vpc.VpcId))
 
 	tgwVpctAttachmentName := ec2.TagSpecification{
 		ResourceType: awsgo.String(ec2.ResourceTypeTransitGatewayAttachment),


### PR DESCRIPTION
Included changes:
  * Excluded region ap-northeast-3 from OpenSearch tests since can't be deployed t3.small.search instances there
  * Updated TestNukeTransitGatewayVpcAttachment to use distinct subnets by AZ
  * Added check for SQS queue availability

![image (22)](https://user-images.githubusercontent.com/10694338/149575856-ede05a76-8504-4580-8faa-52e48b1b7d24.png)

Fixes failures like:
```
=== RUN   TestCanTagOpenSearchDomains
=== PAUSE TestCanTagOpenSearchDomains
=== CONT  TestCanTagOpenSearchDomains
[cloud-nuke] time="2022-01-12T21:57:13+02:00" level=info msg="Random region chosen: ap-northeast-3"
    opensearch_test.go:124: 
        	Error Trace:	opensearch_test.go:124
        	            				opensearch_test.go:29
        	Error:      	Received unexpected error:
        	            	InvalidTypeException: Invalid instance type: t3.small.search
        	Test:       	TestCanTagOpenSearchDomains
--- FAIL: TestCanTagOpenSearchDomains (2.76s)

=== CONT  TestNukeTransitGatewayVpcAttachment
    transit_gateway_test.go:236: 
        	Error Trace:	transit_gateway_test.go:236
        	            				transit_gateway_test.go:289
        	Error:      	Received unexpected error:
        	            	DuplicateSubnetsInSameZone: Duplicate Subnets for same AZ
        	            		status code: 400, request id: fc1cd196-94ea-4ecc-a0c8-9018b54e500b
        	Test:       	TestNukeTransitGatewayVpcAttachment
--- FAIL: TestNukeTransitGatewayVpcAttachment (182.08s)
```

https://app.circleci.com/pipelines/github/gruntwork-io/cloud-nuke/5974/workflows/b44c51b1-565b-459e-a1e6-9c21703aad04/jobs/26918/steps

https://app.circleci.com/pipelines/github/gruntwork-io/cloud-nuke/5974/workflows/b7941e88-c4fb-44a4-b225-7a368e21ff00/jobs/26878/tests#failed-test-0
