### PR TITLE
Avoid more resources

### DIFF
--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -7,6 +7,9 @@ s3:
       - "^gruntwork-terratest-[a-zA-Z0-9]{6}$"
       - "^gw-cis-aws-config-all-regions-[a-zA-Z0-9]{6}-.*"
       - "^gruntwork-test-[a-zA-Z0-9]{6}-config-test$"
+      - "^gruntwork-test-[a-zA-Z0-9]{6}-cloudtrail-test.*"
+      - "^gruntwork-test-privs3bucket-[a-zA-Z0-9]{6}"
+      - "^gruntwork-terratest-[a-zA-Z0-9]{6}-logs"
       - "^houston-static-[a-zA-Z0-9]{12}.*"
       - "^.*-cloud-nuke-test-.*"
       - "^alb-alb-[a-zA-Z0-9]{6}-access-logs$"
@@ -17,7 +20,12 @@ s3:
       - "^[a-zA-Z0-9]{6}-ecs-service-test-s3-bucket"
       - "^test-service-[a-zA-Z0-9]{6}-test-s3-bucket"
       - "^tst-openvpn-[a-zA-Z0-9]{6}"
+      - "^openvpn-test-[a-zA-Z0-9]{6}"
       - "^vault-module-test-[a-zA-Z0-9]{6}"
+      - "^es-cluster-[a-zA-Z0-9]{6}-es-backup-bucket"
+      - "^gruntwork-(test-)?ecs-deploy-runner-outputs-[a-zA-Z0-9]{6}"
+      - "^test-bucket-.*"
+      - "^test-private-s3-bucket-.*"
 
 SecretsManager:
   include:

--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -8,14 +8,16 @@ s3:
       - "^gw-cis-aws-config-all-regions-[a-zA-Z0-9]{6}-.*"
       - "^gruntwork-test-[a-zA-Z0-9]{6}-config-test$"
       - "^houston-static-[a-zA-Z0-9]{12}.*"
-      - "^cloud-nuke-test-[a-zA-Z0-9]{12}.*"
-      - "^cloud-nuke-test-[a-zA-Z0-9]{6}-bucket$"
+      - "^.*-cloud-nuke-test-.*"
       - "^alb-alb-[a-zA-Z0-9]{6}-access-logs$"
       - "^kafka-zk-standalone-[a-zA-Z0-9]{6}$"
       - "^zookeeper-cluster-test-[a-zA-Z0-9]{6}$"
       - "^terragrunt-test-bucket-[a-zA-Z0-9]{6}.*"
       - "^[a-zA-Z0-9]{6}-service-test-s3-bucket"
       - "^[a-zA-Z0-9]{6}-ecs-service-test-s3-bucket"
+      - "^test-service-[a-zA-Z0-9]{6}-test-s3-bucket"
+      - "^tst-openvpn-[a-zA-Z0-9]{6}"
+      - "^vault-module-test-[a-zA-Z0-9]{6}"
 
 SecretsManager:
   include:

--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -92,3 +92,9 @@ CloudWatchLogGroup:
       - "jenkins-[a-zA-Z0-9]{6}$"
       - "openvpn-server-[a-zA-Z0-9]{6}_log_group$"
       - "vpc-test-[a-zA-Z0-9]{6}.*"
+
+IAMUsers:
+  exclude:
+    names_regex:
+      # We want to make sure the main circle-ci-test user is never deleted
+      - "^circle-ci-test$"


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Avoids the main circle-ci-test user when nuking IAM Users. Also adds a few more test buckets that should be deleted.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
N/A
