### PR TITLE
Temporarily avoid nuking IAM groups and policies in GW test accounts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,8 @@ jobs:
               --force \
               --config ./.circleci/nuke_config.yml \
               --exclude-resource-type iam \
+              --exclude-resource-type iam-group \
+              --exclude-resource-type iam-policy \
               --exclude-resource-type vpc \
               --exclude-resource-type kmscustomerkeys
           no_output_timeout: 1h
@@ -63,7 +65,9 @@ jobs:
               --force \
               --config ./.circleci/nuke_config.yml \
               --exclude-resource-type iam \
-              --exclude-resource-type vpc \
+              --exclude-resource-type iam-group \
+              --exclude-resource-type iam-policy \
+--exclude-resource-type vpc \
               --exclude-resource-type kmscustomerkeys
           no_output_timeout: 1h
   deploy:


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

These changes temporarily exclude IAM groups and IAM policies from the nuke routine run on Gruntwork test accounts. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

