### PR TITLE
Implement support for Macie member accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The currently supported functionality includes:
 - Inspecting and deleting all Customer managed keys from Key Management Service in an AWS account
 - Inspecting and deleting all CloudWatch Log Groups in an AWS Account
 - Inspecting and deleting all GuardDuty Detectors in an AWS Account
+- Inspecting and deleting all Macie member accounts in an AWS account - as long as those accounts were created by Invitation - and not via AWS Organizations
 
 ### BEWARE!
 

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -734,7 +734,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		// Macie member accounts
 		macieAccounts := MacieMember{}
 		if IsNukeable(macieAccounts.ResourceName(), resourceTypes) {
-			accountIds, err := getAllMacieAccounts(session, excludeAfter, configObj)
+			accountIds, err := getAllMacieMemberAccounts(session, excludeAfter, configObj)
 			if err != nil {
 				return nil, errors.WithStackTrace(err)
 			}

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -732,7 +732,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End GuardDuty detectors
 		// Macie member accounts
-		macieAccounts := Macie{}
+		macieAccounts := MacieMember{}
 		if IsNukeable(macieAccounts.ResourceName(), resourceTypes) {
 			accountIds, err := getAllMacieAccounts(session, excludeAfter, configObj)
 			if err != nil {
@@ -843,7 +843,7 @@ func ListResourceTypes() []string {
 		KmsCustomerKeys{}.ResourceName(),
 		CloudWatchLogGroups{}.ResourceName(),
 		GuardDuty{}.ResourceName(),
-		Macie{}.ResourceName(),
+		MacieMember{}.ResourceName(),
 	}
 	sort.Strings(resourceTypes)
 	return resourceTypes

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -731,6 +731,20 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 
 		}
 		// End GuardDuty detectors
+		// Macie member accounts
+		macieAccounts := Macie{}
+		if IsNukeable(macieAccounts.ResourceName(), resourceTypes) {
+			accountIds, err := getAllMacieAccounts(session, excludeAfter, configObj)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+			if len(accountIds) > 0 {
+				macieAccounts.AccountIds = accountIds
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, macieAccounts)
+			}
+
+		}
+		// End Macie member accounts
 
 		if len(resourcesInRegion.Resources) > 0 {
 			account.Resources[region] = resourcesInRegion
@@ -829,6 +843,7 @@ func ListResourceTypes() []string {
 		KmsCustomerKeys{}.ResourceName(),
 		CloudWatchLogGroups{}.ResourceName(),
 		GuardDuty{}.ResourceName(),
+		Macie{}.ResourceName(),
 	}
 	sort.Strings(resourceTypes)
 	return resourceTypes

--- a/aws/macie.go
+++ b/aws/macie.go
@@ -60,8 +60,6 @@ func nukeAllMacieMemberAccounts(session *session.Session, identifiers []string) 
 	svc := macie2.New(session)
 	region := aws.StringValue(session.Config.Region)
 
-	disassociatedAccountIds := []string{}
-
 	if len(identifiers) == 0 {
 		logging.Logger.Infof("No Macie member accounts to nuke in region %s", *session.Config.Region)
 		return nil
@@ -82,7 +80,6 @@ func nukeAllMacieMemberAccounts(session *session.Session, identifiers []string) 
 		}
 
 		logging.Logger.Infof("[OK] Macie account association for accountId %s deleted in %s", accountId, region)
-		disassociatedAccountIds = append(disassociatedAccountIds, accountId)
 	}
 
 	return nil

--- a/aws/macie.go
+++ b/aws/macie.go
@@ -19,23 +19,7 @@ func getAllMacieMemberAccounts(session *session.Session, excludeAfter time.Time,
 
 	allMacieAccounts := []string{}
 	output, err := svc.GetAdministratorAccount(&macie2.GetAdministratorAccountInput{})
-	// If the current account does have an Administrator account relationship, and it is enabled, then we consider this a macie member account
-	if output.Administrator != nil && output.Administrator.RelationshipStatus != nil {
-		if aws.StringValue(output.Administrator.RelationshipStatus) == macie2.RelationshipStatusEnabled {
-
-			input := &sts.GetCallerIdentityInput{}
-			output, err := stssvc.GetCallerIdentity(input)
-			if err != nil {
-				return allMacieAccounts, errors.WithStackTrace(err)
-			}
-
-			currentAccountId := aws.StringValue(output.Account)
-
-			allMacieAccounts = append(allMacieAccounts, currentAccountId)
-		}
-	}
 	if err != nil {
-
 		// There are several different errors that AWS may return when you attempt to call Macie operations on an account
 		// that doesn't yet have Macie enabled. For our purposes, this is fine, as we're only looking for those accounts and
 		// regions where Macie is enabled. Therefore, we ignore only these expected errors, and return any other errror that might occur
@@ -51,6 +35,22 @@ func getAllMacieMemberAccounts(session *session.Session, excludeAfter time.Time,
 			return allMacieAccounts, errors.WithStackTrace(err)
 		}
 	}
+	// If the current account does have an Administrator account relationship, and it is enabled, then we consider this a macie member account
+	if output.Administrator != nil && output.Administrator.RelationshipStatus != nil {
+		if aws.StringValue(output.Administrator.RelationshipStatus) == macie2.RelationshipStatusEnabled {
+
+			input := &sts.GetCallerIdentityInput{}
+			output, err := stssvc.GetCallerIdentity(input)
+			if err != nil {
+				return allMacieAccounts, errors.WithStackTrace(err)
+			}
+
+			currentAccountId := aws.StringValue(output.Account)
+
+			allMacieAccounts = append(allMacieAccounts, currentAccountId)
+		}
+	}
+
 	return allMacieAccounts, nil
 }
 

--- a/aws/macie.go
+++ b/aws/macie.go
@@ -1,0 +1,96 @@
+package aws
+
+import (
+	goerror "errors"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+func getAllMacieAccounts(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]string, error) {
+	svc := macie2.New(session)
+	stssvc := sts.New(session)
+
+	allMacieAccounts := []string{}
+	output, err := svc.GetAdministratorAccount(&macie2.GetAdministratorAccountInput{})
+	if output.Administrator != nil && output.Administrator.RelationshipStatus != nil {
+		if aws.StringValue(output.Administrator.RelationshipStatus) == macie2.RelationshipStatusEnabled {
+
+			input := &sts.GetCallerIdentityInput{}
+			output, err := stssvc.GetCallerIdentity(input)
+			if err != nil {
+				return allMacieAccounts, errors.WithStackTrace(err)
+			}
+
+			currentAccountId := aws.StringValue(output.Account)
+
+			if shouldIncludeMacieAccount(currentAccountId, excludeAfter, configObj) {
+				allMacieAccounts = append(allMacieAccounts, currentAccountId)
+			}
+		}
+	}
+	if err != nil {
+
+		// There are several different errors that AWS may return when you attempt to call Macie operations on an account
+		// that doesn't yet have Macie enabled. For our purposes, this is fine, as we're only looking for those accounts and
+		// regions where Macie is enabled. Therefore, we ignore only these expected errors, and return any other errror that might occur
+		var ade *macie2.AccessDeniedException
+		var rnfe *macie2.ResourceNotFoundException
+
+		switch {
+		case goerror.As(err, &ade):
+			logging.Logger.Debugf("Macie AccessDeniedException means macie is not enabled in account, so skipping")
+		case goerror.As(err, &rnfe):
+			logging.Logger.Debugf("Macie ResourceNotFoundException means macie is not enabled in account, so skipping")
+		default:
+			return allMacieAccounts, errors.WithStackTrace(err)
+		}
+	}
+	return allMacieAccounts, nil
+}
+
+// TODO - not sure this pattern is really useful here, as Macie member accounts don't have a timestamp for when they were "created"
+// The closest would be the timestamp for when they were initiall invited, but there could be a significant delta between when the
+// invite was first sent and when the member account actually accepted it. In the meantime, we probably want to drop this and just
+// return all macie memberships found
+func shouldIncludeMacieAccount(a string, excludeAfter time.Time, configObj config.Config) bool {
+	return true
+}
+
+func nukeAllMacieAccounts(session *session.Session, identifiers []string) error {
+	svc := macie2.New(session)
+	region := aws.StringValue(session.Config.Region)
+
+	disassociatedAccountIds := []string{}
+
+	if len(identifiers) == 0 {
+		logging.Logger.Infof("No Macie member accounts to nuke in region %s", *session.Config.Region)
+		return nil
+	}
+
+	logging.Logger.Infof("Deleting Macie account membership in %s", region)
+
+	for _, accountId := range identifiers {
+		_, disassociateErr := svc.DisassociateFromAdministratorAccount(&macie2.DisassociateFromAdministratorAccountInput{})
+
+		if disassociateErr != nil {
+			return errors.WithStackTrace(disassociateErr)
+		}
+
+		_, err := svc.DisableMacie(&macie2.DisableMacieInput{})
+		if err != nil {
+			return errors.WithStackTrace(err)
+		}
+
+		logging.Logger.Infof("[OK] Macie account association for accountId %s deleted in %s", accountId, region)
+		disassociatedAccountIds = append(disassociatedAccountIds, accountId)
+	}
+
+	return nil
+}

--- a/aws/macie.go
+++ b/aws/macie.go
@@ -22,15 +22,17 @@ func getAllMacieMemberAccounts(session *session.Session, excludeAfter time.Time,
 	if err != nil {
 		// There are several different errors that AWS may return when you attempt to call Macie operations on an account
 		// that doesn't yet have Macie enabled. For our purposes, this is fine, as we're only looking for those accounts and
-		// regions where Macie is enabled. Therefore, we ignore only these expected errors, and return any other errror that might occur
+		// regions where Macie is enabled. Therefore, we ignore only these expected errors, and return any other error that might occur
 		var ade *macie2.AccessDeniedException
 		var rnfe *macie2.ResourceNotFoundException
 
 		switch {
 		case goerror.As(err, &ade):
 			logging.Logger.Debugf("Macie AccessDeniedException means macie is not enabled in account, so skipping")
+			return allMacieAccounts, nil
 		case goerror.As(err, &rnfe):
 			logging.Logger.Debugf("Macie ResourceNotFoundException means macie is not enabled in account, so skipping")
+			return allMacieAccounts, nil
 		default:
 			return allMacieAccounts, errors.WithStackTrace(err)
 		}

--- a/aws/macie.go
+++ b/aws/macie.go
@@ -19,6 +19,7 @@ func getAllMacieAccounts(session *session.Session, excludeAfter time.Time, confi
 
 	allMacieAccounts := []string{}
 	output, err := svc.GetAdministratorAccount(&macie2.GetAdministratorAccountInput{})
+	// If the current account does have an Administrator account relationship, and it is enabled, then we consider this a macie member account
 	if output.Administrator != nil && output.Administrator.RelationshipStatus != nil {
 		if aws.StringValue(output.Administrator.RelationshipStatus) == macie2.RelationshipStatusEnabled {
 
@@ -30,9 +31,7 @@ func getAllMacieAccounts(session *session.Session, excludeAfter time.Time, confi
 
 			currentAccountId := aws.StringValue(output.Account)
 
-			if shouldIncludeMacieAccount(currentAccountId, excludeAfter, configObj) {
-				allMacieAccounts = append(allMacieAccounts, currentAccountId)
-			}
+			allMacieAccounts = append(allMacieAccounts, currentAccountId)
 		}
 	}
 	if err != nil {
@@ -53,14 +52,6 @@ func getAllMacieAccounts(session *session.Session, excludeAfter time.Time, confi
 		}
 	}
 	return allMacieAccounts, nil
-}
-
-// TODO - not sure this pattern is really useful here, as Macie member accounts don't have a timestamp for when they were "created"
-// The closest would be the timestamp for when they were initiall invited, but there could be a significant delta between when the
-// invite was first sent and when the member account actually accepted it. In the meantime, we probably want to drop this and just
-// return all macie memberships found
-func shouldIncludeMacieAccount(a string, excludeAfter time.Time, configObj config.Config) bool {
-	return true
 }
 
 func nukeAllMacieAccounts(session *session.Session, identifiers []string) error {

--- a/aws/macie.go
+++ b/aws/macie.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-func getAllMacieAccounts(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]string, error) {
+func getAllMacieMemberAccounts(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]string, error) {
 	svc := macie2.New(session)
 	stssvc := sts.New(session)
 
@@ -54,7 +54,7 @@ func getAllMacieAccounts(session *session.Session, excludeAfter time.Time, confi
 	return allMacieAccounts, nil
 }
 
-func nukeAllMacieAccounts(session *session.Session, identifiers []string) error {
+func nukeAllMacieMemberAccounts(session *session.Session, identifiers []string) error {
 	svc := macie2.New(session)
 	region := aws.StringValue(session.Config.Region)
 

--- a/aws/macie.go
+++ b/aws/macie.go
@@ -65,7 +65,7 @@ func nukeAllMacieAccounts(session *session.Session, identifiers []string) error 
 		return nil
 	}
 
-	logging.Logger.Infof("Deleting Macie account membership in %s", region)
+	logging.Logger.Infof("Deleting Macie account membership and disabling Macie in %s", region)
 
 	for _, accountId := range identifiers {
 		_, disassociateErr := svc.DisassociateFromAdministratorAccount(&macie2.DisassociateFromAdministratorAccountInput{})

--- a/aws/macie_test.go
+++ b/aws/macie_test.go
@@ -32,9 +32,14 @@ func TestListMacieAccounts(t *testing.T) {
 	assert.Contains(t, retrievedAccountIds, accountId)
 }
 
-// TODO - for this to work properly, we'd probably need a standing invite from another test account
-// that we can continually re-accept at testing time. In testing with the AWS console, you can contiunously
-// delete your membership account association, then re-accept the same standing invitation after enabling Macie again
+// Macie is not very conducive to programmatic testing. In order to make this test work, we  maintain a standing invite
+// from our phxdevops test account to our nuclear-wasteland account. We can continuously "nuke" our membership because
+// Macie supports a member account *that was invited* to remove its own association at any time. Meanwhile, diassociating
+// in this manner does not destroy or invalidate the original invitation, which allows us to to continually re-accept it
+// from our nuclear-wasteland account (where cloud-nuke tests are run), just so that we can nuke it again
+//
+// Macie is also regional, so for the purposes of cost-savings and lower admin overhead, we're initially only testing this
+// in the one hardcoded region
 func acceptTestInvite(t *testing.T, session *session.Session) {
 	svc := macie2.New(session)
 

--- a/aws/macie_test.go
+++ b/aws/macie_test.go
@@ -24,9 +24,9 @@ func TestListMacieAccounts(t *testing.T) {
 
 	acceptTestInvite(t, session)
 	// Clean up after test by deleting the macie account association
-	defer nukeAllMacieAccounts(session, []string{accountId})
+	defer nukeAllMacieMemberAccounts(session, []string{accountId})
 
-	retrievedAccountIds, lookupErr := getAllMacieAccounts(session, time.Now(), config.Config{})
+	retrievedAccountIds, lookupErr := getAllMacieMemberAccounts(session, time.Now(), config.Config{})
 	require.NoError(t, lookupErr)
 
 	assert.Contains(t, retrievedAccountIds, accountId)

--- a/aws/macie_test.go
+++ b/aws/macie_test.go
@@ -34,7 +34,7 @@ func TestListMacieAccounts(t *testing.T) {
 
 // Macie is not very conducive to programmatic testing. In order to make this test work, we  maintain a standing invite
 // from our phxdevops test account to our nuclear-wasteland account. We can continuously "nuke" our membership because
-// Macie supports a member account *that was invited* to remove its own association at any time. Meanwhile, diassociating
+// Macie supports a member account *that was invited* to remove its own association at any time. Meanwhile, disassociating
 // in this manner does not destroy or invalidate the original invitation, which allows us to to continually re-accept it
 // from our nuclear-wasteland account (where cloud-nuke tests are run), just so that we can nuke it again
 //

--- a/aws/macie_test.go
+++ b/aws/macie_test.go
@@ -1,0 +1,44 @@
+package aws
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListMacieAccounts(t *testing.T) {
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	accountId, err := util.GetCurrentAccountId(session)
+	require.NoError(t, err)
+
+	enableMacieAndAcceptInvite(t, session)
+	// Clean up after test by deleting the macie account association
+	defer nukeAllMacieAccounts(session, []string{accountId})
+
+	retrievedAccountIds, lookupErr := getAllMacieAccounts(session, time.Now(), config.Config{})
+	require.NoError(t, lookupErr)
+
+	assert.Contains(t, retrievedAccountIds, accountId)
+}
+
+// TODO - for this to work properly, we'd probably need a standing invite from another test account
+// that we can continually re-accept at testing time. In testing with the AWS console, you can contiunously
+// delete your membership account association, then re-accept the same standing invitation after enabling Macie again
+func enableMacieAndAcceptInvite(t *testing.T, session *session.Session) {
+	svc := macie2.New(session)
+
+	_, err := svc.EnableMacie(&macie2.EnableMacieInput{})
+	require.NoError(t, err)
+}

--- a/aws/macie_test.go
+++ b/aws/macie_test.go
@@ -14,16 +14,15 @@ import (
 )
 
 func TestListMacieAccounts(t *testing.T) {
-	region, err := getRandomRegion()
-	require.NoError(t, err)
-
+	// Currently we hardcode to region us-east-1, because this is where our "standing" test invite exists
+	region := "us-east-1"
 	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
 	require.NoError(t, err)
 
 	accountId, err := util.GetCurrentAccountId(session)
 	require.NoError(t, err)
 
-	enableMacieAndAcceptInvite(t, session)
+	acceptTestInvite(t, session)
 	// Clean up after test by deleting the macie account association
 	defer nukeAllMacieAccounts(session, []string{accountId})
 
@@ -36,9 +35,16 @@ func TestListMacieAccounts(t *testing.T) {
 // TODO - for this to work properly, we'd probably need a standing invite from another test account
 // that we can continually re-accept at testing time. In testing with the AWS console, you can contiunously
 // delete your membership account association, then re-accept the same standing invitation after enabling Macie again
-func enableMacieAndAcceptInvite(t *testing.T, session *session.Session) {
+func acceptTestInvite(t *testing.T, session *session.Session) {
 	svc := macie2.New(session)
 
-	_, err := svc.EnableMacie(&macie2.EnableMacieInput{})
-	require.NoError(t, err)
+	// Accept the "standing" invite from our other test account to become a Macie member account
+	// This works because Macie invites don't expire or get deleted when you disassociate your member account following an invitation
+	acceptInviteInput := &macie2.AcceptInvitationInput{
+		AdministratorAccountId: aws.String("087285199408"),                     // phxdevops
+		InvitationId:           aws.String("28c0eacd402dd97cbf8a0c14b6cc3237"), // "standing" test invite ID
+	}
+
+	_, acceptInviteErr := svc.AcceptInvitation(acceptInviteInput)
+	require.NoError(t, acceptInviteErr)
 }

--- a/aws/macie_test.go
+++ b/aws/macie_test.go
@@ -46,8 +46,8 @@ func acceptTestInvite(t *testing.T, session *session.Session) {
 	// Accept the "standing" invite from our other test account to become a Macie member account
 	// This works because Macie invites don't expire or get deleted when you disassociate your member account following an invitation
 	acceptInviteInput := &macie2.AcceptInvitationInput{
-		AdministratorAccountId: aws.String("087285199408"),                     // phxdevops
-		InvitationId:           aws.String("28c0eacd402dd97cbf8a0c14b6cc3237"), // "standing" test invite ID
+		AdministratorAccountId: aws.String("353720269506"),                     // sandbox
+		InvitationId:           aws.String("18c0febb89142640f07ba497b19bac8e"), // "standing" test invite ID
 	}
 
 	_, acceptInviteErr := svc.AcceptInvitation(acceptInviteInput)

--- a/aws/macie_test.go
+++ b/aws/macie_test.go
@@ -39,7 +39,11 @@ func TestListMacieAccounts(t *testing.T) {
 // from our nuclear-wasteland account (where cloud-nuke tests are run), just so that we can nuke it again
 //
 // Macie is also regional, so for the purposes of cost-savings and lower admin overhead, we're initially only testing this
-// in the one hardcoded region
+// in the one hardcoded region - us-east-1
+//
+// The other reason we only test in us-east-1 is to avoid conflict with our Macie test in the CIS service catalog, which uses
+// these same two accounts for similar purposes, but in EU regions.
+// See: https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/blob/master/test/security/macie_test.go
 func acceptTestInvite(t *testing.T, session *session.Session) {
 	svc := macie2.New(session)
 

--- a/aws/macie_types.go
+++ b/aws/macie_types.go
@@ -1,0 +1,29 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+type Macie struct {
+	AccountIds []string
+}
+
+func (r Macie) ResourceName() string {
+	return "macie"
+}
+
+func (r Macie) ResourceIdentifiers() []string {
+	return r.AccountIds
+}
+
+func (r Macie) MaxBatchSize() int {
+	return 10
+}
+
+func (r Macie) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllMacieAccounts(session, identifiers); err != nil {
+		return errors.WithStackTrace(err)
+	}
+	return nil
+}

--- a/aws/macie_types.go
+++ b/aws/macie_types.go
@@ -10,7 +10,7 @@ type MacieMember struct {
 }
 
 func (r MacieMember) ResourceName() string {
-	return "macie"
+	return "macie-member"
 }
 
 func (r MacieMember) ResourceIdentifiers() []string {

--- a/aws/macie_types.go
+++ b/aws/macie_types.go
@@ -22,7 +22,7 @@ func (r MacieMember) MaxBatchSize() int {
 }
 
 func (r MacieMember) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllMacieAccounts(session, identifiers); err != nil {
+	if err := nukeAllMacieMemberAccounts(session, identifiers); err != nil {
 		return errors.WithStackTrace(err)
 	}
 	return nil

--- a/aws/macie_types.go
+++ b/aws/macie_types.go
@@ -5,23 +5,23 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-type Macie struct {
+type MacieMember struct {
 	AccountIds []string
 }
 
-func (r Macie) ResourceName() string {
+func (r MacieMember) ResourceName() string {
 	return "macie"
 }
 
-func (r Macie) ResourceIdentifiers() []string {
+func (r MacieMember) ResourceIdentifiers() []string {
 	return r.AccountIds
 }
 
-func (r Macie) MaxBatchSize() int {
+func (r MacieMember) MaxBatchSize() int {
 	return 10
 }
 
-func (r Macie) Nuke(session *session.Session, identifiers []string) error {
+func (r MacieMember) Nuke(session *session.Session, identifiers []string) error {
 	if err := nukeAllMacieAccounts(session, identifiers); err != nil {
 		return errors.WithStackTrace(err)
 	}

--- a/util/get_current_account_id.go
+++ b/util/get_current_account_id.go
@@ -1,0 +1,21 @@
+package util
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+func GetCurrentAccountId(session *session.Session) (string, error) {
+	stssvc := sts.New(session)
+
+	input := &sts.GetCallerIdentityInput{}
+
+	output, err := stssvc.GetCallerIdentity(input)
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+
+	return aws.StringValue(output.Account), nil
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #322 by implementing support for "nuking" Macie accounts that were created by Invitation only. (Macie member accounts created via AWS Organizations do not have sufficient permissions to disassociate _themselves_ from the Org). 

Programmatic testing with Macie is pretty awkward. I found that you can continuously accept an invite from another account to become a member account, then disassociate yourself (nuke), then re-use the same standing invitation to re-associate yourself as a member account. I'm currently using this workaround to leave a "standing" invite from our phxdevops account in `us-east-1` for sanity. 

We could expand our test coverage out to other regions, but that would just require maintaining a map of regions to standing invitation IDs.

Furthermore, Macie member accounts don't expose anything useful to us in terms of filtering resources by their creation time, so the usual semantics of `excludeAfter` won't work here. As a result, I just include all found member Macie accounts as nuke-able. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

Implement support for inspecting and nuking Macie member accounts that were created via Invitation only. (Macie member accounts created via AWS Organizations are not able to disassociate themselves). 

