### PR TITLE
Extend cloud-nuke with non-destructive inspect command & library methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,7 @@ Dry run mode is only available within:
 
 You can import cloud-nuke into other projects and use it as a library for programmatically inspecting and counting resources. 
 
-
-```golang
+```golang 
 package main
 
 import (
@@ -206,6 +205,7 @@ func main() {
 
 	// You can scan multiple regions at once, or just pass a single region for speed
 	targetRegions := []string{"us-east-1", "us-west-1", "us-west-2"}
+	excludeRegions := []string{}
 	// You can simultaneously target multiple resource types as well
 	resourceTypes := []string{"ec2", "vpc"}
 	excludeResourceTypes := []string{}
@@ -215,6 +215,7 @@ func main() {
 	// NewQuery is a convenience method for configuring parameters you want to pass to your resource search
 	query, err := nuke_aws.NewQuery(
 		targetRegions,
+		excludeRegions,
 		resourceTypes,
 		excludeResourceTypes,
 		excludeAfter,
@@ -224,7 +225,8 @@ func main() {
 		fmt.Println(err)
 	}
 
-  // Submit our query to cloud-nuke and scan the account
+	// InspectResources still returns *AwsAccountResources, but this struct has been extended with several
+	// convenience methods for quickly determining if resources exist in a given region
 	accountResources, err := nuke_aws.InspectResources(query)
 	if err != nil {
 		fmt.Println(err)
@@ -233,7 +235,7 @@ func main() {
 	// You can call GetRegion to examine a single region's resources
 	usWest1Resources := accountResources.GetRegion("us-west-1")
 
-	// Then further narrow your results by region or resource type 
+	// Then interrogate them with the new methods:
 
 	// Count the number of any resource type within the region
 	countOfEc2InUsWest1 := usWest1Resources.CountOfResourceType("ec2")
@@ -241,18 +243,19 @@ func main() {
 	fmt.Printf("countOfEc2InUsWest1: %d\n", countOfEc2InUsWest1)
 	// countOfEc2InUsWest1: 2
 
-	fmt.Printf("usWest1Resources.ResourceTypePresent(\"ec2\"): %b", usWest1Resources.ResourceTypePresent("ec2"))
+	fmt.Printf("usWest1Resources.ResourceTypePresent(\"ec2\"):%b\n", usWest1Resources.ResourceTypePresent("ec2"))
 	//usWest1Resources.ResourceTypePresent("ec2"): true
 
 	// Get all the resource identifiers for a given resource type
 	// In this example, we're only looking for ec2 instances
 	resourceIds := usWest1Resources.IdentifiersForResourceType("ec2")
 
-	fmt.Printf("resourceIds: ", resourceIds)
+	fmt.Printf("resourceIds: %s", resourceIds)
 	// resourceIds:  [i-0c5d16c3ef28dda24 i-09d9739e1f4d27814]
 
 }
 ```
+
 
 ### Config file
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	nuke_aws "github.com/gruntwork-io/cloud-nuke/aws"
 )
@@ -210,7 +211,7 @@ func main() {
 	resourceTypes := []string{"ec2", "vpc"}
 	excludeResourceTypes := []string{}
 	// excludeAfter is parsed identically to the --older-than flag
-	excludeAfter := "1h"
+	excludeAfter := time.Now()
 
 	// NewQuery is a convenience method for configuring parameters you want to pass to your resource search
 	query, err := nuke_aws.NewQuery(

--- a/README.md
+++ b/README.md
@@ -4,41 +4,43 @@
 
 This repo contains a CLI tool to delete all resources in an AWS account. cloud-nuke was created for situations when you might have an account you use for testing and need to clean up leftover resources so you're not charged for them. Also great for cleaning out accounts with redundant resources. Also great for removing unnecessary defaults like default VPCs and permissive ingress/egress rules in default security groups.
 
+In addition, cloud-nuke offers non-destructive inspecting functionality that can either be called via the command-line interface, or consumed as library methods, for scripting purposes.
+ 
 The currently supported functionality includes:
 
 ## AWS
 
-- Deleting all ACM Private CA in an AWS account
-- Deleting all Auto scaling groups in an AWS account
-- Deleting all Elastic Load Balancers (Classic and V2) in an AWS account
-- Deleting all Transit Gateways in an AWS account
-- Deleting all EBS Volumes in an AWS account
-- Deleting all unprotected EC2 instances in an AWS account
-- Deleting all AMIs in an AWS account
-- Deleting all Snapshots in an AWS account
-- Deleting all Elastic IPs in an AWS account
-- Deleting all Elasticache clusters in an AWS account
-- Deleting all Launch Configurations in an AWS account
-- Deleting all ECS services in an AWS account
-- Deleting all ECS clusters in an AWS account
-- Deleting all EKS clusters in an AWS account
-- Deleting all RDS DB instances in an AWS account
-- Deleting all Lambda Functions in an AWS account
-- Deleting all SQS queues in an AWS account
-- Deleting all S3 buckets in an AWS account - except for buckets tagged with Key=cloud-nuke-excluded Value=true
-- Deleting all default VPCs in an AWS account
+- Inspecting and deleting all ACM Private CA in an AWS account
+- Inspecting and deleting all Auto scaling groups in an AWS account
+- Inspecting and deleting all Elastic Load Balancers (Classic and V in an AWS account
+- Inspecting and deleting all Transit Gateways in an AWS account
+- Inspecting and deleting all EBS Volumes in an AWS account
+- Inspecting and deleting all unprotected EC2 instances in an AWS account
+- Inspecting and deleting all AMIs in an AWS account
+- Inspecting and deleting all Snapshots in an AWS account
+- Inspecting and deleting all Elastic IPs in an AWS account
+- Inspecting and deleting all Elasticache clusters in an AWS account
+- Inspecting and deleting all Launch Configurations in an AWS account
+- Inspecting and deleting all ECS services in an AWS account
+- Inspecting and deleting all ECS clusters in an AWS account
+- Inspecting and deleting all EKS clusters in an AWS account
+- Inspecting and deleting all RDS DB instances in an AWS account
+- Inspecting and deleting all Lambda Functions in an AWS account
+- Inspecting and deleting all SQS queues in an AWS account
+- Inspecting and deleting all S3 buckets in an AWS account - except for buckets tagged with Key=cloud-nuke-excluded Value=true
+- Inspecting and deleting all default VPCs in an AWS account
 - Deleting VPCs in an AWS Account (except for default VPCs which is handled by the dedicated `defaults-aws` subcommand)
-- Deleting all IAM users in an AWS account
-- Deleting all Secrets Manager Secrets in an AWS account
-- Deleting all NAT Gateways in an AWS account
-- Deleting all IAM Access Analyzers in an AWS account
+- Inspecting and deleting all IAM users in an AWS account
+- Inspecting and deleting all Secrets Manager Secrets in an AWS account
+- Inspecting and deleting all NAT Gateways in an AWS account
+- Inspecting and deleting all IAM Access Analyzers in an AWS account
 - Revoking the default rules in the un-deletable default security group of a VPC
-- Deleting all DynamoDB tables in an AWS account
-- Deleting all CloudWatch Dashboards in an AWS account
-- Deleting all OpenSearch Domains in an AWS account
-- Deleting all IAM OpenID Connect Providers
-- Deleting all Customer managed keys from Key Management Service in an AWS account
-- Deleting all CloudWatch Log Groups in an AWS Account
+- Inspecting and deleting all DynamoDB tables in an AWS account
+- Inspecting and deleting all CloudWatch Dashboards in an AWS account
+- Inspecting and deleting all OpenSearch Domains in an AWS account
+- Inspecting and deleting all IAM OpenID Connect Providers
+- Inspecting and deleting all Customer managed keys from Key Management Service in an AWS account
+- Inspecting and deleting all CloudWatch Log Groups in an AWS Account
 
 ### BEWARE!
 
@@ -69,27 +71,44 @@ Simply running `cloud-nuke aws` will start the process of cleaning up your cloud
 
 In AWS, to delete only the default resources, run `cloud-nuke defaults-aws`. This will remove the default VPCs in each region, and will also revoke the ingress and egress rules associated with the default security group in each VPC. Note that the default security group itself is unable to be deleted.
 
-### Nuke resources in certain regions
+### Nuke or inspect resources in certain regions
 
-When using `cloud-nuke aws`, you can use the `--region` flag to target resources in certain regions for deletion. For example the following command will nuke resources only in `ap-south-1` and `ap-south-2` regions:
+When using `cloud-nuke aws`, or `cloud-nuke inspect-aws`, you can use the `--region` flag to target resources in certain regions. For example the following command will nuke resources only in `ap-south-1` and `ap-south-2` regions:
 
 ```shell
 cloud-nuke aws --region ap-south-1 --region ap-south-2
 ```
 
-Including regions is available within both `cloud-nuke aws` and with `cloud-nuke defaults-aws`.
+Similarly, the following command will inspect resources only in `us-east-1` 
+```shell
+cloud-nuke inspect-aws --region us-east-1
+```
+
+Including regions is available within: 
+- `cloud-nuke aws` 
+- `cloud-nuke defaults-aws`
+- `cloud-nuke inspect-aws`
 
 ### Exclude resources in certain regions
 
-When using `cloud-nuke aws`, you can use the `--exclude-region` flag to exclude resources in certain regions from being deleted. For example the following command does not nuke resources in `ap-south-1` and `ap-south-2` regions:
+When using `cloud-nuke aws` or `cloud-nuke inspect-aws`, you can use the `--exclude-region` flag to exclude resources in certain regions from being deleted or inspected. For example the following command does not nuke resources in `ap-south-1` and `ap-south-2` regions:
 
 ```shell
 cloud-nuke aws --exclude-region ap-south-1 --exclude-region ap-south-2
 ```
 
+Similarly, the following command will not inspect resources in the `us-west-1` region:
+
+```shell
+cloud-nuke inspect-aws --exclude-region us-west-1
+```
+
 `--region` and `--exclude-region` flags cannot be specified together i.e. they are mutually exclusive.
 
-Excluding regions is available within both `cloud-nuke aws` and with `cloud-nuke defaults-aws`.
+Excluding regions is available within: 
+- `cloud-nuke aws` 
+- `cloud-nuke defaults-aws`
+- `cloud-nuke inspect-aws`
 
 ### Excluding Resources by Age
 
@@ -99,6 +118,11 @@ You can use the `--older-than` flag to only nuke resources that were created bef
 cloud-nuke aws --older-than 24h
 ```
 
+Excluding resources by age is available within: 
+- `cloud-nuke aws` 
+- `cloud-nuke inspect-aws`
+
+
 ### List supported resource types
 
 You can use the `--list-resource-types` flag to list resource types whose termination is currently supported:
@@ -107,7 +131,12 @@ You can use the `--list-resource-types` flag to list resource types whose termin
 cloud-nuke aws --list-resource-types
 ```
 
-### Terminate specific resource types
+Listing supported resource types is available within: 
+- `cloud-nuke aws` 
+- `cloud-nuke inspect-aws`
+
+
+### Terminate or inspect specific resource types
 
 If you want to target specific resource types (e.g ec2, ami, etc.) instead of all the supported resources you can
 do so by specifying them through the `--resource-type` flag:
@@ -119,6 +148,16 @@ cloud-nuke aws --resource-type ec2 --resource-type ami
 will search and target only `ec2` and `ami` resources. The specified resource type should be a valid resource type
 i.e. it should be present in the `--list-resource-types` output. Using `--resource-type` also speeds up search because
 we are searching only for specific resource types.
+
+Similarly, the following command will inspect only ec2 instances: 
+
+```shell
+cloud-nuke inspect-aws --resource-type ec2
+```
+
+Specifying target resource types is available within: 
+- `cloud-nuke aws` 
+- `cloud-nuke inspect-aws`
 
 ### Exclude terminating specific resource types
 
@@ -133,6 +172,10 @@ This will terminate all resource types other than S3 and EC2.
 
 `--resource-type` and `--exclude-resource-type` flags cannot be specified together i.e. they are mutually exclusive.
 
+Specifying resource types to exclude is available within: 
+- `cloud-nuke aws` 
+- `cloud-nuke inspect-aws`
+
 ### Dry run mode
 
 If you want to check what resources are going to be targeted without actually terminating them, you can use the
@@ -140,6 +183,75 @@ If you want to check what resources are going to be targeted without actually te
 
 ```shell
 cloud-nuke aws --resource-type ec2 --dry-run
+```
+
+Dry run mode is only available within: 
+- `cloud-nuke aws`
+
+### Using cloud-nuke as a library
+
+You can import cloud-nuke into other projects and use it as a library for programmatically inspecting and counting resources. 
+
+
+```golang
+package main
+
+import (
+	"fmt"
+
+	nuke_aws "github.com/gruntwork-io/cloud-nuke/aws"
+)
+
+func main() {
+
+	// You can scan multiple regions at once, or just pass a single region for speed
+	targetRegions := []string{"us-east-1", "us-west-1", "us-west-2"}
+	// You can simultaneously target multiple resource types as well
+	resourceTypes := []string{"ec2", "vpc"}
+	excludeResourceTypes := []string{}
+	// excludeAfter is parsed identically to the --older-than flag
+	excludeAfter := "1h"
+
+	// NewQuery is a convenience method for configuring parameters you want to pass to your resource search
+	query, err := nuke_aws.NewQuery(
+		targetRegions,
+		resourceTypes,
+		excludeResourceTypes,
+		excludeAfter,
+	)
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+  // Submit our query to cloud-nuke and scan the account
+	accountResources, err := nuke_aws.InspectResources(query)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// You can call GetRegion to examine a single region's resources
+	usWest1Resources := accountResources.GetRegion("us-west-1")
+
+	// Then further narrow your results by region or resource type 
+
+	// Count the number of any resource type within the region
+	countOfEc2InUsWest1 := usWest1Resources.CountOfResourceType("ec2")
+
+	fmt.Printf("countOfEc2InUsWest1: %d\n", countOfEc2InUsWest1)
+	// countOfEc2InUsWest1: 2
+
+	fmt.Printf("usWest1Resources.ResourceTypePresent(\"ec2\"): %b", usWest1Resources.ResourceTypePresent("ec2"))
+	//usWest1Resources.ResourceTypePresent("ec2"): true
+
+	// Get all the resource identifiers for a given resource type
+	// In this example, we're only looking for ec2 instances
+	resourceIds := usWest1Resources.IdentifiersForResourceType("ec2")
+
+	fmt.Printf("resourceIds: ", resourceIds)
+	// resourceIds:  [i-0c5d16c3ef28dda24 i-09d9739e1f4d27814]
+
+}
 ```
 
 ### Config file

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -781,6 +781,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 	return &account, nil
 }
 
+// ListResourceTypes - Returns list of resources which can be passed to --resource-type
 func ListResourceTypes() []string {
 	resourceTypes := []string{
 		ACMPCA{}.ResourceName(),

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -781,7 +781,6 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 	return &account, nil
 }
 
-// ListResourceTypes - Returns list of resources which can be passed to --resource-type
 func ListResourceTypes() []string {
 	resourceTypes := []string{
 		ACMPCA{}.ResourceName(),
@@ -893,6 +892,7 @@ func NukeAllResources(account *AwsAccountResources, regions []string) error {
 		if err != nil {
 			return errors.WithStackTrace(err)
 		}
+
 	}
 
 	return nil

--- a/aws/inspect.go
+++ b/aws/inspect.go
@@ -106,7 +106,6 @@ func InspectResources(q Query) (*AwsAccountResources, error) {
 		return account, err
 	}
 
-	// We're currently short-circuiting the config file by passing an empty config here,
-	// but the inspect functionalty does not currently support the config file
+	// NOTE: The inspect functionality currently does not support config file, so we short circuit the logic with an empty struct.
 	return GetAllResources(q.Regions, q.ExcludeAfter, resourceTypes, config.Config{})
 }

--- a/aws/inspect.go
+++ b/aws/inspect.go
@@ -1,0 +1,113 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/go-commons/collections"
+)
+
+// ExtractResourcesForPrinting is a convenience method that converts the nested structure of AwsAccountResources
+// into a flat slice of resource identifiers, well-suited for printing line by line
+func ExtractResourcesForPrinting(account *AwsAccountResources) []string {
+	var resources []string
+
+	if len(account.Resources) == 0 {
+		logging.Logger.Infoln("No resources found!")
+		return resources
+	}
+
+	resources = make([]string, 0)
+	for region, resourcesInRegion := range account.Resources {
+		for _, foundResources := range resourcesInRegion.Resources {
+			for _, identifier := range foundResources.ResourceIdentifiers() {
+				resources = append(resources, fmt.Sprintf("* %s %s %s\n", foundResources.ResourceName(), identifier, region))
+			}
+		}
+	}
+
+	return resources
+}
+
+func ensureValidResourceTypes(resourceTypes, excludeResourceTypes, allResourceTypes []string) ([]string, error) {
+
+	invalidresourceTypes := []string{}
+	for _, resourceType := range resourceTypes {
+		if resourceType == "all" {
+			continue
+		}
+		if !IsValidResourceType(resourceType, allResourceTypes) {
+			invalidresourceTypes = append(invalidresourceTypes, resourceType)
+		}
+	}
+
+	for _, resourceType := range excludeResourceTypes {
+		if !IsValidResourceType(resourceType, allResourceTypes) {
+			invalidresourceTypes = append(invalidresourceTypes, resourceType)
+		}
+	}
+
+	if len(invalidresourceTypes) > 0 {
+		return []string{}, InvalidResourceTypesSuppliedError{InvalidTypes: invalidresourceTypes}
+	}
+
+	return resourceTypes, nil
+}
+
+func HandleResourceTypeSelections(resourceTypes, excludeResourceTypes []string) ([]string, error) {
+	if len(resourceTypes) > 0 && len(excludeResourceTypes) > 0 {
+		return []string{}, ResourceTypeAndExcludeFlagsBothPassedError{}
+	}
+	// Ensure only selected resource types are being targeted
+	allResourceTypes := ListResourceTypes()
+
+	validResourceTypes, err := ensureValidResourceTypes(resourceTypes, excludeResourceTypes, allResourceTypes)
+	if err != nil {
+		return validResourceTypes, err
+	}
+
+	// Handle exclude resource types by going through the list of all types and only include those that are not
+	// mentioned in the exclude list.
+	if len(excludeResourceTypes) > 0 {
+		for _, resourceType := range allResourceTypes {
+			if !collections.ListContainsElement(excludeResourceTypes, resourceType) {
+				resourceTypes = append(resourceTypes, resourceType)
+			}
+		}
+	}
+
+	return resourceTypes, nil
+}
+
+func InspectResources(q Query) (*AwsAccountResources, error) {
+
+	account := &AwsAccountResources{
+		Resources: make(map[string]AwsRegionResource),
+	}
+
+	resourceTypes, err := HandleResourceTypeSelections(q.ResourceTypes, q.ExcludeResourceTypes)
+	if err != nil {
+		return account, err
+	}
+
+	// Log which resource types will be inspected
+	logging.Logger.Info("The following resource types will be scanned for (inspected):")
+	if len(resourceTypes) > 0 {
+		for _, resourceType := range resourceTypes {
+			logging.Logger.Infof("- %s", resourceType)
+		}
+	} else {
+		for _, resourceType := range ListResourceTypes() {
+			logging.Logger.Infof("- %s", resourceType)
+		}
+	}
+
+	if err != nil {
+		return account, err
+	}
+
+	// We're currently short-circuiting the config file by passing an empty config here,
+	// but the inspect functionalty does not currently support the config file
+	return GetAllResources(q.Regions, q.ExcludeAfter, resourceTypes, config.Config{})
+}

--- a/aws/inspect.go
+++ b/aws/inspect.go
@@ -81,19 +81,10 @@ func HandleResourceTypeSelections(resourceTypes, excludeResourceTypes []string) 
 
 func InspectResources(q Query) (*AwsAccountResources, error) {
 
-	account := &AwsAccountResources{
-		Resources: make(map[string]AwsRegionResource),
-	}
-
-	resourceTypes, err := HandleResourceTypeSelections(q.ResourceTypes, q.ExcludeResourceTypes)
-	if err != nil {
-		return account, err
-	}
-
 	// Log which resource types will be inspected
-	logging.Logger.Info("The following resource types will be scanned for (inspected):")
-	if len(resourceTypes) > 0 {
-		for _, resourceType := range resourceTypes {
+	logging.Logger.Info("The following resource types will be inspected:")
+	if len(q.ResourceTypes) > 0 {
+		for _, resourceType := range q.ResourceTypes {
 			logging.Logger.Infof("- %s", resourceType)
 		}
 	} else {
@@ -102,10 +93,6 @@ func InspectResources(q Query) (*AwsAccountResources, error) {
 		}
 	}
 
-	if err != nil {
-		return account, err
-	}
-
 	// NOTE: The inspect functionality currently does not support config file, so we short circuit the logic with an empty struct.
-	return GetAllResources(q.Regions, q.ExcludeAfter, resourceTypes, config.Config{})
+	return GetAllResources(q.Regions, q.ExcludeAfter, q.ResourceTypes, config.Config{})
 }

--- a/aws/inspect.go
+++ b/aws/inspect.go
@@ -55,6 +55,8 @@ func ensureValidResourceTypes(resourceTypes, excludeResourceTypes, allResourceTy
 	return resourceTypes, nil
 }
 
+// HandleResourcrTypeSelections accepts a slice of target resourceTypes and a slice of resourceTypes to exclude. It filters
+// any excluded or invalid types from target resourceTypes then returns the filtered slice
 func HandleResourceTypeSelections(resourceTypes, excludeResourceTypes []string) ([]string, error) {
 	if len(resourceTypes) > 0 && len(excludeResourceTypes) > 0 {
 		return []string{}, ResourceTypeAndExcludeFlagsBothPassedError{}

--- a/aws/inspect.go
+++ b/aws/inspect.go
@@ -79,7 +79,7 @@ func HandleResourceTypeSelections(resourceTypes, excludeResourceTypes []string) 
 	return resourceTypes, nil
 }
 
-func InspectResources(q Query) (*AwsAccountResources, error) {
+func InspectResources(q *Query) (*AwsAccountResources, error) {
 
 	// Log which resource types will be inspected
 	logging.Logger.Info("The following resource types will be inspected:")

--- a/aws/inspect_test.go
+++ b/aws/inspect_test.go
@@ -1,0 +1,93 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleResourceTypeSelectionsRejectsInvalid(t *testing.T) {
+	type TestCase struct {
+		Name                 string
+		ResourceTypes        []string
+		ExcludeResourceTypes []string
+		Want                 []string
+		Error                InvalidResourceTypesSuppliedError
+	}
+
+	testCases := []TestCase{
+		{
+			Name:                 "Invalid resource type is rejected",
+			ResourceTypes:        []string{"invalid_resource"},
+			ExcludeResourceTypes: []string{},
+			Want:                 []string{},
+			Error:                InvalidResourceTypesSuppliedError{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, err := HandleResourceTypeSelections(tc.ResourceTypes, tc.ExcludeResourceTypes)
+			require.Error(t, err)
+			require.ErrorAs(t, err, &tc.Error)
+		})
+	}
+
+}
+
+func TestHandleResourceTypeSelectionsRejectsConflictingParams(t *testing.T) {
+	type TestCase struct {
+		Name                 string
+		ResourceTypes        []string
+		ExcludeResourceTypes []string
+		Want                 []string
+		Error                ResourceTypeAndExcludeFlagsBothPassedError
+	}
+
+	testCases := []TestCase{
+		{
+			Name:                 "Valid resources and valid excludes result in filtering",
+			ResourceTypes:        []string{"ec2", "s3", "lambda"},
+			ExcludeResourceTypes: []string{"ec2"},
+			Want:                 []string{},
+			Error:                ResourceTypeAndExcludeFlagsBothPassedError{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, err := HandleResourceTypeSelections(tc.ResourceTypes, tc.ExcludeResourceTypes)
+			require.Error(t, err)
+			require.ErrorAs(t, err, &tc.Error)
+		})
+	}
+
+}
+
+func TestHandleResourceTypeSelectionsFiltering(t *testing.T) {
+	type TestCase struct {
+		Name                 string
+		ResourceTypes        []string
+		ExcludeResourceTypes []string
+		Want                 []string
+	}
+
+	testCases := []TestCase{{
+		Name:                 "Valid resource types are accepted",
+		ResourceTypes:        []string{"ec2", "vpc"},
+		ExcludeResourceTypes: []string{},
+		Want:                 []string{"ec2", "vpc"},
+	},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			got, err := HandleResourceTypeSelections(tc.ResourceTypes, tc.ExcludeResourceTypes)
+			require.NoError(t, err)
+			if !reflect.DeepEqual(got, tc.Want) {
+				t.Logf("%s: Expected %v but got %v", tc.Name, tc.Want, got)
+				t.Fail()
+			}
+		})
+	}
+}

--- a/aws/types.go
+++ b/aws/types.go
@@ -82,25 +82,15 @@ type Query struct {
 }
 
 // NewQuery configures and returns a Query struct that can be passed into the InspectResources method
-func NewQuery(regions, excludeRegions, resourceTypes, excludeResourceTypes []string, excludeAfter string) (Query, error) {
+func NewQuery(regions, excludeRegions, resourceTypes, excludeResourceTypes []string, excludeAfter time.Time) (*Query, error) {
 
-	q := Query{
+	q := &Query{
 		Regions:              regions,
 		ExcludeRegions:       excludeRegions,
 		ResourceTypes:        resourceTypes,
 		ExcludeResourceTypes: excludeResourceTypes,
+		ExcludeAfter:         excludeAfter,
 	}
-
-	duration, err := time.ParseDuration(excludeAfter)
-
-	if err != nil {
-		return q, InvalidTimeStringPassedError{Underlying: err}
-	}
-
-	// Make it negative so it goes back in time
-	duration = -1 * duration
-
-	q.ExcludeAfter = time.Now().Add(duration)
 
 	validationErr := q.Validate()
 
@@ -113,7 +103,7 @@ func NewQuery(regions, excludeRegions, resourceTypes, excludeResourceTypes []str
 
 // Validate ensures the configured values for a Query are valid, returning an error if there are
 // any invalid params, or nil if the Query is valid
-func (q Query) Validate() error {
+func (q *Query) Validate() error {
 
 	resourceTypes, err := HandleResourceTypeSelections(q.ResourceTypes, q.ExcludeResourceTypes)
 	if err != nil {
@@ -176,7 +166,7 @@ type ResourceInspectionError struct {
 }
 
 func (err ResourceInspectionError) Error() string {
-	return fmt.Sprintf("Error encountered when querying for accoun resources. Original error: %v", err.Underlying)
+	return fmt.Sprintf("Error encountered when querying for account resources. Original error: %v", err.Underlying)
 }
 
 type CouldNotSelectRegionError struct {

--- a/aws/types.go
+++ b/aws/types.go
@@ -1,6 +1,10 @@
 package aws
 
 import (
+	"fmt"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
@@ -8,6 +12,53 @@ const AwsResourceExclusionTagKey = "cloud-nuke-excluded"
 
 type AwsAccountResources struct {
 	Resources map[string]AwsRegionResource
+}
+
+func (a *AwsAccountResources) GetRegion(region string) AwsRegionResource {
+	if val, ok := a.Resources[region]; ok {
+		return val
+	}
+	return AwsRegionResource{}
+}
+
+// MapResourceNameToIdentifiers converts a slice of Resources to a map of resource types to their found identifiers
+// For example: ["ec2"] = ["i-0b22a22eec53b9321", "i-0e22a22yec53b9456"]
+func (arr AwsRegionResource) MapResourceNameToIdentifiers() map[string][]string {
+	// Initialize map of resource name to identifier, e.g., ["ec2"] = "i-0b22a22eec53b9321"
+	m := make(map[string][]string)
+	for _, resource := range arr.Resources {
+		if len(resource.ResourceIdentifiers()) > 0 {
+			for _, id := range resource.ResourceIdentifiers() {
+				m[resource.ResourceName()] = append(m[resource.ResourceName()], id)
+			}
+		}
+	}
+	return m
+}
+
+// CountOfResourceType is a convenience method that returns the number of the supplied resource type found in the AwsRegionResource
+func (arr AwsRegionResource) CountOfResourceType(resourceType string) int {
+	idMap := arr.MapResourceNameToIdentifiers()
+	resourceType = strings.ToLower(resourceType)
+	if val, ok := idMap[resourceType]; ok {
+		return len(val)
+	}
+	return 0
+}
+
+// ResourceTypePresent is a convenience method that returns true, if the given resource is found in the AwsRegionResource, or false if it is not
+func (arr AwsRegionResource) ResourceTypePresent(resourceType string) bool {
+	return arr.CountOfResourceType(resourceType) > 0
+}
+
+// IdentifiersForResourceType is a convenience method that returns the list of resource identifiers for a given resource type, if available
+func (arr AwsRegionResource) IdentifiersForResourceType(resourceType string) []string {
+	idMap := arr.MapResourceNameToIdentifiers()
+	resourceType = strings.ToLower(resourceType)
+	if val, ok := idMap[resourceType]; ok {
+		return val
+	}
+	return []string{}
 }
 
 type AwsResources interface {
@@ -19,4 +70,82 @@ type AwsResources interface {
 
 type AwsRegionResource struct {
 	Resources []AwsResources
+}
+
+// Query is a struct that represents the desired parameters for scanning resources within a given account
+type Query struct {
+	Regions              []string
+	ResourceTypes        []string
+	ExcludeResourceTypes []string
+	ExcludeAfter         time.Time
+}
+
+// NewQuery configures and returns a Query struct that can be passed into the InspectResources method
+func NewQuery(regions, resourceTypes, excludeResourceTypes []string, excludeAfter string) (Query, error) {
+
+	q := Query{
+		Regions:              regions,
+		ResourceTypes:        resourceTypes,
+		ExcludeResourceTypes: excludeResourceTypes,
+	}
+
+	duration, err := time.ParseDuration(excludeAfter)
+
+	if err != nil {
+		return q, InvalidTimeStringPassedError{Underlying: err}
+	}
+
+	// Make it negative so it goes back in time
+	duration = -1 * duration
+
+	q.ExcludeAfter = time.Now().Add(duration)
+
+	validationErr := q.Validate()
+
+	if validationErr != nil {
+		return q, validationErr
+	}
+
+	return q, nil
+}
+
+// Validate ensures the configured values for a Query are valid, returning an error if there are
+// any invalid params, or nil if the Query is valid
+func (q Query) Validate() error {
+
+	resourceTypes, err := HandleResourceTypeSelections(q.ResourceTypes, q.ExcludeResourceTypes)
+	if err != nil {
+		return err
+	}
+
+	q.ResourceTypes = resourceTypes
+
+	//TODO - validate region
+
+	return nil
+}
+
+// custom errors
+
+type InvalidResourceTypesSuppliedError struct {
+	InvalidTypes []string
+}
+
+func (err InvalidResourceTypesSuppliedError) Error() string {
+	return fmt.Sprintf("Invalid resourceTypes %s specified: %s", err.InvalidTypes, "Try --list-resource-types to get a list of valid resource types.")
+}
+
+type ResourceTypeAndExcludeFlagsBothPassedError struct{}
+
+func (err ResourceTypeAndExcludeFlagsBothPassedError) Error() string {
+	return fmt.Sprint("You can not specify both --resource-type and --exclude-resource-type")
+}
+
+type InvalidTimeStringPassedError struct {
+	Entry      string
+	Underlying error
+}
+
+func (err InvalidTimeStringPassedError) Error() string {
+	return fmt.Sprintf("Could not parse %s as a valid time duration. Underlying error: %s", err.Entry, err.Underlying)
 }

--- a/aws/types.go
+++ b/aws/types.go
@@ -141,7 +141,7 @@ func (err InvalidResourceTypesSuppliedError) Error() string {
 type ResourceTypeAndExcludeFlagsBothPassedError struct{}
 
 func (err ResourceTypeAndExcludeFlagsBothPassedError) Error() string {
-	return fmt.Sprint("You can not specify both --resource-type and --exclude-resource-type")
+	return "You can not specify both --resource-type and --exclude-resource-type"
 }
 
 type InvalidTimeStringPassedError struct {

--- a/aws/types_test.go
+++ b/aws/types_test.go
@@ -1,54 +1,11 @@
 package aws
 
 import (
-	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestNewQueryRejectsInvalidExcludeAfterEntries(t *testing.T) {
-
-	type TestCase struct {
-		Name                 string
-		Regions              []string
-		ExcludeRegions       []string
-		ResourceTypes        []string
-		ExcludeResourceTypes []string
-		ExcludeAfter         string
-		Error                InvalidTimeStringPassedError
-	}
-
-	testCases := []TestCase{
-		{
-			Name:                 "Invalid excludeAfter time string rejected",
-			Regions:              []string{"us-east-1"},
-			ExcludeRegions:       []string{},
-			ResourceTypes:        []string{"ec2", "vpc"},
-			ExcludeResourceTypes: []string{},
-			ExcludeAfter:         "this is not a valid time duration",
-			Error:                InvalidTimeStringPassedError{},
-		},
-		{
-			Name:                 "Empty excludeAfter time string rejected",
-			Regions:              []string{"us-east-1"},
-			ExcludeRegions:       []string{},
-			ResourceTypes:        []string{"ec2", "vpc"},
-			ExcludeResourceTypes: []string{},
-			ExcludeAfter:         "", // this ExcludeAfter is intentionally left empty
-			Error:                InvalidTimeStringPassedError{},
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			_, err := NewQuery(tc.Regions, tc.ExcludeRegions, tc.ResourceTypes, tc.ExcludeResourceTypes, tc.ExcludeAfter)
-			if !errors.As(err, &tc.Error) {
-				t.Logf("%s: Expected error of type %T but got %T", tc.Name, tc.Error, err)
-				t.Fail()
-			}
-		})
-	}
-}
 
 func TestNewQueryAcceptsValidExcludeAfterEntries(t *testing.T) {
 	type TestCase struct {
@@ -57,23 +14,23 @@ func TestNewQueryAcceptsValidExcludeAfterEntries(t *testing.T) {
 		ExcludeRegions       []string
 		ResourceTypes        []string
 		ExcludeResourceTypes []string
-		ExcludeAfter         string
+		ExcludeAfter         time.Time
 	}
 
 	testCases := []TestCase{
 		{
-			Name:           "Can pass simple durations: 1h",
+			Name:           "Can pass time.Now plus 24 hours",
 			Regions:        []string{"us-east-1"},
 			ExcludeRegions: []string{},
 			ResourceTypes:  []string{"ec2"},
-			ExcludeAfter:   "1h",
+			ExcludeAfter:   time.Now().Add(time.Hour * 24),
 		},
 		{
-			Name:           "Can pass simple durations: 65m",
+			Name:           "Can pass time.Now",
 			Regions:        []string{"us-east-1"},
 			ExcludeRegions: []string{},
 			ResourceTypes:  []string{"ec2"},
-			ExcludeAfter:   "65m",
+			ExcludeAfter:   time.Now(),
 		},
 	}
 

--- a/aws/types_test.go
+++ b/aws/types_test.go
@@ -1,0 +1,80 @@
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewQueryRejectsInvalidExcludeAfterEntries(t *testing.T) {
+
+	type TestCase struct {
+		Name                 string
+		Regions              []string
+		ResourceTypes        []string
+		ExcludeResourceTypes []string
+		ExcludeAfter         string
+		Error                InvalidTimeStringPassedError
+	}
+
+	testCases := []TestCase{
+		{
+			Name:                 "Invalid excludeAfter time string rejected",
+			Regions:              []string{"us-east-1"},
+			ResourceTypes:        []string{"ec2", "vpc"},
+			ExcludeResourceTypes: []string{},
+			ExcludeAfter:         "this is not a valid time duration",
+			Error:                InvalidTimeStringPassedError{},
+		},
+		{
+			Name:                 "Empty excludeAfter time string rejected",
+			Regions:              []string{"us-east-1"},
+			ResourceTypes:        []string{"ec2", "vpc"},
+			ExcludeResourceTypes: []string{},
+			ExcludeAfter:         "", // this ExcludeAfter is intentionally left empty
+			Error:                InvalidTimeStringPassedError{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, err := NewQuery(tc.Regions, tc.ResourceTypes, tc.ExcludeResourceTypes, tc.ExcludeAfter)
+			if !errors.As(err, &tc.Error) {
+				t.Logf("%s: Expected error of type %T but got %T", tc.Name, tc.Error, err)
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestNewQueryAcceptsValidExcludeAfterEntries(t *testing.T) {
+	type TestCase struct {
+		Name                 string
+		Regions              []string
+		ResourceTypes        []string
+		ExcludeResourceTypes []string
+		ExcludeAfter         string
+	}
+
+	testCases := []TestCase{
+		{
+			Name:          "Can pass simple durations: 1h",
+			Regions:       []string{"us-east-1"},
+			ResourceTypes: []string{"ec2"},
+			ExcludeAfter:  "1h",
+		},
+		{
+			Name:          "Can pass simple durations: 65m",
+			Regions:       []string{"us-east-1"},
+			ResourceTypes: []string{"ec2"},
+			ExcludeAfter:  "65m",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, err := NewQuery(tc.Regions, tc.ResourceTypes, tc.ExcludeResourceTypes, tc.ExcludeAfter)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/aws/types_test.go
+++ b/aws/types_test.go
@@ -12,6 +12,7 @@ func TestNewQueryRejectsInvalidExcludeAfterEntries(t *testing.T) {
 	type TestCase struct {
 		Name                 string
 		Regions              []string
+		ExcludeRegions       []string
 		ResourceTypes        []string
 		ExcludeResourceTypes []string
 		ExcludeAfter         string
@@ -22,6 +23,7 @@ func TestNewQueryRejectsInvalidExcludeAfterEntries(t *testing.T) {
 		{
 			Name:                 "Invalid excludeAfter time string rejected",
 			Regions:              []string{"us-east-1"},
+			ExcludeRegions:       []string{},
 			ResourceTypes:        []string{"ec2", "vpc"},
 			ExcludeResourceTypes: []string{},
 			ExcludeAfter:         "this is not a valid time duration",
@@ -30,6 +32,7 @@ func TestNewQueryRejectsInvalidExcludeAfterEntries(t *testing.T) {
 		{
 			Name:                 "Empty excludeAfter time string rejected",
 			Regions:              []string{"us-east-1"},
+			ExcludeRegions:       []string{},
 			ResourceTypes:        []string{"ec2", "vpc"},
 			ExcludeResourceTypes: []string{},
 			ExcludeAfter:         "", // this ExcludeAfter is intentionally left empty
@@ -38,7 +41,7 @@ func TestNewQueryRejectsInvalidExcludeAfterEntries(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			_, err := NewQuery(tc.Regions, tc.ResourceTypes, tc.ExcludeResourceTypes, tc.ExcludeAfter)
+			_, err := NewQuery(tc.Regions, tc.ExcludeRegions, tc.ResourceTypes, tc.ExcludeResourceTypes, tc.ExcludeAfter)
 			if !errors.As(err, &tc.Error) {
 				t.Logf("%s: Expected error of type %T but got %T", tc.Name, tc.Error, err)
 				t.Fail()
@@ -51,6 +54,7 @@ func TestNewQueryAcceptsValidExcludeAfterEntries(t *testing.T) {
 	type TestCase struct {
 		Name                 string
 		Regions              []string
+		ExcludeRegions       []string
 		ResourceTypes        []string
 		ExcludeResourceTypes []string
 		ExcludeAfter         string
@@ -58,22 +62,24 @@ func TestNewQueryAcceptsValidExcludeAfterEntries(t *testing.T) {
 
 	testCases := []TestCase{
 		{
-			Name:          "Can pass simple durations: 1h",
-			Regions:       []string{"us-east-1"},
-			ResourceTypes: []string{"ec2"},
-			ExcludeAfter:  "1h",
+			Name:           "Can pass simple durations: 1h",
+			Regions:        []string{"us-east-1"},
+			ExcludeRegions: []string{},
+			ResourceTypes:  []string{"ec2"},
+			ExcludeAfter:   "1h",
 		},
 		{
-			Name:          "Can pass simple durations: 65m",
-			Regions:       []string{"us-east-1"},
-			ResourceTypes: []string{"ec2"},
-			ExcludeAfter:  "65m",
+			Name:           "Can pass simple durations: 65m",
+			Regions:        []string{"us-east-1"},
+			ExcludeRegions: []string{},
+			ResourceTypes:  []string{"ec2"},
+			ExcludeAfter:   "65m",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			_, err := NewQuery(tc.Regions, tc.ResourceTypes, tc.ExcludeResourceTypes, tc.ExcludeAfter)
+			_, err := NewQuery(tc.Regions, tc.ExcludeRegions, tc.ResourceTypes, tc.ExcludeResourceTypes, tc.ExcludeAfter)
 			require.NoError(t, err)
 		})
 	}

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -115,7 +115,7 @@ func CreateCli(version string) *cli.App {
 				},
 				cli.StringSliceFlag{
 					Name:  "resource-type",
-					Usage: "Resource types to nuke. Include multiple times if more than one.",
+					Usage: "Resource types to inspect. Include multiple times if more than one.",
 				},
 				cli.StringSliceFlag{
 					Name:  "exclude-resource-type",

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -413,12 +413,17 @@ func awsInspect(c *cli.Context) error {
 		return nil
 	}
 
+	excludeAfter, err := parseDurationParam(c.String("older-than"))
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
 	query, err := aws.NewQuery(
 		c.StringSlice("region"),
 		c.StringSlice("exclude-region"),
 		c.StringSlice("resource-type"),
 		c.StringSlice("exclude-resource-type"),
-		c.String("older-than"),
+		*excludeAfter,
 	)
 
 	if err != nil {

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -422,7 +422,7 @@ func awsInspect(c *cli.Context) error {
 
 	if c.Bool("list-resource-types") {
 		for _, resourceType := range aws.ListResourceTypes() {
-			fmt.Println(resourceType)
+			logging.Logger.Infoln(resourceType)
 		}
 		return nil
 	}

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -123,7 +123,7 @@ func CreateCli(version string) *cli.App {
 				},
 				cli.StringFlag{
 					Name:  "older-than",
-					Usage: "Only delete resources older than this specified value. Can be any valid Go duration, such as 10m or 8h.",
+					Usage: "Only inspect resources older than this specified value. Can be any valid Go duration, such as 10m or 8h.",
 					Value: "0s",
 				},
 			},

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/aws"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
-	"github.com/gruntwork-io/go-commons/collections"
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/go-commons/shell"
 	"github.com/sirupsen/logrus"
@@ -97,6 +96,37 @@ func CreateCli(version string) *cli.App {
 					Usage: "Skip confirmation prompt. WARNING: this will automatically delete defaults without any confirmation",
 				},
 			},
+		}, {
+			Name:   "inspect-aws",
+			Usage:  "Non-destructive inspection of target resources only",
+			Action: errors.WithPanicHandling(awsInspect),
+			Flags: []cli.Flag{
+				cli.StringSliceFlag{
+					Name:  "region",
+					Usage: "regions to include",
+				},
+				cli.StringSliceFlag{
+					Name:  "exclude-region",
+					Usage: "regions to exclude",
+				},
+				cli.BoolFlag{
+					Name:  "list-resource-types",
+					Usage: "List available resource types",
+				},
+				cli.StringSliceFlag{
+					Name:  "resource-type",
+					Usage: "Resource types to nuke. Include multiple times if more than one.",
+				},
+				cli.StringSliceFlag{
+					Name:  "exclude-resource-type",
+					Usage: "Resource types to exclude from nuking. Include multiple times if more than one.",
+				},
+				cli.StringFlag{
+					Name:  "older-than",
+					Usage: "Only delete resources older than this specified value. Can be any valid Go duration, such as 10m or 8h.",
+					Value: "0s",
+				},
+			},
 		},
 	}
 
@@ -146,43 +176,11 @@ func awsNuke(c *cli.Context) error {
 		return nil
 	}
 
-	resourceTypes := c.StringSlice("resource-type")
-	excludeResourceTypes := c.StringSlice("exclude-resource-type")
-	if len(resourceTypes) > 0 && len(excludeResourceTypes) > 0 {
-		return fmt.Errorf("You can not specify both --resource-type and --exclude-resource-type")
-	}
-
-	// Var check to make sure only allowed resource types are included in the --resource-type or --exclude-resource-type
-	// args.
-	invalidresourceTypes := []string{}
-	for _, resourceType := range resourceTypes {
-		if resourceType == "all" {
-			continue
-		}
-		if !aws.IsValidResourceType(resourceType, allResourceTypes) {
-			invalidresourceTypes = append(invalidresourceTypes, resourceType)
-		}
-	}
-
-	for _, resourceType := range excludeResourceTypes {
-		if !aws.IsValidResourceType(resourceType, allResourceTypes) {
-			invalidresourceTypes = append(invalidresourceTypes, resourceType)
-		}
-	}
-
-	if len(invalidresourceTypes) > 0 {
-		msg := "Try --list-resource-types to get list of valid resource types."
-		return fmt.Errorf("Invalid resourceTypes %s specified: %s", invalidresourceTypes, msg)
-	}
-
-	// Handle exclude resource types by going through the list of all types and only include those that are not
-	// mentioned in the exclude list.
-	if len(excludeResourceTypes) > 0 {
-		for _, resourceType := range allResourceTypes {
-			if !collections.ListContainsElement(excludeResourceTypes, resourceType) {
-				resourceTypes = append(resourceTypes, resourceType)
-			}
-		}
+	// Ensure that the resourceTypes and excludeResourceTypes arguments are valid, and then filter
+	// resourceTypes
+	resourceTypes, err := aws.HandleResourceTypeSelections(c.StringSlice("resource-types"), c.StringSlice("exclude-resource-type"))
+	if err != nil {
+		return err
 	}
 
 	// Log which resource types will be nuked
@@ -232,14 +230,7 @@ func awsNuke(c *cli.Context) error {
 		return nil
 	}
 
-	nukableResources := make([]string, 0)
-	for region, resourcesInRegion := range account.Resources {
-		for _, resources := range resourcesInRegion.Resources {
-			for _, identifier := range resources.ResourceIdentifiers() {
-				nukableResources = append(nukableResources, fmt.Sprintf("* %s %s %s\n", resources.ResourceName(), identifier, region))
-			}
-		}
-	}
+	nukableResources := aws.ExtractResourcesForPrinting(account)
 
 	logging.Logger.Infof("The following %d AWS resources will be nuked:", len(nukableResources))
 
@@ -403,4 +394,86 @@ func confirmationPrompt(prompt string, maxPrompts int) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func awsInspect(c *cli.Context) error {
+	logging.Logger.Infoln("Identifying enabled regions")
+	regions, err := aws.GetEnabledRegions()
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+	for _, region := range regions {
+		logging.Logger.Infof("Found enabled region %s", region)
+	}
+
+	configObj := config.Config{}
+	configFilePath := c.String("config")
+
+	if configFilePath != "" {
+		configObjPtr, err := config.GetConfig(configFilePath)
+
+		if err != nil {
+			return fmt.Errorf("Error reading config - %s - %s", configFilePath, err)
+		}
+		configObj = *configObjPtr
+	}
+
+	allResourceTypes := aws.ListResourceTypes()
+
+	if c.Bool("list-resource-types") {
+		for _, resourceType := range aws.ListResourceTypes() {
+			fmt.Println(resourceType)
+		}
+		return nil
+	}
+
+	// Ensure that the resourceTypes and excludeResourceTypes arguments are valid, and then filter
+	// resourceTypes
+	resourceTypes, err := aws.HandleResourceTypeSelections(c.StringSlice("resource-type"), c.StringSlice("exclude-resource-type"))
+
+	// Log which resource types will be nuked
+	logging.Logger.Info("The following resource types will be inspected:")
+	if len(resourceTypes) > 0 {
+		for _, resourceType := range resourceTypes {
+			logging.Logger.Infof("- %s", resourceType)
+		}
+	} else {
+		for _, resourceType := range allResourceTypes {
+			logging.Logger.Infof("- %s", resourceType)
+		}
+	}
+
+	selectedRegions := c.StringSlice("region")
+	excludedRegions := c.StringSlice("exclude-region")
+
+	// targetRegions uses selectedRegions and excludedRegions to create a filtered
+	// target region slice
+	targetRegions, err := aws.GetTargetRegions(regions, selectedRegions, excludedRegions)
+	if err != nil {
+		return fmt.Errorf("Failed to select regions: %s", err)
+	}
+
+	logging.Logger.Infoln(targetRegions)
+
+	excludeAfter, err := parseDurationParam(c.String("older-than"))
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	logging.Logger.Infof("Retrieving active AWS resources in [%s]", strings.Join(targetRegions[:], ", "))
+	account, err := aws.GetAllResources(targetRegions, *excludeAfter, resourceTypes, configObj)
+
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	foundResources := aws.ExtractResourcesForPrinting(account)
+
+	logging.Logger.Infoln("The following AWS resources were found:")
+
+	for _, resource := range foundResources {
+		logging.Logger.Infoln(resource)
+	}
+
+	return nil
 }

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -433,11 +433,7 @@ func awsInspect(c *cli.Context) error {
 	accountResources, err := aws.InspectResources(query)
 
 	if err != nil {
-		return aws.ResourceInspectionError{Underlying: err}
-	}
-
-	if err != nil {
-		return errors.WithStackTrace(err)
+		return errors.WithStackTrace(aws.ResourceInspectionError{Underlying: err})
 	}
 
 	foundResources := aws.ExtractResourcesForPrinting(accountResources)

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -438,8 +438,6 @@ func awsInspect(c *cli.Context) error {
 
 	foundResources := aws.ExtractResourcesForPrinting(accountResources)
 
-	logging.Logger.Infoln("The following AWS resources were found:")
-
 	for _, resource := range foundResources {
 		logging.Logger.Infoln(resource)
 	}

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -119,7 +119,7 @@ func CreateCli(version string) *cli.App {
 				},
 				cli.StringSliceFlag{
 					Name:  "exclude-resource-type",
-					Usage: "Resource types to exclude from nuking. Include multiple times if more than one.",
+					Usage: "Resource types to exclude from inspection. Include multiple times if more than one.",
 				},
 				cli.StringFlag{
 					Name:  "older-than",

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -431,6 +431,10 @@ func awsInspect(c *cli.Context) error {
 	// resourceTypes
 	resourceTypes, err := aws.HandleResourceTypeSelections(c.StringSlice("resource-type"), c.StringSlice("exclude-resource-type"))
 
+	if err != nil {
+		return err
+	}
+
 	// Log which resource types will be nuked
 	logging.Logger.Info("The following resource types will be inspected:")
 	if len(resourceTypes) > 0 {

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -413,8 +413,6 @@ func awsInspect(c *cli.Context) error {
 		return nil
 	}
 
-	logging.Logger.Infof("Retrieving active AWS resources in [%s]", strings.Join(targetRegions[:], ", "))
-
 	query, err := aws.NewQuery(
 		c.StringSlice("region"),
 		c.StringSlice("exclude-region"),

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,10 @@ require (
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/pquerna/otp v1.3.0
 	github.com/sirupsen/logrus v1.6.0
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/objx v0.4.0 // indirect
+	github.com/stretchr/testify v1.7.1
 	github.com/urfave/cli v1.22.4
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	gopkg.in/yaml.v2 v2.2.8
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -402,6 +402,8 @@ github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/y
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -409,6 +411,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -678,6 +682,8 @@ gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

These changes introduce non-destructive "inspect" functionality with the same semantics and parameters as the destructive nuke functionality. As `nuke` is to `DELETE` , `inspect` is to `READ` or `LIST`. 

Non-destructively inspecting resources with cloud-nuke can be useful in CI/CD jobs, preflight checks, and anywhere else that you may wish to ensure that resources: 
- are, or are not, in a given AWS account
- are, or are not, within a given AWS region

There are two ways to consume this new inspect functionality: 
- Via the command-line interface and a new `inspect-aws` command. This command is mostly identical to the `aws` command, but it will never destroy resources and can accept many of the same flags.
- Via a new method `InspectResources` that can be used as a library function for counting the number of target resources in a given region, with an API that works like the following: 

```golang
package main

import (
	"fmt"
	"time"

	nuke_aws "github.com/gruntwork-io/cloud-nuke/aws"
)

func main() {

	// You can scan multiple regions at once, or just pass a single region for speed
	targetRegions := []string{"us-east-1", "us-west-1", "us-west-2"}
	excludeRegions := []string{}
	// You can simultaneously target multiple resource types as well
	resourceTypes := []string{"ec2", "vpc"}
	excludeResourceTypes := []string{}
	// excludeAfter is parsed identically to the --older-than flag
	excludeAfter := time.Now()

	// NewQuery is a convenience method for configuring parameters you want to pass to your resource search
	query, err := nuke_aws.NewQuery(
		targetRegions,
		excludeRegions,
		resourceTypes,
		excludeResourceTypes,
		excludeAfter,
	)

	if err != nil {
		fmt.Println(err)
	}

	// InspectResources still returns *AwsAccountResources, but this struct has been extended with several
	// convenience methods for quickly determining if resources exist in a given region
	accountResources, err := nuke_aws.InspectResources(query)
	if err != nil {
		fmt.Println(err)
	}

	// You can call GetRegion to examine a single region's resources
	usWest1Resources := accountResources.GetRegion("us-west-1")

	// Then interrogate them with the new methods:

	// Count the number of any resource type within the region
	countOfEc2InUsWest1 := usWest1Resources.CountOfResourceType("ec2")

	fmt.Printf("countOfEc2InUsWest1: %d\n", countOfEc2InUsWest1)
	// countOfEc2InUsWest1: 2

	fmt.Printf("usWest1Resources.ResourceTypePresent(\"ec2\"):%b\n", usWest1Resources.ResourceTypePresent("ec2"))
	//usWest1Resources.ResourceTypePresent("ec2"): true

	// Get all the resource identifiers for a given resource type
	// In this example, we're only looking for ec2 instances
	resourceIds := usWest1Resources.IdentifiersForResourceType("ec2")

	fmt.Printf("resourceIds: %s", resourceIds)
	// resourceIds:  [i-0c5d16c3ef28dda24 i-09d9739e1f4d27814]

}
```

Which results in: 

```bash

❯ aws-vault exec nuclear-wasteland -- ./z
[cloud-nuke] INFO[2022-05-31T21:51:03-04:00] The following resource types will be scanned for (inspected):
[cloud-nuke] INFO[2022-05-31T21:51:03-04:00] - ec2
[cloud-nuke] INFO[2022-05-31T21:51:03-04:00] - vpc
[cloud-nuke] INFO[2022-05-31T21:51:03-04:00] Checking region [1/3]: us-east-1
[cloud-nuke] INFO[2022-05-31T21:51:04-04:00] Checking region [2/3]: us-west-1
[cloud-nuke] INFO[2022-05-31T21:51:06-04:00] Checking region [3/3]: us-west-2
countOfEc2InUsWest1:  2
usWest1Resources.ResourceTypePresent("ec2") true
resourceIds:  [i-0c5d16c3ef28dda24 i-09d9739e1f4d27814]
```

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

