### PR TITLE
Handle NatGatewayNotFound

### DIFF
--- a/aws/nat_gateway.go
+++ b/aws/nat_gateway.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/go-commons/errors"
@@ -137,6 +138,9 @@ func areAllNatGatewaysDeleted(svc *ec2.EC2, identifiers []*string) (bool, error)
 	// based on NatGateways.MaxBatchSize.
 	resp, err := svc.DescribeNatGateways(&ec2.DescribeNatGatewaysInput{NatGatewayIds: identifiers})
 	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NatGatewayNotFound" {
+			return true, nil
+		}
 		return false, err
 	}
 	if len(resp.NatGateways) == 0 {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This fixes a bug in the NatGateway nuke routine where the wait routine ignored `NatGatewayNotFound`.

```
[cloud-nuke] INFO[2022-07-07T13:10:06-05:00] Waiting for all NAT gateways to be deleted. returned an error: FatalError{Underlying: NatGatewayNotFound: NAT gateway nat-0f23ac5d3265a98ff was not found
        status code: 400, request id: 578dc5b2-d2b1-4906-8bd0-650a6826e2fc}. Attempt 1 of 30. Sleeping for 10s and will retry.
[cloud-nuke] INFO[2022-07-07T13:10:16-05:00] Waiting for all NAT gateways to be deleted.
[cloud-nuke] INFO[2022-07-07T13:10:16-05:00] Waiting for all NAT gateways to be deleted. returned an error: FatalError{Underlying: NatGatewayNotFound: NAT gateway nat-0f23ac5d3265a98ff was not found
        status code: 400, request id: 1a31f4d5-9943-46d8-aea1-8f4f52bd9cf1}. Attempt 2 of 30. Sleeping for 10s and will retry.
```

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Fixes a bug in the NAT Gateway nuke routine where 404 errors were ignored.