### PR TITLE
Implement support for IAM Roles

### DIFF
--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -106,3 +106,7 @@ IAMUsers:
     names_regex:
       # We want to make sure the main circle-ci-test user is never deleted
       - "^circle-ci-test$"
+IAMRoles:
+  include: 
+    names_regex: 
+      - "^cloud-nuke-Test*"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 vendor
 .vscode
 cloud-nuke
+config.yaml
+.envrc

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ The currently supported functionality includes:
 - Inspecting and deleting all Secrets Manager Secrets in an AWS account
 - Inspecting and deleting all NAT Gateways in an AWS account
 - Inspecting and deleting all IAM Access Analyzers in an AWS account
+- Deleting all IAM users in an AWS account
+- Deleting all IAM roles in an AWS account (except aws defined roles and OrganizationAccountAccessRole)
+- Deleting all Secrets Manager Secrets in an AWS account
+- Deleting all NAT Gateways in an AWS account
+- Deleting all IAM Access Analyzers in an AWS account
 - Revoking the default rules in the un-deletable default security group of a VPC
 - Inspecting and deleting all DynamoDB tables in an AWS account
 - Inspecting and deleting all CloudWatch Dashboards in an AWS account

--- a/README.md
+++ b/README.md
@@ -31,14 +31,10 @@ The currently supported functionality includes:
 - Inspecting and deleting all default VPCs in an AWS account
 - Deleting VPCs in an AWS Account (except for default VPCs which is handled by the dedicated `defaults-aws` subcommand)
 - Inspecting and deleting all IAM users in an AWS account
+- Inspecting and deleting all IAM roles in an AWS account
 - Inspecting and deleting all Secrets Manager Secrets in an AWS account
 - Inspecting and deleting all NAT Gateways in an AWS account
 - Inspecting and deleting all IAM Access Analyzers in an AWS account
-- Deleting all IAM users in an AWS account
-- Deleting all IAM roles in an AWS account (except aws defined roles and OrganizationAccountAccessRole)
-- Deleting all Secrets Manager Secrets in an AWS account
-- Deleting all NAT Gateways in an AWS account
-- Deleting all IAM Access Analyzers in an AWS account
 - Revoking the default rules in the un-deletable default security group of a VPC
 - Inspecting and deleting all DynamoDB tables in an AWS account
 - Inspecting and deleting all CloudWatch Dashboards in an AWS account

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -786,6 +786,20 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End IAM OpenIDConnectProviders
 
+		// IAM Roles
+		iamRoles := IAMRoles{}
+		if IsNukeable(iamRoles.ResourceName(), resourceTypes) {
+			roleNames, err := getAllIamRoles(session, excludeAfter, configObj)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+			if len(roleNames) > 0 {
+				iamRoles.RoleNames = awsgo.StringValueSlice(roleNames)
+				globalResources.Resources = append(globalResources.Resources, iamRoles)
+			}
+		}
+		// End IAM Roles
+
 		if len(globalResources.Resources) > 0 {
 			account.Resources[GlobalRegion] = globalResources
 		}
