### PR TITLE
Fix circleci pipeline to use scheduled pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   docker:
     - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.16-tf1.0-tg31.1-pck1.7
-version: 2
+version: 2.1
 jobs:
   test:
     <<: *defaults
@@ -73,6 +73,10 @@ jobs:
 workflows:
   version: 2
   build-and-test:
+    # Make sure this pipeline doesn't run when a schedule is triggered
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - test:
           filters:
@@ -96,24 +100,20 @@ workflows:
               ignore: /.*/
           context:
             - Gruntwork Admin
-  frequently:
-    triggers:
-      - schedule:
-          cron: "0 0,3,6,9,12,15,18,21 * * *"
-          filters:
-            branches:
-              only: master
+  nuke_phxdevops:
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "every 3 hours", << pipeline.schedule.name >> ]
     jobs:
       - nuke_phx_devops:
           context:
             - Gruntwork Admin
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 6 * * *"
-          filters:
-            branches:
-              only: master
+  nuke_sandbox:
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "nightly", << pipeline.schedule.name >> ]
     jobs:
       - nuke_sandbox:
           context:


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

It turns out that we haven't been running the nuking routines due to the CircleCI triggers changing it's permissions model to no longer support scheduled workflows. Instead, we need to migrate to using [scheduled pipelines](https://circleci.com/docs/scheduled-pipelines). This PR updates the CCI config to start supporting scheduled pipelines.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
(no functional changes)