### PR TITLE
Support nuking IAM EC2 instance profiles with roles - CORE-285

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The currently supported functionality includes:
 - Inspecting and deleting all default VPCs in an AWS account
 - Deleting VPCs in an AWS Account (except for default VPCs which is handled by the dedicated `defaults-aws` subcommand)
 - Inspecting and deleting all IAM users in an AWS account
-- Inspecting and deleting all IAM roles in an AWS account
+- Inspecting and deleting all IAM roles (and any associated EC2 instance profiles) in an AWS account
 - Inspecting and deleting all IAM groups in an AWS account
 - Inspecting and deleting all customer managed IAM policies in an AWS account
 - Inspecting and deleting all Secrets Manager Secrets in an AWS account


### PR DESCRIPTION
## Description

Closes [CORE-285](https://gruntwork.atlassian.net/browse/CORE-285)

This PR implements functionality to nuke IAM EC2 Instance Profiles that are attached to IAM roles being nuked.

### Background

In the AWS console when you create an IAM role with an EC2 trust relationship, AWS automatically creates and links the instance profile required for EC2 instances to assume to the role. Subsequently when you delete an IAM role that has an attached instance profile from the console, AWS will automatically delete the instance profile along with it. When the CLI is used, instance profiles must be manually created, attached, and deleted as separate API actions.

cloud-nuke existing functionality detaches any instances profiles before attempting to delete IAM roles, but it does not delete the instance profiles, causing potential conflicts when trying to create IAM EC2 roles later with the same name. 

This change makes it so cloud-nuke deletes any associated instance profiles when a role is deleted.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.

## Release Notes (draft)

Added functionality to allow cloud-nuke to delete instance profiles attached to roles being deleted


