### PR TITLE
Support nuking elasticache replication groups

### DIFF
--- a/aws/elasticache.go
+++ b/aws/elasticache.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/gruntwork-io/cloud-nuke/config"
@@ -46,24 +47,54 @@ func shouldIncludeElasticacheCluster(cluster *elasticache.CacheCluster, excludeA
 	)
 }
 
-func getSingleCacheCluster(svc *elasticache.ElastiCache, clusterId *string) (*elasticache.CacheCluster, error) {
-	var cacheCluster *elasticache.CacheCluster
+type CacheClusterType string
 
+const (
+	Replication CacheClusterType = "replication"
+	Single      CacheClusterType = "single"
+)
+
+func determineCacheClusterType(svc *elasticache.ElastiCache, clusterId *string) (*string, CacheClusterType, error) {
+	// A single cache cluster can either be standalone, in the case where Engine is memcached,
+	// or a member of a replication group, in the case where Engine is Redis, so we must
+	// check the current clusterId via both describe methods, otherwise we'll fail to find it
 	describeParams := &elasticache.DescribeCacheClustersInput{
 		CacheClusterId: clusterId,
 	}
 
-	output, describeErr := svc.DescribeCacheClusters(describeParams)
+	cacheClustersOutput, describeErr := svc.DescribeCacheClusters(describeParams)
 	if describeErr != nil {
-		return nil, describeErr
+		if awsErr, ok := describeErr.(awserr.Error); ok {
+			if awsErr.Code() == elasticache.ErrCodeCacheClusterNotFoundFault {
+				// It's possible that we're looking at a replication group, in which case we can safely ignore this error
+			} else {
+				return nil, Single, describeErr
+			}
+		}
 	}
 
-	if len(output.CacheClusters) == 1 {
-		cacheCluster = output.CacheClusters[0]
-	} else {
-		return nil, CouldNotLookupCacheClusterErr{ClusterId: clusterId}
+	replicationGroupDescribeParams := &elasticache.DescribeReplicationGroupsInput{
+		ReplicationGroupId: clusterId,
 	}
-	return cacheCluster, nil
+
+	replicationGroupOutput, describeReplicationGroupsErr := svc.DescribeReplicationGroups(replicationGroupDescribeParams)
+	if describeReplicationGroupsErr != nil {
+		if awsErr, ok := describeReplicationGroupsErr.(awserr.Error); ok {
+			if awsErr.Code() == elasticache.ErrCodeReplicationGroupNotFoundFault {
+				// It's possible that we're looking at a cache cluster, in which case we can safely ignore this error
+			} else {
+				return nil, Single, describeReplicationGroupsErr
+			}
+		}
+	}
+
+	if len(cacheClustersOutput.CacheClusters) == 1 {
+		return cacheClustersOutput.CacheClusters[0].CacheClusterId, Single, nil
+	} else if len(replicationGroupOutput.ReplicationGroups) == 1 {
+		return replicationGroupOutput.ReplicationGroups[0].ReplicationGroupId, Replication, nil
+	}
+
+	return nil, Single, CouldNotLookupCacheClusterErr{ClusterId: clusterId}
 }
 
 func nukeNonReplicationGroupElasticacheCluster(svc *elasticache.ElastiCache, clusterId *string) error {
@@ -81,14 +112,11 @@ func nukeNonReplicationGroupElasticacheCluster(svc *elasticache.ElastiCache, clu
 	})
 }
 
-func nukeReplicationGroupMemberElasticacheCluster(svc *elasticache.ElastiCache, cacheCluster *elasticache.CacheCluster) error {
-	clusterId := cacheCluster.CacheClusterId
-	replicationGroupId := cacheCluster.ReplicationGroupId
-
-	logging.Logger.Infof("Elasticache cluster Id: %s is a member of a replication group. Therefore, deleting its replication group Id: %s", aws.StringValue(clusterId), aws.StringValue(replicationGroupId))
+func nukeReplicationGroupMemberElasticacheCluster(svc *elasticache.ElastiCache, clusterId *string) error {
+	logging.Logger.Infof("Elasticache cluster Id: %s is a member of a replication group. Therefore, deleting its replication group", aws.StringValue(clusterId))
 
 	params := &elasticache.DeleteReplicationGroupInput{
-		ReplicationGroupId: replicationGroupId,
+		ReplicationGroupId: clusterId,
 	}
 	_, err := svc.DeleteReplicationGroup(params)
 	if err != nil {
@@ -96,14 +124,14 @@ func nukeReplicationGroupMemberElasticacheCluster(svc *elasticache.ElastiCache, 
 	}
 
 	waitErr := svc.WaitUntilReplicationGroupDeleted(&elasticache.DescribeReplicationGroupsInput{
-		ReplicationGroupId: replicationGroupId,
+		ReplicationGroupId: clusterId,
 	})
 
 	if waitErr != nil {
 		return waitErr
 	}
 
-	logging.Logger.Infof("Successfully deleted replication group Id: %s", aws.StringValue(replicationGroupId))
+	logging.Logger.Infof("Successfully deleted replication group Id: %s", aws.StringValue(clusterId))
 
 	return nil
 }
@@ -124,16 +152,16 @@ func nukeAllElasticacheClusters(session *session.Session, clusterIds []*string) 
 		// because there are two separate codepaths for deleting a cluster. Cache clusters that are not members of a
 		// replication group can be deleted via DeleteCacheCluster, whereas those that are members require a call to
 		// DeleteReplicationGroup, which will destroy both the replication group and its member clusters
-		cacheCluster, describeErr := getSingleCacheCluster(svc, clusterId)
+		clusterId, clusterType, describeErr := determineCacheClusterType(svc, clusterId)
 		if describeErr != nil {
 			return describeErr
 		}
 
 		var err error
-		if cacheCluster.ReplicationGroupId == nil {
+		if clusterType == Single {
 			err = nukeNonReplicationGroupElasticacheCluster(svc, clusterId)
-		} else {
-			err = nukeReplicationGroupMemberElasticacheCluster(svc, cacheCluster)
+		} else if clusterType == Replication {
+			err = nukeReplicationGroupMemberElasticacheCluster(svc, clusterId)
 		}
 
 		if err != nil {

--- a/aws/elasticache.go
+++ b/aws/elasticache.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -59,6 +60,8 @@ func getSingleCacheCluster(svc *elasticache.ElastiCache, clusterId *string) (*el
 
 	if len(output.CacheClusters) == 1 {
 		cacheCluster = output.CacheClusters[0]
+	} else {
+		return nil, CouldNotLookupCacheClusterErr{ClusterId: clusterId}
 	}
 	return cacheCluster, nil
 }
@@ -141,4 +144,14 @@ func nukeAllElasticacheClusters(session *session.Session, clusterIds []*string) 
 
 	logging.Logger.Infof("[OK] %d Elasticache clusters deleted in %s", len(deletedClusterIds), *session.Config.Region)
 	return nil
+}
+
+// Custome errors
+
+type CouldNotLookupCacheClusterErr struct {
+	ClusterId *string
+}
+
+func (err CouldNotLookupCacheClusterErr) Error() string {
+	return fmt.Sprintf("Failed to lookup clusterId: %s", err.ClusterId)
 }

--- a/aws/elasticache.go
+++ b/aws/elasticache.go
@@ -120,8 +120,10 @@ func nukeAllElasticacheClusters(session *session.Session, clusterIds []*string) 
 
 	var deletedClusterIds []*string
 	for _, clusterId := range clusterIds {
-		// First, we need to look up the cache cluster again to determine if it is a member of a replication group or not,
-		// because members of a replication group require that the replication group be deleted first
+		// We need to look up the cache cluster again to determine if it is a member of a replication group or not,
+		// because there are two separate codepaths for deleting a cluster. Cache clusters that are not members of a
+		// replication group can be deleted via DeleteCacheCluster, whereas those that are members require a call to
+		// DeleteReplicationGroup, which will destroy both the replication group and its member clusters
 		cacheCluster, describeErr := getSingleCacheCluster(svc, clusterId)
 		if describeErr != nil {
 			return describeErr

--- a/aws/elasticache.go
+++ b/aws/elasticache.go
@@ -103,7 +103,7 @@ func nukeReplicationGroupMemberElasticacheCluster(svc *elasticache.ElastiCache, 
 		return waitErr
 	}
 
-	logging.Logger.Infof("Successfully deleted replication group Id: %s", replicationGroupId)
+	logging.Logger.Infof("Successfully deleted replication group Id: %s", aws.StringValue(replicationGroupId))
 
 	return nil
 }

--- a/aws/elasticache.go
+++ b/aws/elasticache.go
@@ -153,5 +153,5 @@ type CouldNotLookupCacheClusterErr struct {
 }
 
 func (err CouldNotLookupCacheClusterErr) Error() string {
-	return fmt.Sprintf("Failed to lookup clusterId: %s", err.ClusterId)
+	return fmt.Sprintf("Failed to lookup clusterId: %s", aws.StringValue(err.ClusterId))
 }

--- a/aws/elasticache_test.go
+++ b/aws/elasticache_test.go
@@ -41,6 +41,7 @@ func createTestElasticacheReplicationGroup(t *testing.T, session *session.Sessio
 	output, err := svc.CreateReplicationGroup(&elasticache.CreateReplicationGroupInput{
 		ReplicationGroupDescription: awsgo.String("A test cluster"),
 		ReplicationGroupId:          awsgo.String(name),
+		Engine:                      awsgo.String("Redis"),
 	})
 	require.NoError(t, err)
 

--- a/aws/elasticache_test.go
+++ b/aws/elasticache_test.go
@@ -35,6 +35,21 @@ func createTestElasticacheCluster(t *testing.T, session *session.Session, name s
 	require.NoError(t, err)
 }
 
+func createTestElasticacheReplicationGroup(t *testing, session *session.Session) *string {
+	svc := elasticache.New(session)
+
+	output, err := svc.CreateReplicationGroup(&elasticache.CreateReplicationGroupInput{})
+	require.NoError(t, err)
+
+	err = svc.WaitUntilReplicationGroupAvailable(&elasticache.DescribeReplicationGroupsInput{
+		ReplicationGroupId: output.ReplicationGroup.ReplicationGroupId,
+	})
+
+	require.NoError(t, err)
+
+	return output.ReplicationGroup.ReplicationGroupId
+}
+
 func TestListElasticacheClusters(t *testing.T) {
 	t.Parallel()
 
@@ -42,7 +57,8 @@ func TestListElasticacheClusters(t *testing.T) {
 	require.NoError(t, err)
 
 	session, err := session.NewSession(&awsgo.Config{
-		Region: awsgo.String(region)},
+		Region: awsgo.String(region),
+	},
 	)
 
 	require.NoError(t, err)
@@ -66,7 +82,8 @@ func TestListElasticacheClustersWithConfigFile(t *testing.T) {
 	require.NoError(t, err)
 
 	session, err := session.NewSession(&awsgo.Config{
-		Region: awsgo.String(region)},
+		Region: awsgo.String(region),
+	},
 	)
 
 	require.NoError(t, err)
@@ -102,7 +119,8 @@ func TestNukeElasticacheClusters(t *testing.T) {
 	require.NoError(t, err)
 
 	session, err := session.NewSession(&awsgo.Config{
-		Region: awsgo.String(region)},
+		Region: awsgo.String(region),
+	},
 	)
 
 	require.NoError(t, err)
@@ -110,7 +128,11 @@ func TestNukeElasticacheClusters(t *testing.T) {
 	clusterId := "cloud-nuke-test-" + strings.ToLower(util.UniqueID())
 	createTestElasticacheCluster(t, session, clusterId)
 
-	err = nukeAllElasticacheClusters(session, []*string{&clusterId})
+	replicationGroupId := createTestElasticacheReplicationGroup(t, session)
+	// Ensure that nukeAllElasticacheClusters can handle both scenarios for elasticache:
+	// 1. The elasticache cluster is not the member of a replication group, so it can be deleted directly
+	// 2. The elasticache cluster is a member of a replication group, so that replication group must be deleted
+	err = nukeAllElasticacheClusters(session, []*string{&clusterId, replicationGroupId})
 	require.NoError(t, err)
 
 	clusterIds, err := getAllElasticacheClusters(session, region, time.Now().Add(1*time.Hour), config.Config{})

--- a/aws/elasticache_test.go
+++ b/aws/elasticache_test.go
@@ -39,7 +39,7 @@ func createTestElasticacheReplicationGroup(t *testing.T, session *session.Sessio
 	svc := elasticache.New(session)
 
 	params := &elasticache.CreateReplicationGroupInput{
-		ReplicationGroupDescription: awsgo.String("A test cluster"),
+		ReplicationGroupDescription: awsgo.String(name),
 		ReplicationGroupId:          awsgo.String(name),
 		Engine:                      awsgo.String("Redis"),
 		CacheNodeType:               awsgo.String("cache.r6g.large"),

--- a/aws/elasticache_test.go
+++ b/aws/elasticache_test.go
@@ -38,11 +38,17 @@ func createTestElasticacheCluster(t *testing.T, session *session.Session, name s
 func createTestElasticacheReplicationGroup(t *testing.T, session *session.Session, name string) *string {
 	svc := elasticache.New(session)
 
-	output, err := svc.CreateReplicationGroup(&elasticache.CreateReplicationGroupInput{
+	params := &elasticache.CreateReplicationGroupInput{
 		ReplicationGroupDescription: awsgo.String("A test cluster"),
 		ReplicationGroupId:          awsgo.String(name),
 		Engine:                      awsgo.String("Redis"),
-	})
+		CacheNodeType:               awsgo.String("cache.r6g.large"),
+	}
+
+	validationErr := params.Validate()
+	require.NoError(t, validationErr)
+
+	output, err := svc.CreateReplicationGroup(params)
 	require.NoError(t, err)
 
 	err = svc.WaitUntilReplicationGroupAvailable(&elasticache.DescribeReplicationGroupsInput{

--- a/aws/elasticache_test.go
+++ b/aws/elasticache_test.go
@@ -35,7 +35,7 @@ func createTestElasticacheCluster(t *testing.T, session *session.Session, name s
 	require.NoError(t, err)
 }
 
-func createTestElasticacheReplicationGroup(t *testing, session *session.Session) *string {
+func createTestElasticacheReplicationGroup(t *testing.T, session *session.Session) *string {
 	svc := elasticache.New(session)
 
 	output, err := svc.CreateReplicationGroup(&elasticache.CreateReplicationGroupInput{})


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #333 

These changes introduce support for nuking elasticache clusters that are members of a replication group. The single nuke method has been extended to handle both cases: 
1. Cache cluster is not a member of a replication group, and so can be deleted directly 
2. Cache cluster is a member of a replication group, which itself must then be deleted, because attempting to delete the member cache cluster itself will fail as long as the replication group exists. 

In testing against a deployed Ref Arch, these changes resolve the issue observed in #333.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

