### PR TITLE
Include OpenID Connect Providers to nukable resource

### DIFF
--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -33,3 +33,9 @@ NatGateway:
       # We have an active ECS Deploy Runner running in the sandbox environment for sales demos, and this NAT gateway is
       # critical for that.
       - "^ecs-deploy-runner-v2-nat-gateway-0$"
+
+OIDCProvider:
+  exclude:
+    names_regex:
+      # We have an active OIDC Provider used by github actions
+      - ".*token.actions.githubusercontent.com.*"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The currently supported functionality includes:
 - Deleting all DynamoDB tables in an AWS account
 - Deleting all CloudWatch Dashboards in an AWS account
 - Deleting all OpenSearch Domains in an AWS account
+- Deleting all IAM OpenID Connect Providers
 
 ### BEWARE!
 
@@ -192,6 +193,9 @@ The following resources support the Config file:
 - VPCs
     - Resource type: `vpc`
     - Config key: `VPC`
+- IAM OpenID Connect Providers
+    - Resource type: `oidcprovider`
+    - Config key: `OIDCProvider`
 
 
 #### Example
@@ -293,6 +297,7 @@ To find out what we options are supported in the config file today, consult this
 | ecs                | none  | ✅          | none | none       |
 | elasticache        | none  | ✅          | none | none       |
 | vpc                | none  | ✅          | none | none       |
+| oidcprovider       | none  | ✅          | none | none       |
 | acmpca             | none  | none        | none | none       |
 | ec2 instance       | none  | none        | none | none       |
 | iam role           | none  | none        | none | none       |

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -710,6 +710,21 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End IAM Users
 
+		// IAM OpenID Connect Providers
+		oidcProviders := OIDCProviders{}
+		if IsNukeable(oidcProviders.ResourceName(), resourceTypes) {
+			providerARNs, err := getAllOIDCProviders(session, excludeAfter, configObj)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			if len(providerARNs) > 0 {
+				oidcProviders.ProviderARNs = awsgo.StringValueSlice(providerARNs)
+				globalResources.Resources = append(globalResources.Resources, oidcProviders)
+			}
+		}
+		// End IAM OpenIDConnectProviders
+
 		if len(globalResources.Resources) > 0 {
 			account.Resources[GlobalRegion] = globalResources
 		}
@@ -750,6 +765,7 @@ func ListResourceTypes() []string {
 		DynamoDB{}.ResourceName(),
 		EC2VPCs{}.ResourceName(),
 		Elasticaches{}.ResourceName(),
+		OIDCProviders{}.ResourceName(),
 	}
 	sort.Strings(resourceTypes)
 	return resourceTypes

