### PR TITLE
Attach nuke permissions by circleci context, not env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,9 @@ workflows:
             branches:
               only: master
     jobs:
-      - nuke_phx_devops
+      - nuke_phx_devops:
+          context:
+            - Gruntwork Admin
   nightly:
     triggers:
       - schedule:
@@ -113,4 +115,7 @@ workflows:
             branches:
               only: master
     jobs:
-      - nuke_sandbox
+      - nuke_sandbox:
+          context:
+            - Gruntwork Admin
+            - Gruntwork Sandbox


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This updates the nuke circleci rules to use the CircleCI context instead of using env vars.