### PR TITLE
Filter VPCs by name instead of VPC ID

### DIFF
--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -574,7 +574,7 @@ func NukeDefaultSecurityGroupRules(sgs []DefaultSecurityGroup) error {
 	return nil
 }
 
-// Given an map of tags, return the value of the Name tag
+// Given an slice of tags, return the value of the Name tag
 func GetEC2ResourceNameTagValue(tags []*ec2.Tag) (string, error) {
 	t := make(map[string]string)
 


### PR DESCRIPTION
Fixes #288 

* Move VPC tagging logic outside of filter function, allows for easier testing of `shouldIncludeVpc`
* Remove `TestListVpcsWithConfigFile`, replacing with `TestShouldIncludeVpc`. Table based unit tests are more efficient and can easily test several use cases at once. 