### PR TITLE
update: Skips deleted and in deletion NAT gateways from nuking, adds test for config file lookup

### DIFF
--- a/aws/nat_gateway.go
+++ b/aws/nat_gateway.go
@@ -32,11 +32,17 @@ func getAllNatGateways(session *session.Session, excludeAfter time.Time, configO
 			return !lastPage
 		},
 	)
+
 	return allNatGateways, errors.WithStackTrace(err)
 }
 
 func shouldIncludeNatGateway(ngw *ec2.NatGateway, excludeAfter time.Time, configObj config.Config) bool {
 	if ngw == nil {
+		return false
+	}
+
+	ngwState := aws.StringValue(ngw.State)
+	if ngwState == ec2.NatGatewayStateDeleted || ngwState == ec2.NatGatewayStateDeleting {
 		return false
 	}
 

--- a/aws/nat_gateway_test.go
+++ b/aws/nat_gateway_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"regexp"
 	"testing"
 	"time"
 
@@ -8,6 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/gruntwork-io/go-commons/errors"
 	terraws "github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,6 +32,51 @@ func TestListNatGateways(t *testing.T) {
 	natGatewayIDs, err := getAllNatGateways(session, time.Now(), config.Config{})
 	require.NoError(t, err)
 	assert.Contains(t, aws.StringValueSlice(natGatewayIDs), aws.StringValue(ngwID))
+}
+
+func createNatGatewayWithName(t *testing.T, svc *ec2.EC2, region string, name string) *string {
+	ngwID := createNatGateway(t, svc, region)
+
+	err := setTagsToResource(t, svc, ngwID, []*ec2.Tag{
+		{
+			Key: aws.String("Name"),
+			Value: aws.String(name),
+		},
+	})
+	require.NoError(t, err)
+
+	return ngwID
+}
+
+func TestListNatGatewaysWithConfigFile(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+	svc := ec2.New(session)
+
+	includedNatGatewayName := "cloud-nuke-test-include-" + util.UniqueID()
+	excludedNatGatewayName := "cloud-nuke-test-" + util.UniqueID()
+	includedNatGatewayID := createNatGatewayWithName(t, svc, region, includedNatGatewayName)
+	excludedNatGatewayID := createNatGatewayWithName(t, svc, region, excludedNatGatewayName)
+	defer nukeAllNatGateways(session, []*string{includedNatGatewayID, excludedNatGatewayID})
+
+	nateGatewayIds, err := getAllNatGateways(session, time.Now().Add(1*time.Hour), config.Config{
+		NatGateway: config.ResourceType{
+			IncludeRule: config.FilterRule{
+				NamesRegExp: []config.Expression{
+					{RE: *regexp.MustCompile("^cloud-nuke-test-include-.*")},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 1, len(nateGatewayIds))
+	require.Equal(t, aws.StringValue(includedNatGatewayID), aws.StringValue(nateGatewayIds[0]))
 }
 
 func TestTimeFilterExclusionNewlyCreatedNatGateway(t *testing.T) {
@@ -108,7 +156,14 @@ func TestNukeNatGatewayMoreThanOne(t *testing.T) {
 	assertNatGatewaysDeleted(t, svc, natGateways)
 }
 
-// Helper functions for driving the NAT gateway tests
+// Helper functions for driving the NAT gateway testsŚ
+func setTagsToResource(t *testing.T, svc *ec2.EC2, resourceId *string, tags []*ec2.Tag) error {
+	_, err := svc.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{resourceId},
+		Tags: tags,
+	})
+	return err
+}
 
 // createNatGateway will create a new NAT gateway in the default VPC
 func createNatGateway(t *testing.T, svc *ec2.EC2, region string) *string {
@@ -119,10 +174,13 @@ func createNatGateway(t *testing.T, svc *ec2.EC2, region string) *string {
 		SubnetId:         aws.String(subnet.Id),
 		ConnectivityType: aws.String(ec2.ConnectivityTypePrivate),
 	})
-	require.NoError(t, err)
+	if err != nil {
+		assert.Failf(t, "Could not create test NAT gateways", errors.WithStackTrace(err).Error())
+	}
 	if resp.NatGateway == nil {
 		t.Fatalf("Impossible error: AWS returned nil NAT gateway")
 	}
+
 	return resp.NatGateway.NatGatewayId
 }
 

--- a/aws/nat_gateway_test.go
+++ b/aws/nat_gateway_test.go
@@ -64,7 +64,7 @@ func TestListNatGatewaysWithConfigFile(t *testing.T) {
 	excludedNatGatewayID := createNatGatewayWithName(t, svc, region, excludedNatGatewayName)
 	defer nukeAllNatGateways(session, []*string{includedNatGatewayID, excludedNatGatewayID})
 
-	nateGatewayIds, err := getAllNatGateways(session, time.Now().Add(1*time.Hour), config.Config{
+	natGatewayIds, err := getAllNatGateways(session, time.Now().Add(1*time.Hour), config.Config{
 		NatGateway: config.ResourceType{
 			IncludeRule: config.FilterRule{
 				NamesRegExp: []config.Expression{
@@ -75,8 +75,8 @@ func TestListNatGatewaysWithConfigFile(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, 1, len(nateGatewayIds))
-	require.Equal(t, aws.StringValue(includedNatGatewayID), aws.StringValue(nateGatewayIds[0]))
+	require.Equal(t, 1, len(natGatewayIds))
+	require.Equal(t, aws.StringValue(includedNatGatewayID), aws.StringValue(natGatewayIds[0]))
 }
 
 func TestTimeFilterExclusionNewlyCreatedNatGateway(t *testing.T) {
@@ -156,7 +156,7 @@ func TestNukeNatGatewayMoreThanOne(t *testing.T) {
 	assertNatGatewaysDeleted(t, svc, natGateways)
 }
 
-// Helper functions for driving the NAT gateway testsŚ
+// Helper functions for driving the NAT gateway tests
 func setTagsToResource(t *testing.T, svc *ec2.EC2, resourceId *string, tags []*ec2.Tag) error {
 	_, err := svc.CreateTags(&ec2.CreateTagsInput{
 		Resources: []*string{resourceId},


### PR DESCRIPTION
## Description

~~Solves https://github.com/gruntwork-io/cloud-nuke/issues/310.~~

Edit: I initially thought it would solve issue number 310, but the real problem is in the README.md since it's misleading and doesn't match with the Config key in the Go code (https://github.com/gruntwork-io/cloud-nuke/blob/master/config/config.go#L16). So this PR actually just adds a test and verifies that the code works properly (which it does), and adds a small verification step in the lookup function to make sure that it doesn't retrieve NAT gateways that are deleted or in deletion.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [X] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

- Added test to verify that looking up NAT Gateways with the configuration file works.
- Updated the NAT Gateway lookup method so that it does not retrieve deleted or in deletion resources.

### Migration Guide

None.
