### PR TITLE
Feature/116 iam groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The currently supported functionality includes:
 - Deleting VPCs in an AWS Account (except for default VPCs which is handled by the dedicated `defaults-aws` subcommand)
 - Inspecting and deleting all IAM users in an AWS account
 - Inspecting and deleting all IAM roles in an AWS account
+- Inspecting and deleting all IAM groups in an AWS account
 - Inspecting and deleting all Secrets Manager Secrets in an AWS account
 - Inspecting and deleting all NAT Gateways in an AWS account
 - Inspecting and deleting all IAM Access Analyzers in an AWS account

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The currently supported functionality includes:
 - Inspecting and deleting all IAM users in an AWS account
 - Inspecting and deleting all IAM roles in an AWS account
 - Inspecting and deleting all IAM groups in an AWS account
+- Inspecting and deleting all customer managed IAM policies in an AWS account
 - Inspecting and deleting all Secrets Manager Secrets in an AWS account
 - Inspecting and deleting all NAT Gateways in an AWS account
 - Inspecting and deleting all IAM Access Analyzers in an AWS account
@@ -463,38 +464,39 @@ Be careful when nuking and append the `--dry-run` option if you're unsure. Even 
 
 To find out what we options are supported in the config file today, consult this table. Resource types at the top level of the file that are supported are listed here.
 
-| resource type      | names | names_regex | tags | tags_regex |
-|--------------------|-------|-------------|------|------------|
-| s3                  | none | ✅   | none | none |
-| iam                 | none | ✅   | none | none |
-| ecsserv             | none | ✅   | none | none |
-| ecscluster          | none | ✅   | none | none |
-| secretsmanager      | none | ✅   | none | none |
-| nat-gateway         | none | ✅   | none | none |
-| accessanalyzer      | none | ✅   | none | none |
-| dynamodb            | none | ✅   | none | none |
-| ebs                 | none | ✅   | none | none |
-| lambda              | none | ✅   | none | none |
-| elbv2               | none | ✅   | none | none |
-| ecs                 | none | ✅   | none | none |
-| elasticache         | none | ✅   | none | none |
-| vpc                 | none | ✅   | none | none |
-| oidcprovider        | none | ✅   | none | none |
-| cloudwatch-loggroup | none | ✅   | none | none |
-| kmscustomerkeys     | none | ✅   | none | none |
-| asg                 | none | ✅   | none | none |
-| lc                  | none | ✅   | none | none |
-| eip                 | none | ✅   | none | none |
-| ec2                 | none | ✅   | none | none |
-| apigateway          | none | ✅   | none | none |
-| apigatewayv2        | none | ✅   | none | none |
-| eks                 | none | ✅   | none | none |
-| kinesis-stream      | none | ✅   | none | none |
-| efs                 | none | ✅   | none | none |
-| acmpca              | none | none | none | none |
-| iam role            | none | none | none | none |
-| sagemaker-notebook-instances| none| ✅   | none | none       |
-| ... (more to come)  | none | none | none | none |
+| resource type                | names | names_regex | tags | tags_regex |
+|------------------------------|-------|-------------|------|------------|
+| s3                           | none  | ✅           | none | none       |
+| iam user                     | none  | ✅           | none | none       |
+| ecsserv                      | none  | ✅           | none | none       |
+| ecscluster                   | none  | ✅           | none | none       |
+| secretsmanager               | none  | ✅           | none | none       |
+| nat-gateway                  | none  | ✅           | none | none       |
+| accessanalyzer               | none  | ✅           | none | none       |
+| dynamodb                     | none  | ✅           | none | none       |
+| ebs                          | none  | ✅           | none | none       |
+| lambda                       | none  | ✅           | none | none       |
+| elbv2                        | none  | ✅           | none | none       |
+| ecs                          | none  | ✅           | none | none       |
+| elasticache                  | none  | ✅           | none | none       |
+| vpc                          | none  | ✅           | none | none       |
+| oidcprovider                 | none  | ✅           | none | none       |
+| cloudwatch-loggroup          | none  | ✅           | none | none       |
+| kmscustomerkeys              | none  | ✅           | none | none       |
+| asg                          | none  | ✅           | none | none       |
+| lc                           | none  | ✅           | none | none       |
+| eip                          | none  | ✅           | none | none       |
+| ec2                          | none  | ✅           | none | none       |
+| apigateway                   | none  | ✅           | none | none       |
+| apigatewayv2                 | none  | ✅           | none | none       |
+| eks                          | none  | ✅           | none | none       |
+| kinesis-stream               | none  | ✅           | none | none       |
+| efs                          | none  | ✅           | none | none       |
+| acmpca                       | none  | none        | none | none       |
+| iam role                     | none  | ✅           | none | none       |
+| iam policy                   | none  | ✅           | none | none       |
+| sagemaker-notebook-instances | none  | ✅           | none | none       |
+| ... (more to come)           | none  | none        | none | none       |
 
 
 ### Log level

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -851,6 +851,11 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End IAM Users
 
