### PR TITLE
Fix resource-type include exclude flags

### DIFF
--- a/aws/inspect.go
+++ b/aws/inspect.go
@@ -51,31 +51,30 @@ func ensureValidResourceTypes(resourceTypes []string) ([]string, error) {
 
 // HandleResourceTypeSelections accepts a slice of target resourceTypes and a slice of resourceTypes to exclude. It filters
 // any excluded or invalid types from target resourceTypes then returns the filtered slice
-func HandleResourceTypeSelections(resourceTypes, excludeResourceTypes []string) ([]string, error) {
-	if len(resourceTypes) > 0 && len(excludeResourceTypes) > 0 {
+func HandleResourceTypeSelections(
+	includeResourceTypes, excludeResourceTypes []string,
+) ([]string, error) {
+	if len(includeResourceTypes) > 0 && len(excludeResourceTypes) > 0 {
 		return []string{}, ResourceTypeAndExcludeFlagsBothPassedError{}
 	}
 
-	validResourceTypes, err := ensureValidResourceTypes(resourceTypes)
-	if err != nil {
-		return validResourceTypes, err
-	}
-
-	validExcludeResourceTypes, err := ensureValidResourceTypes(excludeResourceTypes)
-	if err != nil {
-		return validExcludeResourceTypes, err
+	if len(includeResourceTypes) > 0 {
+		return ensureValidResourceTypes(includeResourceTypes)
 	}
 
 	// Handle exclude resource types by going through the list of all types and only include those that are not
 	// mentioned in the exclude list.
-	if len(validExcludeResourceTypes) > 0 {
-		for _, resourceType := range validResourceTypes {
-			if !collections.ListContainsElement(excludeResourceTypes, resourceType) {
-				resourceTypes = append(resourceTypes, resourceType)
-			}
-		}
+	validExcludeResourceTypes, err := ensureValidResourceTypes(excludeResourceTypes)
+	if err != nil {
+		return []string{}, err
 	}
 
+	resourceTypes := []string{}
+	for _, resourceType := range ListResourceTypes() {
+		if !collections.ListContainsElement(validExcludeResourceTypes, resourceType) {
+			resourceTypes = append(resourceTypes, resourceType)
+		}
+	}
 	return resourceTypes, nil
 }
 

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -167,8 +167,6 @@ func awsNuke(c *cli.Context) error {
 		configObj = *configObjPtr
 	}
 
-	allResourceTypes := aws.ListResourceTypes()
-
 	if c.Bool("list-resource-types") {
 		for _, resourceType := range aws.ListResourceTypes() {
 			fmt.Println(resourceType)
@@ -178,21 +176,15 @@ func awsNuke(c *cli.Context) error {
 
 	// Ensure that the resourceTypes and excludeResourceTypes arguments are valid, and then filter
 	// resourceTypes
-	resourceTypes, err := aws.HandleResourceTypeSelections(c.StringSlice("resource-types"), c.StringSlice("exclude-resource-type"))
+	resourceTypes, err := aws.HandleResourceTypeSelections(c.StringSlice("resource-type"), c.StringSlice("exclude-resource-type"))
 	if err != nil {
 		return err
 	}
 
 	// Log which resource types will be nuked
 	logging.Logger.Info("The following resource types will be nuked:")
-	if len(resourceTypes) > 0 {
-		for _, resourceType := range resourceTypes {
-			logging.Logger.Infof("- %s", resourceType)
-		}
-	} else {
-		for _, resourceType := range allResourceTypes {
-			logging.Logger.Infof("- %s", resourceType)
-		}
+	for _, resourceType := range resourceTypes {
+		logging.Logger.Infof("- %s", resourceType)
 	}
 
 	regions, err := aws.GetEnabledRegions()


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This fixes the regression bug that was introduced in https://github.com/gruntwork-io/cloud-nuke/pull/305, where the `--exclude-resource-type` no longer handled exclusions correctly.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
