### PR TITLE
Fix API Gateway v2 nuking behavior

### DIFF
--- a/aws/apigatewayv2.go
+++ b/aws/apigatewayv2.go
@@ -95,8 +95,8 @@ func deleteApiGatewayAsyncV2(wg *sync.WaitGroup, errChan chan error, svc *apigat
 	errChan <- err
 
 	if err == nil {
-		logging.Logger.Infof("[OK] API Gateway (v1) %s deleted in %s", aws.StringValue(apiId), region)
+		logging.Logger.Infof("[OK] API Gateway (v2) %s deleted in %s", aws.StringValue(apiId), region)
 	} else {
-		logging.Logger.Errorf("[Failed] Error deleting API Gateway (v1) %s in %s", aws.StringValue(apiId), region)
+		logging.Logger.Errorf("[Failed] Error deleting API Gateway (v2) %s in %s", aws.StringValue(apiId), region)
 	}
 }

--- a/aws/apigatewayv2_test.go
+++ b/aws/apigatewayv2_test.go
@@ -81,7 +81,7 @@ func TestTimeFilterExclusionNewlyCreatedAPIGatewayV2(t *testing.T) {
 
 	testGw, createTestGwErr := createTestAPIGatewayV2(t, session, apigwName)
 	require.NoError(t, createTestGwErr)
-	defer nukeAllAPIGateways(session, []*string{testGw.ID})
+	defer nukeAllAPIGatewaysV2(session, []*string{testGw.ID})
 
 	// Assert API Gateway is picked up without filters
 	apigwIds, err := getAllAPIGatewaysV2(session, time.Now(), config.Config{})

--- a/aws/apigatewayv2_types.go
+++ b/aws/apigatewayv2_types.go
@@ -23,7 +23,7 @@ func (apigateway ApiGatewayV2) MaxBatchSize() int {
 }
 
 func (apigateway ApiGatewayV2) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllAPIGateways(session, awsgo.StringSlice(identifiers)); err != nil {
+	if err := nukeAllAPIGatewaysV2(session, awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -210,6 +210,7 @@ func awsNuke(c *cli.Context) error {
 	}
 
 	logging.Logger.Infof("Retrieving active AWS resources in [%s]", strings.Join(targetRegions[:], ", "))
+
 	account, err := aws.GetAllResources(targetRegions, *excludeAfter, resourceTypes, configObj)
 	if err != nil {
 		return errors.WithStackTrace(err)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/company/issues/519

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)
Fixes a bug that was preventing API Gateway v2 nuking from working properly.

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