+		//IAM Groups
+		//TODO Search through existig iam groups for resources to nuke
+		//TODO Append the nukeable ones to the global list of resources
+		//END IAM Groups
+
 		// IAM OpenID Connect Providers
 		oidcProviders := OIDCProviders{}
 		if IsNukeable(oidcProviders.ResourceName(), resourceTypes) {
@@ -913,6 +918,7 @@ func ListResourceTypes() []string {
 		S3Buckets{}.ResourceName(),
 		IAMUsers{}.ResourceName(),
 		IAMRoles{}.ResourceName(),
+		IAMGroups{}.ResourceName(),
 		SecretsManagerSecrets{}.ResourceName(),
 		NatGateways{}.ResourceName(),
 		OpenSearchDomains{}.ResourceName(),

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -852,8 +852,17 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		// End IAM Users
 
 		//IAM Groups
-		//TODO Search through existig iam groups for resources to nuke
-		//TODO Append the nukeable ones to the global list of resources
+		iamGroups := IAMGroups{}
+		if IsNukeable(iamGroups.ResourceName(), resourceTypes) {
+			groupNames, err := getAllIamGroups(session, excludeAfter, configObj)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+			if len(groupNames) > 0 {
+				iamGroups.GroupNames = awsgo.StringValueSlice(groupNames)
+				globalResources.Resources = append(globalResources.Resources, iamGroups)
+			}
+		}
 		//END IAM Groups
 
 		// IAM OpenID Connect Providers

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -865,6 +865,20 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		//END IAM Groups
 
+		//IAM Policies
+		iamPolicies := IAMPolicies{}
+		if IsNukeable(iamPolicies.ResourceName(), resourceTypes) {
+			policyArns, err := getAllLocalIamPolicies(session, excludeAfter, configObj)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+			if len(policyArns) > 0 {
+				iamPolicies.PolicyArns = awsgo.StringValueSlice(policyArns)
+				globalResources.Resources = append(globalResources.Resources, iamPolicies)
+			}
+		}
+		//End IAM Policies
+
 		// IAM OpenID Connect Providers
 		oidcProviders := OIDCProviders{}
 		if IsNukeable(oidcProviders.ResourceName(), resourceTypes) {
@@ -928,6 +942,7 @@ func ListResourceTypes() []string {
 		IAMUsers{}.ResourceName(),
 		IAMRoles{}.ResourceName(),
 		IAMGroups{}.ResourceName(),
+		IAMPolicies{}.ResourceName(),
 		SecretsManagerSecrets{}.ResourceName(),
 		NatGateways{}.ResourceName(),
 		OpenSearchDomains{}.ResourceName(),

--- a/aws/iam_group.go
+++ b/aws/iam_group.go
@@ -1,0 +1,58 @@
+package aws
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/gruntwork-io/cloud-nuke/config"
+)
+
+func getAllIamGroups(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
+	//TODO implement
+	return nil, nil
+}
+
+//nukeAllIamGroups - delete all IAM Roles
+func nukeAllIamGroups(session *session.Session, groupNames []*string) error {
+	//TODO implement
+	return nil
+}
+
+//deleteIamGroupAsync - Asynchronosly remove an IAM group from AWS along with any sub-items
+func deleteIamGroupAsync() {
+	//TODO implement
+}
+
+//TODO do I need shouldInclude function?
+
+//deleteIamGroup - removes an IAM group from AWS (ensure group is empty before calling?)
+func deleteIamGroup(svc *iam.IAM, groupName *string) error {
+	return nil
+}
+
+//Not sure if needed
+func shouldIncludeIamGroup(iamGroup *iam.Group, excludeAfter time.Time, configObj config.Config) bool {
+	return false
+}
+
+//TODO delete policy functions belong here eventually but out of scope for trial
+
+//Custom Errors
+type TooManyIamGroupErr struct{}
+
+func (err TooManyIamGroupErr) Error() string {
+	return "Too many IAM Groups requested at once"
+}
+
+//Sanity Check
+
+// 1. aws.go lists all the resources
+// 2. I'd be adding something to the global resources that checks for any nukeable groups
+// 3. If not dry run, aws.go calls the .Nuke() function on each resource
+// 4. As far as I can tell (excluding potentially policies) there are no pre-requisites for removing
+//		an iam group.  Any users would get cleaned up by existing functionality and order shouldn't matter
+// 5. I'll add IAMGroups to the config.go file which may get us config file support for free, not 100% sure
+
+//IAM GROUP TYPES
+//		Implement AwsResources interface

--- a/aws/iam_group.go
+++ b/aws/iam_group.go
@@ -3,37 +3,84 @@ package aws
 import (
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
 )
 
 func getAllIamGroups(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
-	//TODO implement
-	return nil, nil
+	svc := iam.New(session)
+
+	allIamGroups := []*string{}
+	err := svc.ListGroupsPages(
+		&iam.ListGroupsInput{},
+		func(page *iam.ListGroupsOutput, lastPage bool) bool {
+			for _, iamGroup := range page.Groups {
+				if shouldIncludeIamGroup(iamGroup, excludeAfter, configObj) {
+					allIamGroups = append(allIamGroups, iamGroup.GroupName)
+				}
+			}
+			return !lastPage
+		},
+	)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+	return allIamGroups, nil
 }
 
-//nukeAllIamGroups - delete all IAM Roles
+//nukeAllIamGroups - delete all IAM Roles.  Caller is responsible for pagination (no more than 100/request)
 func nukeAllIamGroups(session *session.Session, groupNames []*string) error {
+	region := aws.StringValue(session.Config.Region) //Since this is a global resource this can be any random region
+	svc := iam.New(session)
+
+	if len(groupNames) == 0 {
+		logging.Logger.Info("No IAM Groups to nuke")
+		return nil
+	}
+
+	//Probably not required since pagination is handled by the caller
+	if len(groupNames) > 100 {
+		logging.Logger.Errorf("Nuking too many IAM Groups at once (100): Halting to avoid rate limits")
+		return TooManyIamGroupErr{}
+	}
+
+	//No bulk delete exists, do it with goroutines
+	//TODO
+
 	//TODO implement
 	return nil
 }
 
-//deleteIamGroupAsync - Asynchronosly remove an IAM group from AWS along with any sub-items
-func deleteIamGroupAsync() {
-	//TODO implement
-}
-
-//TODO do I need shouldInclude function?
-
-//deleteIamGroup - removes an IAM group from AWS (ensure group is empty before calling?)
+//deleteIamGroup - removes an IAM group from AWS
 func deleteIamGroup(svc *iam.IAM, groupName *string) error {
+	_, err := svc.DeleteGroup(&iam.DeleteGroupInput{
+		GroupName: groupName,
+	})
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
 	return nil
 }
 
-//Not sure if needed
+//check if iam group should be included based on config rules (RegExp and Exclude After)
 func shouldIncludeIamGroup(iamGroup *iam.Group, excludeAfter time.Time, configObj config.Config) bool {
-	return false
+	if iamGroup == nil {
+		return false
+	}
+
+	if excludeAfter.Before(*iamGroup.CreateDate) {
+		return false
+	}
+
+	return config.ShouldInclude(
+		aws.StringValue(iamGroup.GroupName),
+		configObj.IAMGroups.IncludeRule.NamesRegExp,
+		configObj.IAMGroups.ExcludeRule.NamesRegExp,
+	)
 }
 
 //TODO delete policy functions belong here eventually but out of scope for trial

--- a/aws/iam_group_test.go
+++ b/aws/iam_group_test.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"testing"
+	"time"
+
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListIamGroups(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region),
+	})
+	require.NoError(t, err)
+
+	groupNames, err := getAllIamGroups(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, groupNames) //TODO based on iam test ask if needs preconfiguration to have at least one group
+}
+
+//TODO implement create a new testing group, with users?
+func createTestGroup(t *testing.T, session *session.Session, name string) error {
+	return nil
+}

