### PR TITLE
Delete s3 BucketPolicy before nuke Bucket to avoid errors when policy… 

### DIFF
--- a/aws/s3_test.go
+++ b/aws/s3_test.go
@@ -651,7 +651,7 @@ func TestFilterS3Bucket_Config(t *testing.T) {
 
 // TestNukeS3BucketWithBucketPolicy tests deletion of S3 buckets with a policy that denies deletion
 func TestNukeS3BucketWithBucketPolicy(t *testing.T) {
-	awsParams, err := newS3TestAWSParams("eu-central-1")
+	awsParams, err := newS3TestAWSParams("")
 	require.NoError(t, err, "Failed to setup AWS params")
 
 	// Create test bucket


### PR DESCRIPTION
… refuses deletion

This fixes a bug where you run into the problem when deleting s3 buckets but they have a bucket policy that prohibits deleting the entire bucket. 

The fix ensures that the bucket policy is cleared before attempting to delete the bucket.

Solves the Issue #213