--- a/aws/oidc_provider.go
+++ b/aws/oidc_provider.go
@@ -1,0 +1,192 @@
+package aws
+
+import (
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/hashicorp/go-multierror"
+)
+
+// oidcProvider is an internal struct to collect the necessary information we need to filter in the OIDC Providers that
+// should be deleted. This exists because no struct in the AWS SDK represents all the information collected here.
+type oidcProvider struct {
+	ARN         *string
+	CreateTime  *time.Time
+	ProviderURL *string
+}
+
+// getAllOIDCProviders will list all the OpenID Connect Providers in an account, filtering out those that do not match
+// the requested rules (older-than and config file settings). Note that since the list API does not return the necessary
+// information to implement the filters, we use goroutines to asynchronously and concurrently fetch the details for all
+// the providers that are found in the account.
+func getAllOIDCProviders(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
+	svc := iam.New(session)
+
+	output, err := svc.ListOpenIDConnectProviders(&iam.ListOpenIDConnectProvidersInput{})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	providerARNs := []*string{}
+	for _, provider := range output.OpenIDConnectProviderList {
+		providerARNs = append(providerARNs, provider.Arn)
+	}
+	providers, err := getAllOIDCProviderDetails(svc, providerARNs)
+	if err != nil {
+		return nil, err
+	}
+
+	providerARNsToDelete := []*string{}
+	for _, provider := range providers {
+		if shouldIncludeOIDCProvider(provider, excludeAfter, configObj) {
+			providerARNsToDelete = append(providerARNsToDelete, provider.ARN)
+		}
+	}
+	return providerARNsToDelete, nil
+}
+
+// getAllOIDCProviderDetails fetches the details of the given list of OpenID Connect Providers so that we can make
+// informed decisions about which ones should be included in the nuking procedure.
+func getAllOIDCProviderDetails(svc *iam.IAM, providerARNs []*string) ([]oidcProvider, error) {
+	numRetrieving := len(providerARNs)
+
+	// Schedule goroutines to retrieve the provider details async.
+	wg := new(sync.WaitGroup)
+	wg.Add(numRetrieving)
+	resultChans := make([]chan *oidcProvider, numRetrieving)
+	errChans := make([]chan error, numRetrieving)
+	for i, providerARN := range providerARNs {
+		resultChans[i] = make(chan *oidcProvider, 1)
+		errChans[i] = make(chan error, 1)
+		go getOIDCProviderDetailAsync(wg, resultChans[i], errChans[i], svc, providerARN)
+	}
+	wg.Wait()
+
+	// Collect errors, if any.
+	var allErrs *multierror.Error
+	for _, errChan := range errChans {
+		if err := <-errChan; err != nil {
+			allErrs = multierror.Append(allErrs, err)
+		}
+	}
+	finalErr := allErrs.ErrorOrNil()
+	if finalErr != nil {
+		return nil, errors.WithStackTrace(finalErr)
+	}
+
+	// Collect results, if any.
+	var allResults []oidcProvider
+	for _, resultChan := range resultChans {
+		if result := <-resultChan; result != nil {
+			allResults = append(allResults, *result)
+		}
+	}
+
+	return allResults, nil
+}
+
+// shouldIncludeOIDCProvider determines whether or not a given OpenID Connect Provider should be nuked based on the
+// given constraints.
+func shouldIncludeOIDCProvider(provider oidcProvider, excludeAfter time.Time, configObj config.Config) bool {
+	if excludeAfter.Before(aws.TimeValue(provider.CreateTime)) {
+		return false
+	}
+
+	return config.ShouldInclude(
+		aws.StringValue(provider.ProviderURL),
+		configObj.OIDCProvider.IncludeRule.NamesRegExp,
+		configObj.OIDCProvider.ExcludeRule.NamesRegExp,
+	)
+}
+
+// getOIDCProviderDetailAsync is a routine for fetching the details of a single OpenID Connect Provider. This function
+// is designed to be called in a goroutine.
+func getOIDCProviderDetailAsync(wg *sync.WaitGroup, resultChan chan *oidcProvider, errChan chan error, svc *iam.IAM, providerARN *string) {
+	defer wg.Done()
+
+	resp, err := svc.GetOpenIDConnectProvider(&iam.GetOpenIDConnectProviderInput{OpenIDConnectProviderArn: providerARN})
+	if err != nil {
+		resultChan <- nil
+		errChan <- errors.WithStackTrace(err)
+		return
+	}
+
+	provider := oidcProvider{
+		ARN:         providerARN,
+		CreateTime:  resp.CreateDate,
+		ProviderURL: resp.Url,
+	}
+	resultChan <- &provider
+	errChan <- nil
+}
+
+// nukeAllOIDCProviders deletes all the given OpenID Connect Providers from the account.
+func nukeAllOIDCProviders(session *session.Session, identifiers []*string) error {
+	svc := iam.New(session)
+
+	if len(identifiers) == 0 {
+		logging.Logger.Infof("No OIDC Providers to nuke")
+		return nil
+	}
+
+	// NOTE: we don't need to do pagination here, because the pagination is handled by the caller to this function,
+	// based on OIDCProviders.MaxBatchSize, however we add a guard here to warn users when the batching fails and has a
+	// chance of throttling AWS. Since we concurrently make one call for each identifier, we pick 100 for the limit here
+	// because many APIs in AWS have a limit of 100 requests per second.
+	if len(identifiers) > 100 {
+		logging.Logger.Errorf("Nuking too many OIDC Providers at once (100): halting to avoid hitting AWS API rate limiting")
+		return TooManyOIDCProvidersErr{}
+	}
+
+	// There is no bulk delete OIDC Provider API, so we delete the batch of nat gateways concurrently using go routines.
+	logging.Logger.Infof("Deleting OIDC Providers")
+	wg := new(sync.WaitGroup)
+	wg.Add(len(identifiers))
+	errChans := make([]chan error, len(identifiers))
+	for i, providerARN := range identifiers {
+		errChans[i] = make(chan error, 1)
+		go deleteOIDCProviderAsync(wg, errChans[i], svc, providerARN)
+	}
+	wg.Wait()
+
+	// Collect all the errors from the async delete calls into a single error struct.
+	var allErrs *multierror.Error
+	for _, errChan := range errChans {
+		if err := <-errChan; err != nil {
+			allErrs = multierror.Append(allErrs, err)
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
+	}
+	finalErr := allErrs.ErrorOrNil()
+	if finalErr != nil {
+		return errors.WithStackTrace(finalErr)
+	}
+
+	for _, providerARN := range identifiers {
+		logging.Logger.Infof("[OK] OIDC Provider %s was deleted", aws.StringValue(providerARN))
+	}
+	return nil
+}
+
+// deleteOIDCProviderAsync deletes the provided OIDC Provider asynchronously in a goroutine, using wait groups for
+// concurrency control and a return channel for errors.
+func deleteOIDCProviderAsync(wg *sync.WaitGroup, errChan chan error, svc *iam.IAM, providerARN *string) {
+	defer wg.Done()
+
+	_, err := svc.DeleteOpenIDConnectProvider(&iam.DeleteOpenIDConnectProviderInput{OpenIDConnectProviderArn: providerARN})
+	errChan <- err
+}
+
+// Custom errors
+
+type TooManyOIDCProvidersErr struct{}
+
+func (err TooManyOIDCProvidersErr) Error() string {
+	return "Too many OIDC Providers requested at once."
+}

--- a/aws/oidc_provider_test.go
+++ b/aws/oidc_provider_test.go
@@ -1,0 +1,180 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// NOTE: OpenID Connect Provider is a global resource, so we use the default region for the tests.
+
+func TestListOIDCProviders(t *testing.T) {
+	t.Parallel()
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(defaultRegion)})
+	require.NoError(t, err)
+	svc := iam.New(session)
+
+	oidcProviderARN := createOIDCProvider(t, svc, "base", defaultRegion)
+	defer deleteOIDCProvider(t, svc, oidcProviderARN, true)
+
+	providerARNs, err := getAllOIDCProviders(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.Contains(t, aws.StringValueSlice(providerARNs), aws.StringValue(oidcProviderARN))
+}
+
+func TestTimeFilterExclusionNewlyCreatedOIDCProvider(t *testing.T) {
+	t.Parallel()
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(defaultRegion)})
+	require.NoError(t, err)
+	svc := iam.New(session)
+
+	oidcProviderARN := createOIDCProvider(t, svc, "base", defaultRegion)
+	defer deleteOIDCProvider(t, svc, oidcProviderARN, true)
+
+	// Assert OpenID Connect Provider is picked up without filters
+	providerARNsNewer, err := getAllOIDCProviders(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.Contains(t, aws.StringValueSlice(providerARNsNewer), aws.StringValue(oidcProviderARN))
+
+	// Assert provider doesn't appear when we look at providers older than 1 Hour
+	olderThan := time.Now().Add(-1 * time.Hour)
+	providerARNsOlder, err := getAllOIDCProviders(session, olderThan, config.Config{})
+	require.NoError(t, err)
+	assert.Contains(t, aws.StringValueSlice(providerARNsOlder), aws.StringValue(oidcProviderARN))
+}
+
+func TestConfigExclusionCreatedOIDCProvider(t *testing.T) {
+	t.Parallel()
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(defaultRegion)})
+	require.NoError(t, err)
+	svc := iam.New(session)
+
+	includedOIDCProviderARN := createOIDCProvider(t, svc, "include", defaultRegion)
+	defer deleteOIDCProvider(t, svc, includedOIDCProviderARN, true)
+
+	excludedOIDCProviderARN := createOIDCProvider(t, svc, "exclude", defaultRegion)
+	defer deleteOIDCProvider(t, svc, excludedOIDCProviderARN, true)
+
+	// Assert OpenID Connect Providers are picked up without filters
+	providerARNsNewer, err := getAllOIDCProviders(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.Contains(t, aws.StringValueSlice(providerARNsNewer), aws.StringValue(includedOIDCProviderARN))
+	assert.Contains(t, aws.StringValueSlice(providerARNsNewer), aws.StringValue(excludedOIDCProviderARN))
+
+	// Assert provider doesn't appear when we filter providers by config file
+	providerARNsConfigFiltered, err := getAllOIDCProviders(session, time.Now(), config.Config{
+		OIDCProvider: config.ResourceType{
+			IncludeRule: config.FilterRule{
+				NamesRegExp: []config.Expression{
+					config.Expression{
+						RE: *regexp.MustCompile(".*include.*"),
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, aws.StringValueSlice(providerARNsConfigFiltered), aws.StringValue(includedOIDCProviderARN))
+	assert.NotContains(t, aws.StringValueSlice(providerARNsConfigFiltered), aws.StringValue(excludedOIDCProviderARN))
+}
+
+func TestNukeOIDCProviderOne(t *testing.T) {
+	t.Parallel()
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(defaultRegion)})
+	require.NoError(t, err)
+	svc := iam.New(session)
+
+	// We ignore errors in the delete call here, because it is intended to be a stop gap in case there is a bug in nuke.
+	oidcProviderARN := createOIDCProvider(t, svc, "base", defaultRegion)
+	defer deleteOIDCProvider(t, svc, oidcProviderARN, false)
+
+	identifiers := []*string{oidcProviderARN}
+	require.NoError(
+		t,
+		nukeAllOIDCProviders(session, identifiers),
+	)
+
+	// Make sure the OIDC Provider is deleted.
+	assertOIDCProvidersDeleted(t, svc, identifiers)
+}
+
+func TestNukeOIDCProviderMoreThanOne(t *testing.T) {
+	t.Parallel()
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(defaultRegion)})
+	require.NoError(t, err)
+	svc := iam.New(session)
+
+	providers := []*string{}
+	for i := 0; i < 3; i++ {
+		// We ignore errors in the delete call here, because it is intended to be a stop gap in case there is a bug in nuke.
+		oidcProviderARN := createOIDCProvider(t, svc, "base", defaultRegion)
+		defer deleteOIDCProvider(t, svc, oidcProviderARN, false)
+		providers = append(providers, oidcProviderARN)
+	}
+
+	require.NoError(
+		t,
+		nukeAllOIDCProviders(session, providers),
+	)
+
+	// Make sure all OIDCProviders are deleted.
+	assertOIDCProvidersDeleted(t, svc, providers)
+}
+
+// Helper functions for driving the OIDC Provider tests
+
+// createOIDCProvider will create a new OIDC Provider
+func createOIDCProvider(t *testing.T, svc *iam.IAM, basename string, region string) *string {
+	input := &iam.CreateOpenIDConnectProviderInput{
+		Url: aws.String(fmt.Sprintf("https://%s.%s.gruntwork-sandbox.in", util.UniqueID(), basename)),
+		// We can use a non-functional thumbprint here because we don't care if the provider actually works - only that
+		// the resource exists.
+		ThumbprintList: aws.StringSlice([]string{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}),
+	}
+	resp, err := svc.CreateOpenIDConnectProvider(input)
+	require.NoError(t, err)
+
+	// Wait 5 seconds after creation to ensure the OIDC provider gets propagated through AWS system.
+	time.Sleep(time.Second * 5)
+
+	return resp.OpenIDConnectProviderArn
+}
+
+// deleteOIDCProvider is a function to delete the given OpenID Connect Provider.
+func deleteOIDCProvider(t *testing.T, svc *iam.IAM, providerARN *string, checkErr bool) {
+	input := &iam.DeleteOpenIDConnectProviderInput{OpenIDConnectProviderArn: providerARN}
+	_, err := svc.DeleteOpenIDConnectProvider(input)
+	if checkErr {
+		require.NoError(t, err)
+	}
+}
+
+func assertOIDCProvidersDeleted(t *testing.T, svc *iam.IAM, identifiers []*string) {
+	resp, err := svc.ListOpenIDConnectProviders(&iam.ListOpenIDConnectProvidersInput{})
+	require.NoError(t, err)
+
+	providerARNsFound := []string{}
+	for _, provider := range resp.OpenIDConnectProviderList {
+		if provider != nil {
+			providerARNsFound = append(providerARNsFound, aws.StringValue(provider.Arn))
+		}
+	}
+
+	for _, providerARN := range identifiers {
+		assert.NotContains(t, providerARNsFound, aws.StringValue(providerARN))
+	}
+}

--- a/aws/oidc_provider_test.go
+++ b/aws/oidc_provider_test.go
@@ -24,7 +24,7 @@ func TestListOIDCProviders(t *testing.T) {
 	require.NoError(t, err)
 	svc := iam.New(session)
 
-	oidcProviderARN := createOIDCProvider(t, svc, "base", defaultRegion)
+	oidcProviderARN := createOIDCProvider(t, svc, "base")
 	defer deleteOIDCProvider(t, svc, oidcProviderARN, true)
 
 	providerARNs, err := getAllOIDCProviders(session, time.Now(), config.Config{})
@@ -39,7 +39,7 @@ func TestTimeFilterExclusionNewlyCreatedOIDCProvider(t *testing.T) {
 	require.NoError(t, err)
 	svc := iam.New(session)
 
-	oidcProviderARN := createOIDCProvider(t, svc, "base", defaultRegion)
+	oidcProviderARN := createOIDCProvider(t, svc, "base")
 	defer deleteOIDCProvider(t, svc, oidcProviderARN, true)
 
 	// Assert OpenID Connect Provider is picked up without filters
@@ -51,7 +51,7 @@ func TestTimeFilterExclusionNewlyCreatedOIDCProvider(t *testing.T) {
 	olderThan := time.Now().Add(-1 * time.Hour)
 	providerARNsOlder, err := getAllOIDCProviders(session, olderThan, config.Config{})
 	require.NoError(t, err)
-	assert.Contains(t, aws.StringValueSlice(providerARNsOlder), aws.StringValue(oidcProviderARN))
+	assert.NotContains(t, aws.StringValueSlice(providerARNsOlder), aws.StringValue(oidcProviderARN))
 }
 
 func TestConfigExclusionCreatedOIDCProvider(t *testing.T) {
@@ -61,10 +61,10 @@ func TestConfigExclusionCreatedOIDCProvider(t *testing.T) {
 	require.NoError(t, err)
 	svc := iam.New(session)
 
-	includedOIDCProviderARN := createOIDCProvider(t, svc, "include", defaultRegion)
+	includedOIDCProviderARN := createOIDCProvider(t, svc, "include")
 	defer deleteOIDCProvider(t, svc, includedOIDCProviderARN, true)
 
-	excludedOIDCProviderARN := createOIDCProvider(t, svc, "exclude", defaultRegion)
+	excludedOIDCProviderARN := createOIDCProvider(t, svc, "exclude")
 	defer deleteOIDCProvider(t, svc, excludedOIDCProviderARN, true)
 
 	// Assert OpenID Connect Providers are picked up without filters
@@ -98,7 +98,7 @@ func TestNukeOIDCProviderOne(t *testing.T) {
 	svc := iam.New(session)
 
 	// We ignore errors in the delete call here, because it is intended to be a stop gap in case there is a bug in nuke.
-	oidcProviderARN := createOIDCProvider(t, svc, "base", defaultRegion)
+	oidcProviderARN := createOIDCProvider(t, svc, "base")
 	defer deleteOIDCProvider(t, svc, oidcProviderARN, false)
 
 	identifiers := []*string{oidcProviderARN}
@@ -121,7 +121,7 @@ func TestNukeOIDCProviderMoreThanOne(t *testing.T) {
 	providers := []*string{}
 	for i := 0; i < 3; i++ {
 		// We ignore errors in the delete call here, because it is intended to be a stop gap in case there is a bug in nuke.
-		oidcProviderARN := createOIDCProvider(t, svc, "base", defaultRegion)
+		oidcProviderARN := createOIDCProvider(t, svc, "base")
 		defer deleteOIDCProvider(t, svc, oidcProviderARN, false)
 		providers = append(providers, oidcProviderARN)
 	}
@@ -138,7 +138,7 @@ func TestNukeOIDCProviderMoreThanOne(t *testing.T) {
 // Helper functions for driving the OIDC Provider tests
 
 // createOIDCProvider will create a new OIDC Provider
-func createOIDCProvider(t *testing.T, svc *iam.IAM, basename string, region string) *string {
+func createOIDCProvider(t *testing.T, svc *iam.IAM, basename string) *string {
 	input := &iam.CreateOpenIDConnectProviderInput{
 		Url: aws.String(fmt.Sprintf("https://%s.%s.gruntwork-sandbox.in", random.UniqueId(), basename)),
 		// We can use a non-functional thumbprint here because we don't care if the provider actually works - only that

--- a/aws/oidc_provider_test.go
+++ b/aws/oidc_provider_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -140,7 +140,7 @@ func TestNukeOIDCProviderMoreThanOne(t *testing.T) {
 // createOIDCProvider will create a new OIDC Provider
 func createOIDCProvider(t *testing.T, svc *iam.IAM, basename string, region string) *string {
 	input := &iam.CreateOpenIDConnectProviderInput{
-		Url: aws.String(fmt.Sprintf("https://%s.%s.gruntwork-sandbox.in", util.UniqueID(), basename)),
+		Url: aws.String(fmt.Sprintf("https://%s.%s.gruntwork-sandbox.in", random.UniqueId(), basename)),
 		// We can use a non-functional thumbprint here because we don't care if the provider actually works - only that
 		// the resource exists.
 		ThumbprintList: aws.StringSlice([]string{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}),

--- a/aws/oidc_provider_test.go
+++ b/aws/oidc_provider_test.go
@@ -148,8 +148,8 @@ func createOIDCProvider(t *testing.T, svc *iam.IAM, basename string, region stri
 	resp, err := svc.CreateOpenIDConnectProvider(input)
 	require.NoError(t, err)
 
-	// Wait 5 seconds after creation to ensure the OIDC provider gets propagated through AWS system.
-	time.Sleep(time.Second * 5)
+	// Wait 10 seconds after creation to ensure the OIDC provider gets propagated through AWS system.
+	time.Sleep(time.Second * 10)
 
 	return resp.OpenIDConnectProviderArn
 }

--- a/aws/oidc_provider_types.go
+++ b/aws/oidc_provider_types.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+// OIDCProviders - represents all AWS OpenID Connect providers that should be deleted.
+type OIDCProviders struct {
+	ProviderARNs []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (oidcprovider OIDCProviders) ResourceName() string {
+	return "oidcprovider"
+}
+
+// ResourceIdentifiers - The ARNs of the OIDC providers.
+func (oidcprovider OIDCProviders) ResourceIdentifiers() []string {
+	return oidcprovider.ProviderARNs
+}
+
+func (oidcprovider OIDCProviders) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle. Note that OIDC Provider does not support bulk delete, so
+	// we will be deleting this many in parallel using go routines. We conservatively pick 10 here, both to limit
+	// overloading the runtime and to avoid AWS throttling with many API calls.
+	return 10
+}
+
+// Nuke - nuke 'em all!!!
+func (oidcprovider OIDCProviders) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllOIDCProviders(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	ECSCluster            ResourceType `yaml:"ECSCluster"`
 	Elasticache           ResourceType `yaml:"Elasticache"`
 	VPC                   ResourceType `yaml:"VPC"`
+	OIDCProvider          ResourceType `yaml:"OIDCProvider"`
 }
 
 type ResourceType struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,6 +26,7 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 


### PR DESCRIPTION
This adds IAM OpenID Connect Provider for nuking consideration. I implemented this to clean up residule OIDC providers in `phxdevops` since that caused us to reach AWS limits there in our testing.