### PR TITLE
Fix nukeSecurityGroup for delete chained-security-group

### DIFF
--- a/aws/ec2_test.go
+++ b/aws/ec2_test.go
@@ -32,6 +32,7 @@ const (
 	ExampleSecurityGroupId      = "sg-" + ExampleId
 	ExampleSecurityGroupIdTwo   = "sg-" + ExampleIdTwo
 	ExampleSecurityGroupIdThree = "sg-" + ExampleIdThree
+	ExampleSecurityGroupRuleId  = "sgr-" + ExampleId
 	ExampleInternetGatewayId    = "igw-" + ExampleId
 	ExampleEndpointId           = "vpce-" + ExampleId
 )

--- a/aws/ec2_unit_test.go
+++ b/aws/ec2_unit_test.go
@@ -149,6 +149,14 @@ func TestNukeMockVpcs(t *testing.T) {
 		}
 		deleteNetworkAclInput := getDeleteNetworkAclInput(ExampleNetworkAclId)
 
+		describeSecurityGroupRulesInput := getDescribeSecurityGroupRulesInput(ExampleSecurityGroupId)
+		describeSecurityGroupRulesOutput := getDescribeSecurityGroupRulesOutput([]string{ExampleSecurityGroupRuleId})
+		describeSecurityGroupRulesFunc := func(input *ec2.DescribeSecurityGroupRulesInput) (*ec2.DescribeSecurityGroupRulesOutput, error) {
+			return describeSecurityGroupRulesOutput, nil
+		}
+		revokeSecurityGroupEgressInput := getRevokeSecurityGroupEgressInput(ExampleSecurityGroupId ,ExampleSecurityGroupRuleId)
+		revokeSecurityGroupIngressInput := getRevokeSecurityGroupIngressInput(ExampleSecurityGroupId, ExampleSecurityGroupRuleId)
+
 		describeSecurityGroupsInput := getDescribeSecurityGroupsInput(vpc.VpcId)
 		describeSecurityGroupsOutput := getDescribeSecurityGroupsOutput([]string{ExampleSecurityGroupId})
 		describeSecurityGroupsFunc := func(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
@@ -174,6 +182,9 @@ func TestNukeMockVpcs(t *testing.T) {
 			mockEC2.EXPECT().DescribeNetworkAcls(describeNetworkAclsInput).DoAndReturn(describeNetworkAclsFunc),
 			mockEC2.EXPECT().DeleteNetworkAcl(deleteNetworkAclInput),
 			mockEC2.EXPECT().DescribeSecurityGroups(describeSecurityGroupsInput).DoAndReturn(describeSecurityGroupsFunc),
+			mockEC2.EXPECT().DescribeSecurityGroupRules(describeSecurityGroupRulesInput).DoAndReturn(describeSecurityGroupRulesFunc),
+			mockEC2.EXPECT().RevokeSecurityGroupEgress(revokeSecurityGroupEgressInput),
+			mockEC2.EXPECT().RevokeSecurityGroupIngress(revokeSecurityGroupIngressInput),
 			mockEC2.EXPECT().DeleteSecurityGroup(deleteSecurityGroupInput),
 			mockEC2.EXPECT().DeleteVpc(deleteVpcInput),
 		)

--- a/aws/mock_ec2_utils_for_test.go
+++ b/aws/mock_ec2_utils_for_test.go
@@ -127,6 +127,46 @@ func getDeleteNetworkAclInput(networkAclId string) *ec2.DeleteNetworkAclInput {
 	}
 }
 
+func getDescribeSecurityGroupRulesInput(securityGroupId string) *ec2.DescribeSecurityGroupRulesInput {
+	return &ec2.DescribeSecurityGroupRulesInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name:   awsgo.String("group-id"),
+				Values: []*string{awsgo.String(securityGroupId)},
+			},
+		},
+	}
+}
+
+func getDescribeSecurityGroupRulesOutput(securityGroupRuleIds []string) *ec2.DescribeSecurityGroupRulesOutput {
+	var securityGroupRules []*ec2.SecurityGroupRule
+	for _, securityGroupRule := range securityGroupRuleIds {
+		securityGroupRules = append(securityGroupRules, &ec2.SecurityGroupRule{
+			IsEgress: awsgo.Bool(true), // egress rule
+			SecurityGroupRuleId: awsgo.String(securityGroupRule),
+		})
+		securityGroupRules = append(securityGroupRules, &ec2.SecurityGroupRule{
+			IsEgress: awsgo.Bool(false), // ingress rule
+			SecurityGroupRuleId: awsgo.String(securityGroupRule),
+		})
+	}
+	return &ec2.DescribeSecurityGroupRulesOutput{SecurityGroupRules: securityGroupRules}
+}
+
+func getRevokeSecurityGroupEgressInput(securityGroupId string, securityGroupRuleId string) *ec2.RevokeSecurityGroupEgressInput {
+	return &ec2.RevokeSecurityGroupEgressInput{
+		GroupId: awsgo.String(securityGroupId),
+		SecurityGroupRuleIds: []*string{awsgo.String(securityGroupRuleId)},
+	}
+}
+
+func getRevokeSecurityGroupIngressInput(securityGroupId string, securityGroupRuleId string) *ec2.RevokeSecurityGroupIngressInput {
+	return &ec2.RevokeSecurityGroupIngressInput{
+		GroupId: awsgo.String(securityGroupId),
+		SecurityGroupRuleIds: []*string{awsgo.String(securityGroupRuleId)},
+	}
+}
+
 func getDescribeSecurityGroupsInput(vpcId string) *ec2.DescribeSecurityGroupsInput {
 	return &ec2.DescribeSecurityGroupsInput{
 		Filters: []*ec2.Filter{


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fix nukeSecurityGroup to delete all ingess/egress rule before deleting security group.

and added testing code that using existing method.

Fixes #316.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

