### PR TITLE
Implement support for API Gateway v1 and v2 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The currently supported functionality includes:
 
 - Inspecting and deleting all ACM Private CA in an AWS account
 - Inspecting and deleting all Auto scaling groups in an AWS account
-- Inspecting and deleting all Elastic Load Balancers (Classic and V in an AWS account
+- Inspecting and deleting all Elastic Load Balancers (v1 and v2) in an AWS account
 - Inspecting and deleting all Transit Gateways in an AWS account
 - Inspecting and deleting all EBS Volumes in an AWS account
 - Inspecting and deleting all unprotected EC2 instances in an AWS account
@@ -46,6 +46,7 @@ The currently supported functionality includes:
 - Inspecting and deleting all Macie member accounts in an AWS account - as long as those accounts were created by Invitation - and not via AWS Organizations
 - Inspecting and deleting all SageMaker Notebook Instances in an AWS account
 - Inspecting and deleting all Kinesis Streams in an AWS account
+- Inspecting and deleting all API Gateways (v1 and v2) in an AWS account
 
 ### BEWARE!
 
@@ -469,6 +470,8 @@ To find out what we options are supported in the config file today, consult this
 | lc                  | none | ✅   | none | none |
 | eip                 | none | ✅   | none | none |
 | ec2                 | none | ✅   | none | none |
+| apigateway          | none | ✅   | none | none |
+| apigatewayv2        | none | ✅   | none | none |
 | eks                 | none | ✅   | none | none |
 | kinesis-stream      | none | ✅   | none | none |
 | acmpca              | none | none | none | none |

--- a/aws/apigateway.go
+++ b/aws/apigateway.go
@@ -1,0 +1,102 @@
+package aws
+
+import (
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/hashicorp/go-multierror"
+)
+
+func getAllAPIGateways(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
+	svc := apigateway.New(session)
+
+	result, err := svc.GetRestApis(&apigateway.GetRestApisInput{})
+	if err != nil {
+		return []*string{}, errors.WithStackTrace(err)
+	}
+	Ids := []*string{}
+	for _, apigateway := range result.Items {
+		if shouldIncludeAPIGateway(apigateway, excludeAfter, configObj) {
+			Ids = append(Ids, apigateway.Id)
+		}
+	}
+
+	return Ids, nil
+}
+
+func shouldIncludeAPIGateway(apigw *apigateway.RestApi, excludeAfter time.Time, configObj config.Config) bool {
+	if apigw == nil {
+		return false
+	}
+
+	if apigw.CreatedDate != nil {
+		if excludeAfter.Before(aws.TimeValue(apigw.CreatedDate)) {
+			return false
+		}
+	}
+
+	return config.ShouldInclude(
+		aws.StringValue(apigw.Name),
+		configObj.APIGateway.IncludeRule.NamesRegExp,
+		configObj.APIGateway.ExcludeRule.NamesRegExp,
+	)
+}
+
+func nukeAllAPIGateways(session *session.Session, identifiers []*string) error {
+	region := aws.StringValue(session.Config.Region)
+
+	svc := apigateway.New(session)
+
+	if len(identifiers) == 0 {
+		logging.Logger.Infof("No API Gateways (v1) to nuke in region %s", region)
+	}
+
+	if len(identifiers) > 100 {
+		logging.Logger.Errorf("Nuking too many API Gateways (v1) at once (100): halting to avoid hitting AWS API rate limiting")
+		return TooManyApiGatewayErr{}
+	}
+
+	// There is no bulk delete Api Gateway API, so we delete the batch of gateways concurrently using goroutines
+	logging.Logger.Infof("Deleting Api Gateways (v1) in region %s", region)
+	wg := new(sync.WaitGroup)
+	wg.Add(len(identifiers))
+	errChans := make([]chan error, len(identifiers))
+	for i, apigwID := range identifiers {
+		errChans[i] = make(chan error, 1)
+		go deleteApiGatewayAsync(wg, errChans[i], svc, apigwID, region)
+	}
+	wg.Wait()
+
+	var allErrs *multierror.Error
+	for _, errChan := range errChans {
+		if err := <-errChan; err != nil {
+			allErrs = multierror.Append(allErrs, err)
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
+	}
+	finalErr := allErrs.ErrorOrNil()
+	if finalErr != nil {
+		return errors.WithStackTrace(finalErr)
+	}
+	return nil
+}
+
+func deleteApiGatewayAsync(wg *sync.WaitGroup, errChan chan error, svc *apigateway.APIGateway, apigwID *string, region string) {
+	defer wg.Done()
+
+	input := &apigateway.DeleteRestApiInput{RestApiId: apigwID}
+	_, err := svc.DeleteRestApi(input)
+	errChan <- err
+
+	if err == nil {
+		logging.Logger.Infof("[OK] API Gateway (v1) %s deleted in %s", aws.StringValue(apigwID), region)
+	} else {
+		logging.Logger.Errorf("[Failed] Error deleting API Gateway (v1) %s in %s", aws.StringValue(apigwID), region)
+	}
+}

--- a/aws/apigateway_test.go
+++ b/aws/apigateway_test.go
@@ -1,0 +1,148 @@
+package aws
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type TestAPIGateway struct {
+	ID   *string
+	Name *string
+}
+
+func createTestAPIGateway(t *testing.T, session *session.Session, name string) (*TestAPIGateway, error) {
+	svc := apigateway.New(session)
+
+	testGw := &TestAPIGateway{
+		Name: aws.String(name),
+	}
+
+	param := &apigateway.CreateRestApiInput{
+		Name: aws.String(name),
+	}
+
+	output, err := svc.CreateRestApi(param)
+	if err != nil {
+		assert.Failf(t, "Could not create test API Gateway: %s", errors.WithStackTrace(err).Error())
+	}
+
+	testGw.ID = output.Id
+
+	return testGw, nil
+}
+
+func TestListAPIGateways(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region),
+	},
+	)
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	apigwName := "aws-nuke-test-" + util.UniqueID()
+	testGw, createTestGwErr := createTestAPIGateway(t, session, apigwName)
+	require.NoError(t, createTestGwErr)
+	// clean up after this test
+	defer nukeAllAPIGateways(session, []*string{testGw.ID})
+
+	apigwIds, err := getAllAPIGateways(session, time.Now(), config.Config{})
+	if err != nil {
+		assert.Fail(t, "Unable to fetch list of API Gateways (v1)")
+	}
+
+	assert.Contains(t, awsgo.StringValueSlice(apigwIds), aws.StringValue(testGw.ID))
+}
+
+func TestTimeFilterExclusionNewlyCreatedAPIGateway(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	apigwName := "aws-nuke-test-" + util.UniqueID()
+
+	testGw, createTestGwErr := createTestAPIGateway(t, session, apigwName)
+	require.NoError(t, createTestGwErr)
+	defer nukeAllAPIGateways(session, []*string{testGw.ID})
+
+	// Assert API Gateway is picked up without filters
+	apigwIds, err := getAllAPIGateways(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.Contains(t, aws.StringValueSlice(apigwIds), aws.StringValue(testGw.ID))
+
+	// Assert API Gateway doesn't appear when we look at API Gateways older than 1 Hour
+	olderThan := time.Now().Add(-1 * time.Hour)
+	apiGwIdsOlder, err := getAllAPIGateways(session, olderThan, config.Config{})
+	require.NoError(t, err)
+	assert.NotContains(t, aws.StringValueSlice(apiGwIdsOlder), aws.StringValue(testGw.ID))
+}
+
+func TestNukeAPIGatewayOne(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	apigwName := "aws-nuke-test-" + util.UniqueID()
+	// We ignore errors in the delete call here, because it is intended to be a stop gap in case there is a bug in nuke.
+	testGw, createTestErr := createTestAPIGateway(t, session, apigwName)
+	require.NoError(t, createTestErr)
+
+	nukeErr := nukeAllAPIGateways(session, []*string{testGw.ID})
+	require.NoError(t, nukeErr)
+
+	// Make sure the API Gateway was deleted
+	apigwIds, err := getAllAPIGateways(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+
+	assert.NotContains(t, aws.StringValueSlice(apigwIds), aws.StringValue(testGw.ID))
+}
+
+func TestNukeAPIGatewayMoreThanOne(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	apigwName := "aws-nuke-test-" + util.UniqueID()
+	apigwName2 := "aws-nuke-test-" + util.UniqueID()
+	// We ignore errors in the delete call here, because it is intended to be a stop gap in case there is a bug in nuke.
+	testGw, createTestErr := createTestAPIGateway(t, session, apigwName)
+	require.NoError(t, createTestErr)
+	testGw2, createTestErr2 := createTestAPIGateway(t, session, apigwName2)
+	require.NoError(t, createTestErr2)
+
+	nukeErr := nukeAllAPIGateways(session, []*string{testGw.ID, testGw2.ID})
+	require.NoError(t, nukeErr)
+
+	// Make sure the API Gateway was deleted
+	apigwIds, err := getAllAPIGateways(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+
+	assert.NotContains(t, aws.StringValueSlice(apigwIds), aws.StringValue(testGw.ID))
+	assert.NotContains(t, aws.StringValueSlice(apigwIds), aws.StringValue(testGw2.ID))
+}

--- a/aws/apigateway_types.go
+++ b/aws/apigateway_types.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+type ApiGateway struct {
+	Ids []string
+}
+
+func (apigateway ApiGateway) ResourceName() string {
+	return "apigateway"
+}
+
+func (apigateway ApiGateway) ResourceIdentifiers() []string {
+	return apigateway.Ids
+}
+
+func (apigateway ApiGateway) Nuke(session *session.Session) error {
+	if err := nukeAllAPIGateways(session, awsgo.StringSlice(apigateway.Ids)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+type TooManyApiGatewayErr struct{}
+
+func (err TooManyApiGatewayErr) Error() string {
+	return "Too many Api Gateways requested at once."
+}

--- a/aws/apigatewayv2.go
+++ b/aws/apigatewayv2.go
@@ -1,0 +1,102 @@
+package aws
+
+import (
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/hashicorp/go-multierror"
+)
+
+func getAllAPIGatewaysV2(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
+	svc := apigatewayv2.New(session)
+
+	output, err := svc.GetApis(&apigatewayv2.GetApisInput{})
+	if err != nil {
+		return []*string{}, errors.WithStackTrace(err)
+	}
+	Ids := []*string{}
+	for _, restapi := range output.Items {
+		if shouldIncludeAPIGatewayV2(restapi, excludeAfter, configObj) {
+			Ids = append(Ids, restapi.ApiId)
+		}
+	}
+
+	return Ids, nil
+}
+
+func shouldIncludeAPIGatewayV2(api *apigatewayv2.Api, excludeAfter time.Time, configObj config.Config) bool {
+	if api == nil {
+		return false
+	}
+
+	if api.CreatedDate != nil {
+		if excludeAfter.Before(aws.TimeValue(api.CreatedDate)) {
+			return false
+		}
+	}
+
+	return config.ShouldInclude(
+		aws.StringValue(api.Name),
+		configObj.APIGateway.IncludeRule.NamesRegExp,
+		configObj.APIGateway.ExcludeRule.NamesRegExp,
+	)
+}
+
+func nukeAllAPIGatewaysV2(session *session.Session, identifiers []*string) error {
+	region := aws.StringValue(session.Config.Region)
+
+	svc := apigatewayv2.New(session)
+
+	if len(identifiers) == 0 {
+		logging.Logger.Infof("No API Gateways (v2) to nuke in region %s", region)
+	}
+
+	if len(identifiers) > 100 {
+		logging.Logger.Errorf("Nuking too many API Gateways (v2) at once (100): halting to avoid hitting AWS API rate limiting")
+		return TooManyApiGatewayV2Err{}
+	}
+
+	// There is no bulk delete Api Gateway API, so we delete the batch of gateways concurrently using goroutines
+	logging.Logger.Infof("Deleting Api Gateways (v2) in region %s", region)
+	wg := new(sync.WaitGroup)
+	wg.Add(len(identifiers))
+	errChans := make([]chan error, len(identifiers))
+	for i, apigwID := range identifiers {
+		errChans[i] = make(chan error, 1)
+		go deleteApiGatewayAsyncV2(wg, errChans[i], svc, apigwID, region)
+	}
+	wg.Wait()
+
+	var allErrs *multierror.Error
+	for _, errChan := range errChans {
+		if err := <-errChan; err != nil {
+			allErrs = multierror.Append(allErrs, err)
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
+	}
+	finalErr := allErrs.ErrorOrNil()
+	if finalErr != nil {
+		return errors.WithStackTrace(finalErr)
+	}
+	return nil
+}
+
+func deleteApiGatewayAsyncV2(wg *sync.WaitGroup, errChan chan error, svc *apigatewayv2.ApiGatewayV2, apiId *string, region string) {
+	defer wg.Done()
+
+	input := &apigatewayv2.DeleteApiInput{ApiId: apiId}
+	_, err := svc.DeleteApi(input)
+	errChan <- err
+
+	if err == nil {
+		logging.Logger.Infof("[OK] API Gateway (v1) %s deleted in %s", aws.StringValue(apiId), region)
+	} else {
+		logging.Logger.Errorf("[Failed] Error deleting API Gateway (v1) %s in %s", aws.StringValue(apiId), region)
+	}
+}

--- a/aws/apigatewayv2_test.go
+++ b/aws/apigatewayv2_test.go
@@ -34,7 +34,7 @@ func createTestAPIGatewayV2(t *testing.T, session *session.Session, name string)
 
 	output, err := svc.CreateApi(param)
 	if err != nil {
-		assert.Failf(t, "Could not create test API Gateway: %s", errors.WithStackTrace(err).Error())
+		assert.Failf(t, "Could not create test API Gateway (v2): %s", errors.WithStackTrace(err).Error())
 	}
 
 	testGw.ID = output.ApiId

--- a/aws/apigatewayv2_test.go
+++ b/aws/apigatewayv2_test.go
@@ -1,0 +1,148 @@
+package aws
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type TestAPIGatewayV2 struct {
+	ID   *string
+	Name *string
+}
+
+func createTestAPIGatewayV2(t *testing.T, session *session.Session, name string) (*TestAPIGatewayV2, error) {
+	svc := apigatewayv2.New(session)
+
+	testGw := &TestAPIGatewayV2{
+		Name: aws.String(name),
+	}
+
+	param := &apigatewayv2.CreateApiInput{
+		Name:         aws.String(name),
+		ProtocolType: aws.String("HTTP"),
+	}
+
+	output, err := svc.CreateApi(param)
+	if err != nil {
+		assert.Failf(t, "Could not create test API Gateway: %s", errors.WithStackTrace(err).Error())
+	}
+
+	testGw.ID = output.ApiId
+	return testGw, nil
+}
+
+func TestListAPIGatewaysV2(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region),
+	},
+	)
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	apigwName := "aws-nuke-test-" + util.UniqueID()
+	testGw, createTestGwErr := createTestAPIGatewayV2(t, session, apigwName)
+	require.NoError(t, createTestGwErr)
+	// clean up after this test
+	defer nukeAllAPIGatewaysV2(session, []*string{testGw.ID})
+
+	apigwIds, err := getAllAPIGatewaysV2(session, time.Now(), config.Config{})
+	if err != nil {
+		assert.Fail(t, "Unable to fetch list of API Gateways (v2)")
+	}
+
+	assert.Contains(t, awsgo.StringValueSlice(apigwIds), aws.StringValue(testGw.ID))
+}
+
+func TestTimeFilterExclusionNewlyCreatedAPIGatewayV2(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	apigwName := "aws-nuke-test-" + util.UniqueID()
+
+	testGw, createTestGwErr := createTestAPIGatewayV2(t, session, apigwName)
+	require.NoError(t, createTestGwErr)
+	defer nukeAllAPIGateways(session, []*string{testGw.ID})
+
+	// Assert API Gateway is picked up without filters
+	apigwIds, err := getAllAPIGatewaysV2(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.Contains(t, aws.StringValueSlice(apigwIds), aws.StringValue(testGw.ID))
+
+	// Assert API Gateway doesn't appear when we look at API Gateways older than 1 Hour
+	olderThan := time.Now().Add(-1 * time.Hour)
+	apiGwIdsOlder, err := getAllAPIGatewaysV2(session, olderThan, config.Config{})
+	require.NoError(t, err)
+	assert.NotContains(t, aws.StringValueSlice(apiGwIdsOlder), aws.StringValue(testGw.ID))
+}
+
+func TestNukeAPIGatewayV2One(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	apigwName := "aws-nuke-test-" + util.UniqueID()
+	// We ignore errors in the delete call here, because it is intended to be a stop gap in case there is a bug in nuke.
+	testGw, createTestErr := createTestAPIGatewayV2(t, session, apigwName)
+	require.NoError(t, createTestErr)
+
+	nukeErr := nukeAllAPIGatewaysV2(session, []*string{testGw.ID})
+	require.NoError(t, nukeErr)
+
+	// Make sure the API Gateway was deleted
+	apigwIds, err := getAllAPIGatewaysV2(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+
+	assert.NotContains(t, aws.StringValueSlice(apigwIds), aws.StringValue(testGw.ID))
+}
+
+func TestNukeAPIGatewayV2MoreThanOne(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	apigwName := "aws-nuke-test-" + util.UniqueID()
+	apigwName2 := "aws-nuke-test-" + util.UniqueID()
+	// We ignore errors in the delete call here, because it is intended to be a stop gap in case there is a bug in nuke.
+	testGw, createTestErr := createTestAPIGatewayV2(t, session, apigwName)
+	require.NoError(t, createTestErr)
+	testGw2, createTestErr2 := createTestAPIGatewayV2(t, session, apigwName2)
+	require.NoError(t, createTestErr2)
+
+	nukeErr := nukeAllAPIGatewaysV2(session, []*string{testGw.ID, testGw2.ID})
+	require.NoError(t, nukeErr)
+
+	// Make sure the API Gateway was deleted
+	apigwIds, err := getAllAPIGatewaysV2(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+
+	assert.NotContains(t, aws.StringValueSlice(apigwIds), aws.StringValue(testGw.ID))
+	assert.NotContains(t, aws.StringValueSlice(apigwIds), aws.StringValue(testGw2.ID))
+}

--- a/aws/apigatewayv2_types.go
+++ b/aws/apigatewayv2_types.go
@@ -6,31 +6,32 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-type ApiGateway struct {
+type ApiGatewayV2 struct {
 	Ids []string
 }
 
-func (apigateway ApiGateway) ResourceName() string {
-	return "apigateway"
+func (apigateway ApiGatewayV2) ResourceName() string {
+	return "apigatewayv2"
 }
 
-func (apigateway ApiGateway) ResourceIdentifiers() []string {
+func (apigateway ApiGatewayV2) ResourceIdentifiers() []string {
 	return apigateway.Ids
 }
 
-func (apigateway ApiGateway) MaxBatchSize() int {
+func (apigateway ApiGatewayV2) MaxBatchSize() int {
 	return 10
 }
 
-func (apigateway ApiGateway) Nuke(session *session.Session, identifiers []string) error {
+func (apigateway ApiGatewayV2) Nuke(session *session.Session, identifiers []string) error {
 	if err := nukeAllAPIGateways(session, awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
+
 	return nil
 }
 
-type TooManyApiGatewayErr struct{}
+type TooManyApiGatewayV2Err struct{}
 
-func (err TooManyApiGatewayErr) Error() string {
+func (err TooManyApiGatewayV2Err) Error() string {
 	return "Too many Api Gateways requested at once."
 }

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -777,7 +777,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		// API Gateways (v2)
 		apiGatewaysV2 := ApiGatewayV2{}
 		if IsNukeable(apiGatewaysV2.ResourceName(), resourceTypes) {
-			gatewayV2Ids, err := getAllAPIGateways(cloudNukeSession, excludeAfter, configObj)
+			gatewayV2Ids, err := getAllAPIGatewaysV2(cloudNukeSession, excludeAfter, configObj)
 			if err != nil {
 				return nil, errors.WithStackTrace(err)
 			}

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -760,6 +760,34 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End Kinesis Streams
 
+		// API Gateways (v1)
+		apiGateways := ApiGateway{}
+		if IsNukeable(apiGateways.ResourceName(), resourceTypes) {
+			gatewayIds, err := getAllAPIGateways(cloudNukeSession, excludeAfter, configObj)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+			if len(gatewayIds) > 0 {
+				apiGateways.Ids = awsgo.StringValueSlice(gatewayIds)
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, apiGateways)
+			}
+		}
+		// End API Gateways (v1)
+
+		// API Gateways (v2)
+		apiGatewaysV2 := ApiGatewayV2{}
+		if IsNukeable(apiGatewaysV2.ResourceName(), resourceTypes) {
+			gatewayV2Ids, err := getAllAPIGateways(cloudNukeSession, excludeAfter, configObj)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+			if len(gatewayV2Ids) > 0 {
+				apiGatewaysV2.Ids = awsgo.StringValueSlice(gatewayV2Ids)
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, apiGatewaysV2)
+			}
+		}
+		// End API Gateways (v2)
+
 		if len(resourcesInRegion.Resources) > 0 {
 			account.Resources[region] = resourcesInRegion
 		}
@@ -872,6 +900,8 @@ func ListResourceTypes() []string {
 		MacieMember{}.ResourceName(),
 		SageMakerNotebookInstances{}.ResourceName(),
 		KinesisStreams{}.ResourceName(),
+		ApiGateway{}.ResourceName(),
+		ApiGatewayV2{}.ResourceName(),
 	}
 	sort.Strings(resourceTypes)
 	return resourceTypes

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	EKSCluster            ResourceType `yaml:"EKSCluster"`
 	SageMakerNotebook     ResourceType `yaml:"SageMakerNotebook"`
 	KinesisStream         ResourceType `yaml:"KinesisStream"`
+	APIGateway            ResourceType `yaml:"APIGateway"`
 }
 
 type ResourceType struct {

--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	SageMakerNotebook     ResourceType `yaml:"SageMakerNotebook"`
 	KinesisStream         ResourceType `yaml:"KinesisStream"`
 	APIGateway            ResourceType `yaml:"APIGateway"`
+	APIGatewayV2          ResourceType `yaml:"APIGatewayV2"`
 }
 
 type ResourceType struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,6 +38,7 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 
@@ -629,6 +630,194 @@ func TestConfigSageMakerNotebook_FilterNames(t *testing.T) {
 	if len(configObj.SageMakerNotebook.IncludeRule.NamesRegExp) == 0 ||
 		len(configObj.SageMakerNotebook.ExcludeRule.NamesRegExp) == 0 {
 		assert.Fail(t, "ConfigObj should contain SageMakerNotebook regexes, %+v\n", configObj)
+	}
+
+	return
+}
+
+// APIGateway Tests
+
+func TestConfigAPIGateway_Empty(t *testing.T) {
+	configFilePath := "./mocks/apigateway_empty.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should be empty, %+v\n", configObj.APIGateway)
+	}
+
+	return
+}
+
+func TestConfigAPIGateway_EmptyFilters(t *testing.T) {
+	configFilePath := "./mocks/apigateway_empty_filters.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should be empty, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigAPIGateway_EmptyRules(t *testing.T) {
+	configFilePath := "./mocks/apigateway_empty_rules.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should be empty, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigAPIGateway_IncludeNames(t *testing.T) {
+	configFilePath := "./mocks/apigateway_include_names.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should not be empty, %+v\n", configObj)
+	}
+
+	if len(configObj.APIGateway.IncludeRule.NamesRegExp) == 0 {
+		assert.Fail(t, "ConfigObj should contain APIGateway regexes, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigAPIGateway_ExcludeNames(t *testing.T) {
+	configFilePath := "./mocks/apigateway_exclude_names.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should not be empty, %+v\n", configObj)
+	}
+
+	if len(configObj.APIGateway.ExcludeRule.NamesRegExp) == 0 {
+		assert.Fail(t, "ConfigObj should contain APIGateway regexes, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigAPIGateway_FilterNames(t *testing.T) {
+	configFilePath := "./mocks/apigateway_filter_names.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should not be empty, %+v\n", configObj)
+	}
+
+	if len(configObj.APIGateway.IncludeRule.NamesRegExp) == 0 ||
+		len(configObj.APIGateway.ExcludeRule.NamesRegExp) == 0 {
+		assert.Fail(t, "ConfigObj should contain APIGateway regexes, %+v\n", configObj)
+	}
+
+	return
+}
+
+// end APIGateway tests
+
+// APIGateway V2 tests
+
+func TestConfigAPIGatewayV2_Empty(t *testing.T) {
+	configFilePath := "./mocks/apigatewayv2_empty.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should be empty, %+v\n", configObj.APIGateway)
+	}
+
+	return
+}
+
+func TestConfigAPIGatewayV2_EmptyFilters(t *testing.T) {
+	configFilePath := "./mocks/apigatewayv2_empty_filters.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should be empty, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigAPIGatewayV2_EmptyRules(t *testing.T) {
+	configFilePath := "./mocks/apigatewayv2_empty_rules.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if !reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should be empty, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigAPIGatewayV2_IncludeNames(t *testing.T) {
+	configFilePath := "./mocks/apigatewayv2_include_names.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should not be empty, %+v\n", configObj)
+	}
+
+	if len(configObj.APIGatewayV2.IncludeRule.NamesRegExp) == 0 {
+		assert.Fail(t, "ConfigObj should contain APIGatewayV2 regexes, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigAPIGatewayV2_ExcludeNames(t *testing.T) {
+	configFilePath := "./mocks/apigatewayv2_exclude_names.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should not be empty, %+v\n", configObj)
+	}
+
+	if len(configObj.APIGatewayV2.ExcludeRule.NamesRegExp) == 0 {
+		assert.Fail(t, "ConfigObj should contain APIGatewayV2 regexes, %+v\n", configObj)
+	}
+
+	return
+}
+
+func TestConfigAPIGatewayV2_FilterNames(t *testing.T) {
+	configFilePath := "./mocks/apigatewayv2_filter_names.yaml"
+	configObj, err := GetConfig(configFilePath)
+
+	require.NoError(t, err)
+
+	if reflect.DeepEqual(configObj, emptyConfig()) {
+		assert.Fail(t, "Config should not be empty, %+v\n", configObj)
+	}
+
+	if len(configObj.APIGatewayV2.IncludeRule.NamesRegExp) == 0 ||
+		len(configObj.APIGatewayV2.ExcludeRule.NamesRegExp) == 0 {
+		assert.Fail(t, "ConfigObj should contain APIGatewayV2 regexes, %+v\n", configObj)
 	}
 
 	return

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -37,6 +37,7 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 

--- a/config/mocks/apigateway_empty.yaml
+++ b/config/mocks/apigateway_empty.yaml
@@ -1,0 +1,1 @@
+APIGateway:

--- a/config/mocks/apigateway_empty_filters.yaml
+++ b/config/mocks/apigateway_empty_filters.yaml
@@ -1,0 +1,5 @@
+APIGateway:
+  include:
+    names_regex:
+  exclude:
+    names_regex:

--- a/config/mocks/apigateway_empty_rules.yaml
+++ b/config/mocks/apigateway_empty_rules.yaml
@@ -1,0 +1,3 @@
+APIGateway:
+  include:
+  exclude:

--- a/config/mocks/apigateway_exclude_names.yaml
+++ b/config/mocks/apigateway_exclude_names.yaml
@@ -1,0 +1,5 @@
+APIGateway:
+  exclude:
+    names_regex:
+      - alice
+      - bob

--- a/config/mocks/apigateway_exclude_names.yml
+++ b/config/mocks/apigateway_exclude_names.yml
@@ -1,0 +1,5 @@
+APIGateway:
+  exclude:
+    names_regex:
+      - alice
+      - bob

--- a/config/mocks/apigateway_filter_names.yaml
+++ b/config/mocks/apigateway_filter_names.yaml
@@ -1,0 +1,9 @@
+APIGateway:
+  include:
+    names_regex:
+      - ^cloud-nuke-*
+      - test
+  exclude:
+    names_regex:
+      - alice
+      - bob

--- a/config/mocks/apigateway_include_names.yaml
+++ b/config/mocks/apigateway_include_names.yaml
@@ -1,0 +1,5 @@
+APIGateway:
+  include:
+    names_regex:
+      - ^cloud-nuke-*
+      - test

--- a/config/mocks/apigatewayv2_empty.yaml
+++ b/config/mocks/apigatewayv2_empty.yaml
@@ -1,0 +1,1 @@
+APIGatewayV2:

--- a/config/mocks/apigatewayv2_empty_filters.yaml
+++ b/config/mocks/apigatewayv2_empty_filters.yaml
@@ -1,0 +1,5 @@
+APIGatewayV2:
+  include:
+    names_regex:
+  exclude:
+    names_regex:

--- a/config/mocks/apigatewayv2_empty_rules.yaml
+++ b/config/mocks/apigatewayv2_empty_rules.yaml
@@ -1,0 +1,3 @@
+APIGatewayV2:
+  include:
+  exclude:

--- a/config/mocks/apigatewayv2_exclude_names.yaml
+++ b/config/mocks/apigatewayv2_exclude_names.yaml
@@ -1,0 +1,5 @@
+APIGatewayV2:
+  exclude:
+    names_regex:
+      - alice
+      - bob

--- a/config/mocks/apigatewayv2_filter_names.yaml
+++ b/config/mocks/apigatewayv2_filter_names.yaml
@@ -1,0 +1,9 @@
+APIGatewayV2:
+  include:
+    names_regex:
+      - ^cloud-nuke-*
+      - test
+  exclude:
+    names_regex:
+      - alice
+      - bob

--- a/config/mocks/apigatewayv2_include_names.yaml
+++ b/config/mocks/apigatewayv2_include_names.yaml
@@ -1,0 +1,5 @@
+APIGatewayV2:
+  include:
+    names_regex:
+      - ^cloud-nuke-*
+      - test


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #349.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Implement support for inspecting and nuking API Gateways (v1 and v2).

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