--- a/aws/iam_group_test.go
+++ b/aws/iam_group_test.go
@@ -1,16 +1,20 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+//Test that we can list IAM groups in an AWS account
 func TestListIamGroups(t *testing.T) {
 	t.Parallel()
 
@@ -24,10 +28,41 @@ func TestListIamGroups(t *testing.T) {
 
 	groupNames, err := getAllIamGroups(session, time.Now(), config.Config{})
 	require.NoError(t, err)
-	assert.NotEmpty(t, groupNames) //TODO based on iam test ask if needs preconfiguration to have at least one group
+	assert.NotEmpty(t, groupNames)
 }
 
-//TODO implement create a new testing group, with users?
+//TODO could create empty and full IAM groups?
+
+//Creates an empty IAM group for testing
 func createTestGroup(t *testing.T, session *session.Session, name string) error {
+	svc := iam.New(session)
+
+	groupInput := &iam.CreateGroupInput{
+		GroupName: awsgo.String(name),
+	}
+
+	group, err := svc.CreateGroup(groupInput)
+	fmt.Println(group.Group.Arn)
+	require.NoError(t, err)
 	return nil
+}
+
+//Test that we can nuke iam groups.
+func TestNukeIamGroups(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region),
+	})
+	require.NoError(t, err)
+
+	name := "cloud-nuke-test" + util.UniqueID()
+	err = createTestGroup(t, session, name)
+	require.NoError(t, err)
+
+	err = nukeAllIamGroups(session, []*string{&name})
+	require.NoError(t, err)
 }

