### PR TITLE
fix: Config key typo in README for NAT Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ The following resources support the Config file:
     - Config key: `SecretsManager`
 - NAT Gateways
     - Resource type: `nat-gateway`
-    - Config key: `NATGateway`
+    - Config key: `NatGateway`
 - IAM Access Analyzers
     - Resource type: `accessanalyzer`
     - Config key: `AccessAnalyzer`


### PR DESCRIPTION
## Description

Fixes #314.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [X] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

- Updated the README so that the config key for NAT Gateways filtering is correct.

### Migration Guide

None.
