### PR TITLE
Add config support for EKS and exclude ghost cluster in our account

### DIFF
--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -40,6 +40,12 @@ OIDCProvider:
       # We have an active OIDC Provider used by github actions
       - ".*token.actions.githubusercontent.com.*"
 
+EKSCluster:
+  exclude:
+    names_regex:
+      # This EKS cluster is a ghost cluster in our account in the ap-southeast-1 region that can not be deleted.
+      - "^cloud-nuke-TestListEksClusters-o8DrEi$"
+
 CloudWatchLogGroup:
   # Use an allow list instead of block list because we haven't done the due diligence yet to figure out what log groups
   # we need to keep. This is hard to do in the current scenario as we have thousands of log groups in the accounts.

--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ The following resources support the Config file:
 - EC2 Instances
     - Resource type: `ec2`
     - Config key: `EC2`
+- EKS Clusters
+    - Resource type: `ekscluster`
+    - Config key: `EKSCluster`
 
 #### Example
 
@@ -302,30 +305,31 @@ To find out what we options are supported in the config file today, consult this
 
 | resource type      | names | names_regex | tags | tags_regex |
 |--------------------|-------|-------------|------|------------|
-| s3                 | none  | ✅          | none | none       |
-| iam                | none  | ✅          | none | none       |
-| ecsserv            | none  | ✅          | none | none       |
-| ecscluster         | none  | ✅          | none | none       |
-| secretsmanager     | none  | ✅          | none | none       |
-| nat-gateway        | none  | ✅          | none | none       |
-| accessanalyzer     | none  | ✅          | none | none       |
-| dynamodb           | none  | ✅          | none | none       |
-| ebs                | none  | ✅          | none | none       |
-| lambda             | none  | ✅          | none | none       |
-| elbv2              | none  | ✅          | none | none       |
-| ecs                | none  | ✅          | none | none       |
-| elasticache        | none  | ✅          | none | none       |
-| vpc                | none  | ✅          | none | none       |
-| oidcprovider       | none  | ✅          | none | none       |
-| cloudwatch-loggroup | none  | ✅          | none | none       |
-| kmscustomerkeys     | none  | ✅          | none | none       |
-| asg                | none  | ✅          | none | none       |
-| lc                 | none  | ✅          | none | none       |
-| eip                | none  | ✅          | none | none       |
-| ec2                | none  | ✅          | none | none       |
-| acmpca             | none  | none        | none | none       |
-| iam role           | none  | none        | none | none       |
-| ... (more to come) | none  | none        | none | none       |
+| s3                  | none | ✅   | none | none |
+| iam                 | none | ✅   | none | none |
+| ecsserv             | none | ✅   | none | none |
+| ecscluster          | none | ✅   | none | none |
+| secretsmanager      | none | ✅   | none | none |
+| nat-gateway         | none | ✅   | none | none |
+| accessanalyzer      | none | ✅   | none | none |
+| dynamodb            | none | ✅   | none | none |
+| ebs                 | none | ✅   | none | none |
+| lambda              | none | ✅   | none | none |
+| elbv2               | none | ✅   | none | none |
+| ecs                 | none | ✅   | none | none |
+| elasticache         | none | ✅   | none | none |
+| vpc                 | none | ✅   | none | none |
+| oidcprovider        | none | ✅   | none | none |
+| cloudwatch-loggroup | none | ✅   | none | none |
+| kmscustomerkeys     | none | ✅   | none | none |
+| asg                 | none | ✅   | none | none |
+| lc                  | none | ✅   | none | none |
+| eip                 | none | ✅   | none | none |
+| ec2                 | none | ✅   | none | none |
+| eks                 | none | ✅   | none | none |
+| acmpca              | none | none | none | none |
+| iam role            | none | none | none | none |
+| ... (more to come)  | none | none | none | none |
 
 
 

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -502,7 +502,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		// EKS resources
 		eksClusters := EKSClusters{}
 		if IsNukeable(eksClusters.ResourceName(), resourceTypes) {
-			eksClusterNames, err := getAllEksClusters(session, excludeAfter)
+			eksClusterNames, err := getAllEksClusters(session, excludeAfter, configObj)
 			if err != nil {
 				return nil, errors.WithStackTrace(err)
 			}

--- a/aws/eks_test.go
+++ b/aws/eks_test.go
@@ -14,12 +14,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	// Exclude ap-southeast-1, which currently has a ghost EKS cluster that messes cloud-nuke up.
+	excludeRegionsForEKSTest = []string{"ap-southeast-1"}
+)
+
 // Test that we can successfully list clusters by manually creating a cluster, and then using the list function to find
 // it.
 func TestListEksClusters(t *testing.T) {
 	t.Parallel()
 
-	region, err := getRandomRegion()
+	region, err := getRandomRegionWithExclusions(excludeRegionsForEKSTest)
 	require.NoError(t, err)
 
 	awsSession, err := session.NewSession(&awsgo.Config{
@@ -53,7 +58,7 @@ func TestListEksClusters(t *testing.T) {
 func TestNukeEksClusters(t *testing.T) {
 	t.Parallel()
 
-	region, err := getRandomRegion()
+	region, err := getRandomRegionWithExclusions(excludeRegionsForEKSTest)
 	require.NoError(t, err)
 
 	awsSession, err := session.NewSession(&awsgo.Config{
@@ -79,7 +84,7 @@ func TestNukeEksClusters(t *testing.T) {
 func TestNukeEksClustersWithCompute(t *testing.T) {
 	t.Parallel()
 
-	region, err := getRandomRegion()
+	region, err := getRandomRegionWithExclusions(excludeRegionsForEKSTest)
 	require.NoError(t, err)
 
 	awsSession, err := session.NewSession(&awsgo.Config{

--- a/aws/eks_test.go
+++ b/aws/eks_test.go
@@ -7,6 +7,7 @@ import (
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/stretchr/testify/assert"
@@ -34,13 +35,13 @@ func TestListEksClusters(t *testing.T) {
 	cluster := createEKSCluster(t, awsSession, uniqueID, *role.Arn)
 	defer nukeAllEksClusters(awsSession, []*string{cluster.Name})
 
-	eksClusterNames, err := getAllEksClusters(awsSession, time.Now().Add(1*time.Hour*-1))
+	eksClusterNames, err := getAllEksClusters(awsSession, time.Now().Add(1*time.Hour*-1), config.Config{})
 	if err != nil {
 		assert.Failf(t, "Unable to fetch list of clusters: %s", err.Error())
 	}
 	assert.NotContains(t, awsgo.StringValueSlice(eksClusterNames), *cluster.Name)
 
-	eksClusterNames, err = getAllEksClusters(awsSession, time.Now().Add(1*time.Hour))
+	eksClusterNames, err = getAllEksClusters(awsSession, time.Now().Add(1*time.Hour), config.Config{})
 	if err != nil {
 		assert.Failf(t, "Unable to fetch list of clusters: %s", err.Error())
 	}
@@ -69,7 +70,7 @@ func TestNukeEksClusters(t *testing.T) {
 	err = nukeAllEksClusters(awsSession, []*string{cluster.Name})
 	require.NoError(t, err)
 
-	eksClusterNames, err := getAllEksClusters(awsSession, time.Now().Add(1*time.Hour))
+	eksClusterNames, err := getAllEksClusters(awsSession, time.Now().Add(1*time.Hour), config.Config{})
 	require.NoError(t, err)
 	assert.NotContains(t, awsgo.StringValueSlice(eksClusterNames), *cluster.Name)
 }
@@ -121,7 +122,7 @@ func TestNukeEksClustersWithCompute(t *testing.T) {
 	err = nukeAllEksClusters(awsSession, []*string{cluster.Name})
 	require.NoError(t, err)
 
-	eksClusterNames, err := getAllEksClusters(awsSession, time.Now().Add(1*time.Hour))
+	eksClusterNames, err := getAllEksClusters(awsSession, time.Now().Add(1*time.Hour), config.Config{})
 	require.NoError(t, err)
 	assert.NotContains(t, awsgo.StringValueSlice(eksClusterNames), *cluster.Name)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	EC2                   ResourceType `yaml:"EC2"`
 	CloudWatchLogGroup    ResourceType `yaml:"CloudWatchLogGroup"`
 	KMSCustomerKeys       ResourceType `yaml:"KMSCustomerKeys"`
+	EKSCluster            ResourceType `yaml:"EKSCluster"`
 }
 
 type ResourceType struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,6 +33,7 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 


### PR DESCRIPTION
In our account where we are running `cloud-nuke`, we have a ghost EKS cluster that shows up in the list API, but will return a 404 if you try to get the details. This EKS cluster will presumably be garbage collected by AWS eventually, but in the meantime, it causes problems by halting execution of `cloud-nuke` everytime it tries to nuke our account.

This PR works around this limitation by adding config support to EKS cluster nuking, and adding an explicit exclude rule to ignore the ghost cluster.