@@ -818,6 +832,7 @@ func ListResourceTypes() []string {
 		LambdaFunctions{}.ResourceName(),
 		S3Buckets{}.ResourceName(),
 		IAMUsers{}.ResourceName(),
+		IAMRoles{}.ResourceName(),
 		SecretsManagerSecrets{}.ResourceName(),
 		NatGateways{}.ResourceName(),
 		OpenSearchDomains{}.ResourceName(),

--- a/aws/iam_role.go
+++ b/aws/iam_role.go
@@ -151,7 +151,7 @@ func nukeAllIamRoles(session *session.Session, roleNames []*string) error {
 	}
 
 	// NOTE: we don't need to do pagination here, because the pagination is handled by the caller to this function,
-	// based on NatGateways.MaxBatchSize, however we add a guard here to warn users when the batching fails and has a
+	// based on IAMRoles.MaxBatchSize, however we add a guard here to warn users when the batching fails and has a
 	// chance of throttling AWS. Since we concurrently make one call for each identifier, we pick 100 for the limit here
 	// because many APIs in AWS have a limit of 100 requests per second.
 	if len(roleNames) > 100 {

--- a/aws/iam_role.go
+++ b/aws/iam_role.go
@@ -142,7 +142,6 @@ func nukeRole(svc *iam.IAM, roleName *string) error {
 // Delete all IAM Roles
 func nukeAllIamRoles(session *session.Session, roleNames []*string) error {
 	region := aws.StringValue(session.Config.Region)
-
 	svc := iam.New(session)
 
 	if len(roleNames) == 0 {

--- a/aws/iam_role.go
+++ b/aws/iam_role.go
@@ -1,0 +1,176 @@
+package aws
+
+import (
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/hashicorp/go-multierror"
+)
+
+// List all IAM users in the AWS account and returns a slice of the UserNames
+func getAllIamRoles(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
+	svc := iam.New(session)
+
+	var roleNames []*string
+
+	// TODO: Probably use ListRoles together with ListRolesPages in case there are lots of roles
+	output, err := svc.ListRoles(&iam.ListRolesInput{})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	for _, role := range output.Roles {
+		if strings.Contains(aws.StringValue(role.RoleName), "OrganizationAccountAccessRole") {
+			continue
+		}
+		if strings.Contains(aws.StringValue(role.Arn), "aws-service-role") || strings.Contains(aws.StringValue(role.Arn), "aws-reserved") {
+			continue
+		}
+
+		if config.ShouldInclude(aws.StringValue(role.RoleName), configObj.IAMRoles.IncludeRule.NamesRegExp, configObj.IAMRoles.ExcludeRule.NamesRegExp) && excludeAfter.After(*role.CreateDate) {
+			roleNames = append(roleNames, role.RoleName)
+		}
+	}
+
+	return roleNames, nil
+}
+
+func detachRolePolicies(svc *iam.IAM, roleName *string) error {
+	policiesOutput, err := svc.ListAttachedRolePolicies(&iam.ListAttachedRolePoliciesInput{
+		RoleName: roleName,
+	})
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	for _, attachedPolicy := range policiesOutput.AttachedPolicies {
+		arn := attachedPolicy.PolicyArn
+		_, err = svc.DetachRolePolicy(&iam.DetachRolePolicyInput{
+			PolicyArn: arn,
+			RoleName:  roleName,
+		})
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+			return errors.WithStackTrace(err)
+		}
+		logging.Logger.Infof("Detached Policy %s from Role %s", aws.StringValue(arn), aws.StringValue(roleName))
+	}
+
+	return nil
+}
+
+func deleteInlineRolePolicies(svc *iam.IAM, roleName *string) error {
+	policyOutput, err := svc.ListRolePolicies(&iam.ListRolePoliciesInput{
+		RoleName: roleName,
+	})
+	if err != nil {
+		logging.Logger.Errorf("[Failed] %s", err)
+		return errors.WithStackTrace(err)
+	}
+
+	for _, policyName := range policyOutput.PolicyNames {
+		_, err := svc.DeleteRolePolicy(&iam.DeleteRolePolicyInput{
+			PolicyName: policyName,
+			RoleName:   roleName,
+		})
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+			return errors.WithStackTrace(err)
+		}
+		logging.Logger.Infof("Deleted Inline Policy %s from Role %s", aws.StringValue(policyName), aws.StringValue(roleName))
+	}
+
+	return nil
+}
+
+func removeRoleFromInstanceProfiles(svc *iam.IAM, roleName *string) error {
+	resp, err := svc.ListInstanceProfilesForRole(&iam.ListInstanceProfilesForRoleInput{
+		RoleName: roleName,
+	})
+	if err != nil {
+		logging.Logger.Errorf("[Failed] %s", err)
+		return errors.WithStackTrace(err)
+	}
+
+	for _, profile := range resp.InstanceProfiles {
+		_, err := svc.RemoveRoleFromInstanceProfile(&iam.RemoveRoleFromInstanceProfileInput{
+			RoleName:            roleName,
+			InstanceProfileName: profile.InstanceProfileName,
+		})
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+			return errors.WithStackTrace(err)
+		}
+
+		logging.Logger.Infof("Removed Role %s from Instance Profile %s", aws.StringValue(roleName), aws.StringValue(profile.InstanceProfileName))
+	}
+
+	return nil
+}
+
+func deleteIamRole(svc *iam.IAM, roleName *string) error {
+	_, err := svc.DeleteRole(&iam.DeleteRoleInput{
+		RoleName: roleName,
+	})
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+// Nuke a single user
+func nukeRole(svc *iam.IAM, roleName *string) error {
+	// Functions used to really nuke an IAM Role as a role can have many attached
+	// items we need delete/detach them before actually deleting it.
+	// NOTE: The actual role deletion should always be the last one. This way we
+	// can guarantee that it will fail if we forgot to delete/detach an item.
+	functions := []func(svc *iam.IAM, roleName *string) error{
+		detachRolePolicies,
+		deleteInlineRolePolicies,
+		removeRoleFromInstanceProfiles,
+		deleteIamRole,
+	}
+
+	for _, fn := range functions {
+		if err := fn(svc, roleName); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Delete all IAM Roles
+func nukeAllIamRoles(session *session.Session, roleNames []*string) error {
+	if len(roleNames) == 0 {
+		logging.Logger.Info("No IAM Users to nuke")
+		return nil
+	}
+
+	logging.Logger.Info("Deleting all IAM Users")
+
+	deletedUsers := 0
+	svc := iam.New(session)
+	multiErr := new(multierror.Error)
+
+	for _, roleName := range roleNames {
+		err := nukeRole(svc, roleName)
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+			multierror.Append(multiErr, err)
+		} else {
+			deletedUsers++
+			logging.Logger.Infof("Deleted IAM Role: %s", *roleName)
+		}
+	}
+
+	logging.Logger.Infof("[OK] %d IAM Roles(s) terminated", deletedUsers)
+	return multiErr.ErrorOrNil()
+}

--- a/aws/iam_role.go
+++ b/aws/iam_role.go
@@ -117,28 +117,6 @@ func deleteIamRole(svc *iam.IAM, roleName *string) error {
 	return nil
 }
 
-// Nuke a single IAM Role
-func nukeRole(svc *iam.IAM, roleName *string) error {
-	// Functions used to really nuke an IAM Role as a role can have many attached
-	// items we need delete/detach them before actually deleting it.
-	// NOTE: The actual role deletion should always be the last one. This way we
-	// can guarantee that it will fail if we forgot to delete/detach an item.
-	functions := []func(svc *iam.IAM, roleName *string) error{
-		detachInstanceProfilesFromRole,
-		deleteInlineRolePolicies,
-		deleteManagedRolePolicies,
-		deleteIamRole,
-	}
-
-	for _, fn := range functions {
-		if err := fn(svc, roleName); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // Delete all IAM Roles
 func nukeAllIamRoles(session *session.Session, roleNames []*string) error {
 	region := aws.StringValue(session.Config.Region)

--- a/aws/iam_role.go
+++ b/aws/iam_role.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-// List all IAM users in the AWS account and returns a slice of the UserNames
+// List all IAM Roles in the AWS account
 func getAllIamRoles(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
 	svc := iam.New(session)
 
@@ -117,7 +117,7 @@ func deleteIamRole(svc *iam.IAM, roleName *string) error {
 	return nil
 }
 
-// Nuke a single user
+// Nuke a single IAM Role
 func nukeRole(svc *iam.IAM, roleName *string) error {
 	// Functions used to really nuke an IAM Role as a role can have many attached
 	// items we need delete/detach them before actually deleting it.

--- a/aws/iam_role_test.go
+++ b/aws/iam_role_test.go
@@ -1,0 +1,134 @@
+package aws
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListIamRoles(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
+	require.NoError(t, err)
+
+	roleNames, err := getAllIamRoles(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, roleNames)
+}
+
+func createTestRole(t *testing.T, session *session.Session, name string) error {
+	svc := iam.New(session)
+
+	input := &iam.CreateRoleInput{
+		RoleName: aws.String(name),
+		AssumeRolePolicyDocument: aws.String(`{
+			"Version": "2012-10-17",
+			"Statement": [
+			  {
+				"Effect": "Allow",
+				"Principal": {
+				  "Service": "ec2.amazonaws.com"
+				},
+				"Action": "sts:AssumeRole"
+			  }
+			]
+		  }`),
+	}
+
+	_, err := svc.CreateRole(input)
+	require.NoError(t, err)
+
+	return nil
+}
+
+func TestCreateIamRole(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
+	require.NoError(t, err)
+
+	name := "cloud-nuke-test-" + util.UniqueID()
+	roleNames, err := getAllIamRoles(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.NotContains(t, awsgo.StringValueSlice(roleNames), name)
+
+	err = createTestRole(t, session, name)
+	defer nukeAllIamRoles(session, []*string{&name})
+	require.NoError(t, err)
+
+	roleNames, err = getAllIamRoles(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.Contains(t, awsgo.StringValueSlice(roleNames), name)
+}
+
+func TestNukeIamRoles(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
+	require.NoError(t, err)
+
+	name := "cloud-nuke-test-" + util.UniqueID()
+	err = createTestRole(t, session, name)
+	require.NoError(t, err)
+
+	err = nukeAllIamRoles(session, []*string{&name})
+	require.NoError(t, err)
+}
+
+func TestTimeFilterExclusionNewlyCreatedIamRole(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
+	require.NoError(t, err)
+
+	// Assert role didn't exist
+	name := "cloud-nuke-test-" + util.UniqueID()
+	roleNames, err := getAllIamRoles(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.NotContains(t, awsgo.StringValueSlice(roleNames), name)
+
+	// Creates a role
+	err = createTestRole(t, session, name)
+	defer nukeAllIamRoles(session, []*string{&name})
+
+	// Assert role is created
+	roleNames, err = getAllIamRoles(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.Contains(t, awsgo.StringValueSlice(roleNames), name)
+
+	// Assert role doesn't appear when we look at roles older than 1 Hour
+	olderThan := time.Now().Add(-1 * time.Hour)
+	roleNames, err = getAllIamRoles(session, olderThan, config.Config{})
+	require.NoError(t, err)
+	assert.NotContains(t, awsgo.StringValueSlice(roleNames), name)
+}

--- a/aws/iam_role_types.go
+++ b/aws/iam_role_types.go
@@ -1,0 +1,36 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+// IAMRoles - represents all IAMRoles on the AWS Account
+type IAMRoles struct {
+	RoleNames []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (r IAMRoles) ResourceName() string {
+	return "iam-role"
+}
+
+// ResourceIdentifiers - The IAM UserNames
+func (r IAMRoles) ResourceIdentifiers() []string {
+	return r.RoleNames
+}
+
+// Tentative batch size to ensure AWS doesn't throttle
+func (r IAMRoles) MaxBatchSize() int {
+	return 200
+}
+
+// Nuke - nuke 'em all!!!
+func (r IAMRoles) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllIamRoles(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/aws/iam_role_types.go
+++ b/aws/iam_role_types.go
@@ -23,7 +23,7 @@ func (r IAMRoles) ResourceIdentifiers() []string {
 
 // Tentative batch size to ensure AWS doesn't throttle
 func (r IAMRoles) MaxBatchSize() int {
-	return 200
+	return 80
 }
 
 // Nuke - nuke 'em all!!!

--- a/aws/macie_test.go
+++ b/aws/macie_test.go
@@ -2,12 +2,10 @@ package aws
 
 import (
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/macie2"
-	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,7 +24,7 @@ func TestListMacieAccounts(t *testing.T) {
 	// Clean up after test by deleting the macie account association
 	defer nukeAllMacieMemberAccounts(session, []string{accountId})
 
-	retrievedAccountIds, lookupErr := getAllMacieMemberAccounts(session, time.Now(), config.Config{})
+	retrievedAccountIds, lookupErr := getAllMacieMemberAccounts(session)
 	require.NoError(t, lookupErr)
 
 	assert.Contains(t, retrievedAccountIds, accountId)

--- a/aws/types.go
+++ b/aws/types.go
@@ -110,12 +110,15 @@ func (q *Query) Validate() error {
 
 	q.ResourceTypes = resourceTypes
 
-	enabledRegions, err := GetEnabledRegions()
+	regions, err := GetEnabledRegions()
 	if err != nil {
 		return CouldNotDetermineEnabledRegionsError{Underlying: err}
 	}
 
-	targetRegions, err := GetTargetRegions(enabledRegions, q.Regions, q.ExcludeRegions)
+	// global is a fake region, used to represent global resources
+	regions = append(regions, GlobalRegion)
+
+	targetRegions, err := GetTargetRegions(regions, q.Regions, q.ExcludeRegions)
 	if err != nil {
 		return CouldNotSelectRegionError{Underlying: err}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 type Config struct {
 	S3                    ResourceType `yaml:"s3"`
 	IAMUsers              ResourceType `yaml:"IAMUsers"`
+	IAMRoles              ResourceType `yaml:"IAMRoles"`
 	SecretsManagerSecrets ResourceType `yaml:"SecretsManager"`
 	NatGateway            ResourceType `yaml:"NatGateway"`
 	AccessAnalyzer        ResourceType `yaml:"AccessAnalyzer"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,6 +34,7 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

These changes are based on #251, but also introduce concurrent deletion of roles for speed. They introduce support for inspecting and nuking IAM Roles. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

