### PR TITLE
Ensure VPCEs are deleted before attempting to delete subnets

### DIFF
--- a/aws/ec2_unit_test.go
+++ b/aws/ec2_unit_test.go
@@ -113,6 +113,19 @@ func TestNukeMockVpcs(t *testing.T) {
 		detachInternetGatewayInput := getDetachInternetGatewayInput(vpc.VpcId, ExampleInternetGatewayId)
 		deleteInternetGatewayInput := getDeleteInternetGatewayInput(ExampleInternetGatewayId)
 
+		describeEndpointsInput := getDescribeEndpointsInput(vpc.VpcId)
+		describeEndpointsOutput := getDescribeEndpointsOutput([]string{ExampleEndpointId})
+		describeEndpointsFunc := func(input *ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {
+			return describeEndpointsOutput, nil
+		}
+		deleteEndpointInput := getDeleteEndpointInput(ExampleEndpointId)
+
+		describeEndpointsWaitForDeletionInput := getDescribeEndpointsWaitForDeletionInput(vpc.VpcId)
+		describeEndpointsWaitForDeletionOutput := getDescribeEndpointsOutput(nil)
+		describeEndpointsWaitForDeletionFunc := func(input *ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {
+			return describeEndpointsWaitForDeletionOutput, nil
+		}
+
 		describeSubnetsInput := getDescribeSubnetsInput(vpc.VpcId)
 		describeSubnetsOutput := getDescribeSubnetsOutput([]string{ExampleSubnetId, ExampleSubnetIdTwo, ExampleSubnetIdThree})
 		describeSubnetsFunc := func(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
@@ -143,19 +156,15 @@ func TestNukeMockVpcs(t *testing.T) {
 		}
 		deleteSecurityGroupInput := getDeleteSecurityGroupInput(ExampleSecurityGroupId)
 
-		describeEndpointsInput := getDescribeEndpointsInput(vpc.VpcId)
-		describeEndpointsOutput := getDescribeEndpointsOutput([]string{ExampleEndpointId})
-		describeEndpointsFunc := func(input *ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {
-			return describeEndpointsOutput, nil
-		}
-		deleteEndpointInput := getDeleteEndpointInput(ExampleEndpointId)
-
 		deleteVpcInput := getDeleteVpcInput(vpc.VpcId)
 
 		gomock.InOrder(
 			mockEC2.EXPECT().DescribeInternetGateways(describeInternetGatewaysInput).DoAndReturn(describeInternetGatewaysFunc),
 			mockEC2.EXPECT().DetachInternetGateway(detachInternetGatewayInput),
 			mockEC2.EXPECT().DeleteInternetGateway(deleteInternetGatewayInput),
+			mockEC2.EXPECT().DescribeVpcEndpoints(describeEndpointsInput).DoAndReturn(describeEndpointsFunc),
+			mockEC2.EXPECT().DeleteVpcEndpoints(deleteEndpointInput),
+			mockEC2.EXPECT().DescribeVpcEndpoints(describeEndpointsWaitForDeletionInput).DoAndReturn(describeEndpointsWaitForDeletionFunc),
 			mockEC2.EXPECT().DescribeSubnets(describeSubnetsInput).DoAndReturn(describeSubnetsFunc),
 			mockEC2.EXPECT().DeleteSubnet(deleteSubnetInputOne),
 			mockEC2.EXPECT().DeleteSubnet(deleteSubnetInputTwo),
@@ -166,8 +175,6 @@ func TestNukeMockVpcs(t *testing.T) {
 			mockEC2.EXPECT().DeleteNetworkAcl(deleteNetworkAclInput),
 			mockEC2.EXPECT().DescribeSecurityGroups(describeSecurityGroupsInput).DoAndReturn(describeSecurityGroupsFunc),
 			mockEC2.EXPECT().DeleteSecurityGroup(deleteSecurityGroupInput),
-			mockEC2.EXPECT().DescribeVpcEndpoints(describeEndpointsInput).DoAndReturn(describeEndpointsFunc),
-			mockEC2.EXPECT().DeleteVpcEndpoints(deleteEndpointInput),
 			mockEC2.EXPECT().DeleteVpc(deleteVpcInput),
 		)
 	}

--- a/aws/mock_ec2_utils_for_test.go
+++ b/aws/mock_ec2_utils_for_test.go
@@ -187,6 +187,21 @@ func getDescribeEndpointsInput(vpcId string) *ec2.DescribeVpcEndpointsInput {
 	}
 }
 
+func getDescribeEndpointsWaitForDeletionInput(vpcId string) *ec2.DescribeVpcEndpointsInput {
+	return &ec2.DescribeVpcEndpointsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   awsgo.String("vpc-id"),
+				Values: []*string{awsgo.String(vpcId)},
+			},
+			{
+				Name:   awsgo.String("vpc-endpoint-state"),
+				Values: []*string{awsgo.String("deleting")},
+			},
+		},
+	}
+}
+
 func getDescribeEndpointsOutput(endpointIds []string) *ec2.DescribeVpcEndpointsOutput {
 	var endpoints []*ec2.VpcEndpoint
 	for _, endpointId := range endpointIds {


### PR DESCRIPTION
Fixes #285.

- Moves VPCE deletion to before subnet deletion
- Adds `waitForVPCEndpointsToBeDeleted` to ensure Interface endpoints (which can take a few minutes to delete) are no longer in the 'deleting' state. Without this, the endpoints will be marked for deletion (`state=deleting`), but nuking the subnet immediately after will still fail with the same `DependencyViolation` error. Only when the VPCEs are `state=deleted` will the subnet nuke succeed.

## Testing
Scenario: 1 VPC with 5 VPCEs (x4 Interfaces, x1 gateway)

Output from `cloud-nuke aws --resource-type vpc` (v0.11.3):
```
[cloud-nuke] INFO[2022-04-10T10:37:51+01:00] The following 1 AWS resources will be nuked: 
[cloud-nuke] INFO[2022-04-10T10:37:51+01:00] * vpc vpc-0dcb3d0c8a63e90ff eu-west-2        
[cloud-nuke] INFO[2022-04-10T10:37:52+01:00] Terminating 1 resources in batches           
[cloud-nuke] INFO[2022-04-10T10:37:52+01:00] Deleting all VPCs                            
[cloud-nuke] INFO[2022-04-10T10:37:52+01:00] Nuking VPC vpc-0dcb3d0c8a63e90ff in region eu-west-2 
[cloud-nuke] INFO[2022-04-10T10:37:52+01:00] ...no Internet Gateway found                 
[cloud-nuke] INFO[2022-04-10T10:37:52+01:00] ...deleting subnet subnet-04b3fcbd2be872954  
[cloud-nuke] ERRO[2022-04-10T10:37:53+01:00] Error cleaning up Subnets for VPC vpc-0dcb3d0c8a63e90ff: DependencyViolation: The subnet 'subnet-04b3fcbd2be872954' has dependencies and cannot be deleted.
        status code: 400, request id: c42bdcb9-60bb-4cec-bd34-7e9c924ac7e9 
[cloud-nuke] ERRO[2022-04-10T10:37:53+01:00] [Failed] DependencyViolation: The subnet 'subnet-04b3fcbd2be872954' has dependencies and cannot be deleted.
        status code: 400, request id: c42bdcb9-60bb-4cec-bd34-7e9c924ac7e9 
[cloud-nuke] INFO[2022-04-10T10:37:53+01:00] [OK] 0 VPC terminated
```

Output from running `go run main.go -- aws --resource-type vpc` from this branch:
```
[cloud-nuke] INFO[2022-04-10T10:39:27+01:00] The following 1 AWS resources will be nuked: 
[cloud-nuke] INFO[2022-04-10T10:39:27+01:00] * vpc vpc-0dcb3d0c8a63e90ff eu-west-2
[cloud-nuke] INFO[2022-04-10T10:39:28+01:00] Terminating 1 resources in batches           
[cloud-nuke] INFO[2022-04-10T10:39:28+01:00] Deleting all VPCs                            
[cloud-nuke] INFO[2022-04-10T10:39:28+01:00] Nuking VPC vpc-0dcb3d0c8a63e90ff in region eu-west-2 
[cloud-nuke] INFO[2022-04-10T10:39:29+01:00] ...no Internet Gateway found                 
[cloud-nuke] INFO[2022-04-10T10:39:29+01:00] ...deleting VPC endpoint vpce-0356fe4f7f58db326 
[cloud-nuke] INFO[2022-04-10T10:39:29+01:00] ...deleting VPC endpoint vpce-0924979afb92c2cff 
[cloud-nuke] INFO[2022-04-10T10:39:29+01:00] ...deleting VPC endpoint vpce-02dcf936328226fb8 
[cloud-nuke] INFO[2022-04-10T10:39:29+01:00] ...deleting VPC endpoint vpce-0206a20fdfd31dcda 
[cloud-nuke] INFO[2022-04-10T10:39:29+01:00] ...deleting VPC endpoint vpce-0a41f1cef857e1914 
[cloud-nuke] INFO[2022-04-10T10:42:50+01:00] ...deleting subnet subnet-04b3fcbd2be872954  
[cloud-nuke] INFO[2022-04-10T10:42:50+01:00] ...deleting Security Group sg-000f57040831d869a 
[cloud-nuke] INFO[2022-04-10T10:42:51+01:00] ...deleting Security Group sg-013735c91727e2980
...
[cloud-nuke] INFO[2022-04-10T10:42:52+01:00] ...deleting VPC vpc-0dcb3d0c8a63e90ff        
[cloud-nuke] INFO[2022-04-10T10:42:52+01:00] Deleted VPC: vpc-0dcb3d0c8a63e90ff           
[cloud-nuke] INFO[2022-04-10T10:42:52+01:00] [OK] 1 VPC terminated
```

`go test -run TestNukeMockVpcs` => Passed
`go test -run TestNukeVpcs` => Passed