--- a/aws/iam_group_types.go
+++ b/aws/iam_group_types.go
@@ -1,0 +1,37 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+//IAMGroups - represents all IAMGroups on the AWS Account
+type IAMGroups struct {
+	GroupNames []string
+}
+
+//ResourceName - the simple name of the AWS resource
+func (u IAMGroups) ResourceName() string {
+	return "iam-group"
+}
+
+// ResourceIdentifiers - The IAM GroupNames
+func (g IAMGroups) ResourceIdentifiers() []string {
+	return g.GroupNames
+}
+
+// Tentative batch size to ensure AWS doesn't throttle
+// There's a global max of 500 groups so it shouldn't take long either way
+func (g IAMGroups) MaxBatchSize() int {
+	return 80
+}
+
+// Nuke - Destroy every group in this collection
+func (g IAMGroups) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllIamGroups(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/aws/iam_policy.go
+++ b/aws/iam_policy.go
@@ -1,0 +1,203 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/hashicorp/go-multierror"
+	"sync"
+	"time"
+)
+
+// Returns the ARN of all customer managed policies
+func getAllLocalIamPolicies(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
+	svc := iam.New(session)
+
+	var allIamPolicies []*string
+
+	err := svc.ListPoliciesPages(
+		&iam.ListPoliciesInput{Scope: aws.String(iam.PolicyScopeTypeLocal)},
+		func(page *iam.ListPoliciesOutput, lastPage bool) bool {
+			for _, policy := range page.Policies {
+				if shouldIncludeIamPolicy(policy, excludeAfter, configObj) {
+					allIamPolicies = append(allIamPolicies, policy.Arn)
+				}
+			}
+			return !lastPage
+		},
+	)
+
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	return allIamPolicies, nil
+}
+
+// Delete all iam customer managed policies. Caller is responsible for pagination (no more than 100/request)
+func nukeAllIamPolicies(session *session.Session, policyArns []*string) error {
+	svc := iam.New(session)
+
+	if len(policyArns) == 0 {
+		logging.Logger.Info("No IAM Policies to nuke")
+	}
+
+	//Probably not required since pagination is handled by the caller
+	if len(policyArns) > 100 {
+		logging.Logger.Errorf("Nuking too many IAM Policies at once (100): Halting to avoid rate limits")
+		return TooManyIamPolicyErr{}
+	}
+
+	//No Bulk Delete exists, do it with goroutines
+	logging.Logger.Info("Deleting all IAM Policies")
+	wg := new(sync.WaitGroup)
+	wg.Add(len(policyArns))
+	errChans := make([]chan error, len(policyArns))
+	for i, arn := range policyArns {
+		errChans[i] = make(chan error, 1)
+		go deleteIamPolicyAsync(wg, errChans[i], svc, arn)
+	}
+	wg.Wait()
+
+	//Collapse the errors down to one
+	var allErrs *multierror.Error
+	for _, errChan := range errChans {
+		if err := <-errChan; err != nil {
+			allErrs = multierror.Append(allErrs, err)
+			logging.Logger.Errorf("[Failed] %s", err)
+		}
+	}
+	finalErr := allErrs.ErrorOrNil()
+	if finalErr != nil {
+		return errors.WithStackTrace(finalErr)
+	}
+
+	return nil
+}
+
+// Removes an IAM Policy from AWS, designed to run as a goroutine
+func deleteIamPolicyAsync(wg *sync.WaitGroup, errChan chan error, svc *iam.IAM, policyArn *string) {
+	defer wg.Done()
+	var multierr *multierror.Error
+
+	//Detach any entities the policy is attached to
+	err := detachPolicyEntities(svc, policyArn)
+	if err != nil {
+		multierr = multierror.Append(multierr, err)
+	}
+
+	//Get Old Policy Versions
+	var versionsToRemove []*string
+	err = svc.ListPolicyVersionsPages(&iam.ListPolicyVersionsInput{PolicyArn: policyArn},
+		func(page *iam.ListPolicyVersionsOutput, lastPage bool) bool {
+			for _, policyVersion := range page.Versions {
+				if !*policyVersion.IsDefaultVersion {
+					versionsToRemove = append(versionsToRemove, policyVersion.VersionId)
+				}
+			}
+			return !lastPage
+		})
+	if err != nil {
+		multierr = multierror.Append(multierr, err)
+	}
+
+	//Delete old policy versions
+	for _, versionId := range versionsToRemove {
+		_, err = svc.DeletePolicyVersion(&iam.DeletePolicyVersionInput{VersionId: versionId, PolicyArn: policyArn})
+		if err != nil {
+			multierr = multierror.Append(multierr, err)
+		}
+	}
+	//Delete the policy
+	_, err = svc.DeletePolicy(&iam.DeletePolicyInput{PolicyArn: policyArn})
+	if err != nil {
+		multierr = multierror.Append(multierr, err)
+	} else {
+		logging.Logger.Infof("[OK] IAM Policy %s was deleted in global", aws.StringValue(policyArn))
+	}
+
+	errChan <- multierr.ErrorOrNil()
+}
+
+func detachPolicyEntities(svc *iam.IAM, policyArn *string) error {
+	var allPolicyGroups []*string
+	var allPolicyRoles []*string
+	var allPolicyUsers []*string
+	err := svc.ListEntitiesForPolicyPages(&iam.ListEntitiesForPolicyInput{PolicyArn: policyArn},
+		func(page *iam.ListEntitiesForPolicyOutput, lastPage bool) bool {
+			for _, group := range page.PolicyGroups {
+				allPolicyGroups = append(allPolicyGroups, group.GroupName)
+			}
+			for _, role := range page.PolicyRoles {
+				allPolicyRoles = append(allPolicyRoles, role.RoleName)
+			}
+			for _, user := range page.PolicyUsers {
+				allPolicyUsers = append(allPolicyUsers, user.UserName)
+			}
+			return !lastPage
+		},
+	)
+	if err != nil {
+		return err
+	}
+	//Detach policy from any users
+	for _, userName := range allPolicyUsers {
+		detachUserInput := &iam.DetachUserPolicyInput{
+			UserName:  userName,
+			PolicyArn: policyArn,
+		}
+		_, err = svc.DetachUserPolicy(detachUserInput)
+		if err != nil {
+			return err
+		}
+	}
+	//Detach policy from any groups
+	for _, groupName := range allPolicyGroups {
+		detachGroupInput := &iam.DetachGroupPolicyInput{
+			GroupName: groupName,
+			PolicyArn: policyArn,
+		}
+		_, err = svc.DetachGroupPolicy(detachGroupInput)
+		if err != nil {
+			return err
+		}
+	}
+	//Detach policy from any roles
+	for _, roleName := range allPolicyRoles {
+		detachRoleInput := &iam.DetachRolePolicyInput{
+			RoleName:  roleName,
+			PolicyArn: policyArn,
+		}
+		_, err = svc.DetachRolePolicy(detachRoleInput)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+func shouldIncludeIamPolicy(iamPolicy *iam.Policy, excludeAfter time.Time, configObj config.Config) bool {
+	if iamPolicy == nil {
+		return false
+	}
+
+	if excludeAfter.Before(aws.TimeValue(iamPolicy.CreateDate)) {
+		return false
+	}
+
+	return config.ShouldInclude(
+		aws.StringValue(iamPolicy.PolicyName),
+		configObj.IAMPolicies.IncludeRule.NamesRegExp,
+		configObj.IAMPolicies.ExcludeRule.NamesRegExp,
+	)
+}
+
+// TooManyIamPolicyErr Custom Errors
+type TooManyIamPolicyErr struct{}
+
+func (err TooManyIamPolicyErr) Error() string {
+	return "Too many IAM Groups requested at once"
+}

--- a/aws/iam_policy_test.go
+++ b/aws/iam_policy_test.go
@@ -1,0 +1,209 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+// Stores info for cleanup
+type entityInfo struct {
+	PolicyArn *string
+	UserName  *string
+	GroupName *string
+	RoleName  *string
+}
+
+const fakePolicy string = `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "VisualEditor0",
+				"Effect": "Allow",
+				"Action": "elasticmapreduce:*",
+				"Resource": "*",
+				"Condition": {
+					"BoolIfExists": {
+						"aws:MultiFactorAuthPresent": "true"
+					}
+				}
+			}
+		]
+	}`
+
+func TestListIamPolicies(t *testing.T) {
+	t.Parallel()
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	localSession, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region),
+	})
+	require.NoError(t, err)
+
+	policyArns, err := getAllLocalIamPolicies(localSession, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, policyArns)
+}
+
+func createPolicyWithNoEntities(t *testing.T, session *session.Session, name string) (string, error) {
+	svc := iam.New(session)
+	doc := awsgo.String(fakePolicy)
+	policy, err := svc.CreatePolicy(&iam.CreatePolicyInput{PolicyName: awsgo.String(name), PolicyDocument: doc})
+	require.NoError(t, err)
+	return *policy.Policy.Arn, nil
+}
+
+func createPolicyWithEntities(t *testing.T, session *session.Session, name string) (*entityInfo, error) {
+	policyArn, err := createPolicyWithNoEntities(t, session, name)
+	svc := iam.New(session)
+	if err != nil {
+		return nil, err
+	}
+
+	//Create version
+	versionInput := &iam.CreatePolicyVersionInput{
+		PolicyArn:      awsgo.String(policyArn),
+		PolicyDocument: awsgo.String(fakePolicy),
+	}
+	_, err = svc.CreatePolicyVersion(versionInput)
+	if err != nil {
+		return nil, err
+	}
+	//Create User and link
+	userName := awsgo.String("test-user-" + util.UniqueID())
+	_, err = svc.CreateUser(&iam.CreateUserInput{UserName: userName})
+	if err != nil {
+		return nil, err
+	}
+
+	userPolicyLink := &iam.AttachUserPolicyInput{
+		UserName:  userName,
+		PolicyArn: awsgo.String(policyArn),
+	}
+	_, err = svc.AttachUserPolicy(userPolicyLink)
+	if err != nil {
+		return nil, err
+	}
+
+	//Create role and link
+	roleName := awsgo.String("test-role-" + util.UniqueID())
+	roleInput := &iam.CreateRoleInput{
+		RoleName: roleName,
+		AssumeRolePolicyDocument: awsgo.String(`{
+			"Version": "2012-10-17",
+			"Statement": [
+				{
+					"Effect": "Allow",
+					"Action": [
+						"sts:AssumeRole"
+					],
+					"Principal": {
+						"Service": [
+							"ec2.amazonaws.com"
+						]
+					}
+				}
+			]
+		}`),
+	}
+	_, err = svc.CreateRole(roleInput)
+	if err != nil {
+		return nil, err
+	}
+
+	rolePolicyLink := &iam.AttachRolePolicyInput{RoleName: roleName, PolicyArn: awsgo.String(policyArn)}
+	_, err = svc.AttachRolePolicy(rolePolicyLink)
+	if err != nil {
+		return nil, err
+	}
+
+	//Create group and link
+	groupName := awsgo.String("test-group-" + util.UniqueID())
+	groupInput := &iam.CreateGroupInput{GroupName: groupName}
+	_, err = svc.CreateGroup(groupInput)
+	if err != nil {
+		return nil, err
+	}
+
+	groupPolicyLink := &iam.AttachGroupPolicyInput{GroupName: groupName, PolicyArn: awsgo.String(policyArn)}
+	_, err = svc.AttachGroupPolicy(groupPolicyLink)
+	if err != nil {
+		return nil, err
+	}
+
+	return &entityInfo{
+		PolicyArn: &policyArn,
+		UserName:  userName,
+		RoleName:  roleName,
+		GroupName: groupName,
+	}, nil
+}
+
+func deletePolicyExtraResources(session *session.Session, entityInfo *entityInfo) {
+	svc := iam.New(session)
+	//Delete User
+	_, err := svc.DeleteUser(&iam.DeleteUserInput{UserName: entityInfo.UserName})
+	if err != nil {
+		logging.Logger.Errorf("Unable to delete test user: %s", *entityInfo.UserName)
+	}
+
+	//Delete Role
+	_, err = svc.DeleteRole(&iam.DeleteRoleInput{RoleName: entityInfo.RoleName})
+	if err != nil {
+		logging.Logger.Errorf("Unable to delete test role: %s", *entityInfo.RoleName)
+	}
+
+	//Delete Group
+	_, err = svc.DeleteGroup(&iam.DeleteGroupInput{GroupName: entityInfo.GroupName})
+	if err != nil {
+		logging.Logger.Errorf("Unable to delete test group: %s", *entityInfo.GroupName)
+	}
+}
+
+func TestNukeIamPolicies(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	localSession, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region),
+	})
+	require.NoError(t, err)
+
+	//Create test entities
+	emptyName := "cloud-nuke-test" + util.UniqueID()
+	var emptyPolicyArn string
+	emptyPolicyArn, err = createPolicyWithNoEntities(t, localSession, emptyName)
+	require.NoError(t, err)
+
+	nonEmptyName := "cloud-nuke-test" + util.UniqueID()
+	entities, err := createPolicyWithEntities(t, localSession, nonEmptyName)
+	defer deletePolicyExtraResources(localSession, entities)
+	require.NoError(t, err)
+
+	//Assert test entities exist
+	var policyArns []*string
+	policyArns, err = getAllLocalIamPolicies(localSession, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.Contains(t, awsgo.StringValueSlice(policyArns), emptyPolicyArn)
+	assert.Contains(t, awsgo.StringValueSlice(policyArns), *entities.PolicyArn)
+
+	//Nuke test entities
+	err = nukeAllIamPolicies(localSession, []*string{&emptyPolicyArn, entities.PolicyArn})
+	require.NoError(t, err)
+
+	//Assert test entities don't exist anymore
+	policyArns, err = getAllLocalIamPolicies(localSession, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.NotContains(t, awsgo.StringValueSlice(policyArns), emptyPolicyArn)
+	assert.NotContains(t, awsgo.StringValueSlice(policyArns), *entities.PolicyArn)
+}

--- a/aws/iam_policy_types.go
+++ b/aws/iam_policy_types.go
@@ -1,0 +1,36 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+// IAMPolicies - represents all IAM Policies on the AWS account
+type IAMPolicies struct {
+	PolicyArns []string
+}
+
+// ResourceName - the simple name of the AWS resource
+func (p IAMPolicies) ResourceName() string {
+	return "iam-policy"
+}
+
+// ResourceIdentifiers - The IAM GroupNames
+func (p IAMPolicies) ResourceIdentifiers() []string {
+	return p.PolicyArns
+}
+
+// MaxBatchSize Tentative batch size to ensure AWS doesn't throttle
+func (p IAMPolicies) MaxBatchSize() int {
+	return 80
+}
+
+// Nuke - Destroy every group in this collection
+func (p IAMPolicies) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllIamPolicies(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,8 @@ import (
 type Config struct {
 	S3                    ResourceType `yaml:"s3"`
 	IAMUsers              ResourceType `yaml:"IAMUsers"`
-	IAMGroups             ResourceType `yaml:"IAMGroups"` //TODO update the test
+	IAMGroups             ResourceType `yaml:"IAMGroups"`
+	IAMPolicies           ResourceType `yaml:"IAMPolicies"`
 	IAMRoles              ResourceType `yaml:"IAMRoles"`
 	SecretsManagerSecrets ResourceType `yaml:"SecretsManager"`
 	NatGateway            ResourceType `yaml:"NatGateway"`

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 type Config struct {
 	S3                    ResourceType `yaml:"s3"`
 	IAMUsers              ResourceType `yaml:"IAMUsers"`
+	IAMGroups             ResourceType `yaml:"IAMGroups"` //TODO update the test
 	IAMRoles              ResourceType `yaml:"IAMRoles"`
 	SecretsManagerSecrets ResourceType `yaml:"SecretsManager"`
 	NatGateway            ResourceType `yaml:"NatGateway"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,6 +40,8 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes #116.

Adds the ability to nuke IAM Groups

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added support for nuking IAM Groups and customer managed IAM Policies

### Migration Guide

