### PR TITLE
Remove unused variables from getAllMacieMemberAccounts

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -720,7 +720,8 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		// Macie member accounts
 		macieAccounts := MacieMember{}
 		if IsNukeable(macieAccounts.ResourceName(), resourceTypes) {
-			accountIds, err := getAllMacieMemberAccounts(session, excludeAfter, configObj)
+			// Unfortunately, the Macie API doesn't provide the metadata information we'd need to implement the excludeAfter or configObj patterns
+			accountIds, err := getAllMacieMemberAccounts(cloudNukeSession)
 			if err != nil {
 				return nil, errors.WithStackTrace(err)
 			}

--- a/aws/macie.go
+++ b/aws/macie.go
@@ -2,18 +2,19 @@ package aws
 
 import (
 	goerror "errors"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/macie2"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-func getAllMacieMemberAccounts(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]string, error) {
+// getAllMacieMemberAccounts will find and return any Macie accounts that were created via accepting an invite from another AWS Account
+// Unfortunately, the Macie API doesn't provide the metadata information we'd need to implement the excludeAfter or configObj patterns, so we
+// currently can only accept a session
+func getAllMacieMemberAccounts(session *session.Session) ([]string, error) {
 	svc := macie2.New(session)
 	stssvc := sts.New(session)
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Removes unused parameters from `getAllMacieMemberAccounts` per discussion [here](https://github.com/gruntwork-io/cloud-nuke/pull/323#discussion_r923663400).

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

