### PR TITLE
Add support to delete ec2 key pairs using cloud-nuke

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,9 @@ The following resources support the Config file:
 - EC2 Instances
     - Resource type: `ec2`
     - Config key: `EC2`
+- EC2 Key Pairs
+  - Resource type: `ec2-keypairs`
+  - Config key: `EC2KeyPairs`
 - EKS Clusters
     - Resource type: `ekscluster`
     - Config key: `EKSCluster`

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -823,6 +823,21 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End EC2 VPCS
 
+		// Start EC2 KeyPairs
+		KeyPairs := EC2KeyPairs{}
+		if IsNukeable(KeyPairs.ResourceName(), resourceTypes) {
+			keyPairIds, err := getAllEc2KeyPairs(cloudNukeSession, excludeAfter, configObj)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			if len(keyPairIds) > 0 {
+				KeyPairs.KeyPairIds = awsgo.StringValueSlice(keyPairIds)
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, KeyPairs)
+			}
+		}
+		// End EC2 KeyPairs
+
 		// Elasticaches
 		elasticaches := Elasticaches{}
 		if IsNukeable(elasticaches.ResourceName(), resourceTypes) {
@@ -1199,6 +1214,7 @@ func ListResourceTypes() []string {
 		ElasticFileSystem{}.ResourceName(),
 		SNSTopic{}.ResourceName(),
 		CloudtrailTrail{}.ResourceName(),
+		EC2KeyPairs{}.ResourceName(),
 	}
 	sort.Strings(resourceTypes)
 	return resourceTypes

--- a/aws/ec2_key_pair.go
+++ b/aws/ec2_key_pair.go
@@ -36,7 +36,6 @@ func shouldIncludeEc2KeyPair(keyPairInfo *ec2.KeyPairInfo, excludeAfter time.Tim
 	}
 
 	if keyPairInfo.CreateTime != nil && excludeAfter.Before(*keyPairInfo.CreateTime) {
-		print(fmt.Sprintf("Created time: %v and excludeAfter: %v", *keyPairInfo.CreateTime, excludeAfter))
 		return false
 	}
 

--- a/aws/ec2_key_pair.go
+++ b/aws/ec2_key_pair.go
@@ -1,0 +1,89 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/hashicorp/go-multierror"
+	"time"
+)
+
+// getAllEc2KeyPairs extracts the list of existing ec2 key pairs.
+func getAllEc2KeyPairs(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
+	svc := ec2.New(session)
+
+	result, err := svc.DescribeKeyPairs(&ec2.DescribeKeyPairsInput{})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	var ids []*string
+	for _, keyPair := range result.KeyPairs {
+		if shouldIncludeEc2KeyPair(keyPair, excludeAfter, configObj) {
+			ids = append(ids, keyPair.KeyPairId)
+		}
+	}
+
+	return ids, nil
+}
+
+func shouldIncludeEc2KeyPair(keyPairInfo *ec2.KeyPairInfo, excludeAfter time.Time, configObj config.Config) bool {
+	if keyPairInfo == nil || keyPairInfo.KeyName == nil {
+		return false
+	}
+
+	if keyPairInfo.CreateTime != nil && excludeAfter.Before(*keyPairInfo.CreateTime) {
+		print(fmt.Sprintf("Created time: %v and excludeAfter: %v", *keyPairInfo.CreateTime, excludeAfter))
+		return false
+	}
+
+	return config.ShouldInclude(
+		*keyPairInfo.KeyName,
+		configObj.EC2KeyPairs.IncludeRule.NamesRegExp,
+		configObj.EC2KeyPairs.ExcludeRule.NamesRegExp,
+	)
+}
+
+// deleteKeyPair is a helper method that deletes the given ec2 key pair.
+func deleteKeyPair(svc *ec2.EC2, keyPairId *string) error {
+	params := &ec2.DeleteKeyPairInput{
+		KeyPairId: keyPairId,
+	}
+
+	_, err := svc.DeleteKeyPair(params)
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+// nukeAllEc2KeyPairs attempts to delete given ec2 key pair IDs.
+func nukeAllEc2KeyPairs(session *session.Session, keypairIds []*string) error {
+	svc := ec2.New(session)
+
+	if len(keypairIds) == 0 {
+		logging.Logger.Infof("No EC2 key pairs to nuke in region %s", *session.Config.Region)
+		return nil
+	}
+
+	logging.Logger.Infof("Terminating all EC2 key pairs in region %s", *session.Config.Region)
+
+	deletedKeyPairs := 0
+	var multiErr *multierror.Error
+	for _, keypair := range keypairIds {
+		if err := deleteKeyPair(svc, keypair); err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+			multiErr = multierror.Append(multiErr, err)
+		} else {
+			deletedKeyPairs++
+			logging.Logger.Infof("Deleted EC2 KeyPair: %s", *keypair)
+		}
+	}
+
+	logging.Logger.Infof("[OK] %d EC2 KeyPair(s) terminated", deletedKeyPairs)
+	return multiErr.ErrorOrNil()
+}

--- a/aws/ec2_key_pair_test.go
+++ b/aws/ec2_key_pair_test.go
@@ -1,0 +1,94 @@
+package aws
+
+import (
+	"fmt"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"regexp"
+	"testing"
+	"time"
+)
+
+// createTestEc2KeyPair is a helper method to create a test ec2 key pair
+func createTestEc2KeyPair(t *testing.T, svc *ec2.EC2) *ec2.CreateKeyPairOutput {
+	keyPair, err := svc.CreateKeyPair(&ec2.CreateKeyPairInput{
+		KeyName: awsgo.String(util.UniqueID()),
+	})
+
+	require.NoError(t, err)
+
+	err = svc.WaitUntilKeyPairExists(&ec2.DescribeKeyPairsInput{
+		KeyPairIds: awsgo.StringSlice([]string{*keyPair.KeyPairId}),
+	})
+
+	require.NoError(t, err)
+	return keyPair
+}
+
+func TestEc2KeyPairListAndNuke(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	testSession, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
+
+	require.NoError(t, err)
+
+	svc := ec2.New(testSession)
+	createdKeyPair := createTestEc2KeyPair(t, svc)
+	testExcludeAfterTime := time.Now().Add(24 * time.Hour)
+	keyPairIds, err := getAllEc2KeyPairs(testSession, testExcludeAfterTime, config.Config{})
+
+	assert.Contains(t, awsgo.StringValueSlice(keyPairIds), *createdKeyPair.KeyPairId)
+
+	// Note: nuking the ec2 key pair created for testing purpose
+	err = nukeAllEc2KeyPairs(testSession, []*string{createdKeyPair.KeyPairId})
+	require.NoError(t, err)
+
+	// Check whether the key still exist or not.
+	keyPairIds, err = getAllEc2KeyPairs(testSession, testExcludeAfterTime, config.Config{})
+	require.NoError(t, err)
+	require.Empty(t, keyPairIds)
+}
+
+func TestEc2KeyPairListWithConfig(t *testing.T) {
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	testSession, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
+
+	require.NoError(t, err)
+
+	svc := ec2.New(testSession)
+	createdKeyPair := createTestEc2KeyPair(t, svc)
+	createdKeyPair2 := createTestEc2KeyPair(t, svc)
+
+	// Regex expression to not include first key pair
+	nameRegexExp, err := regexp.Compile(fmt.Sprintf("^%s*", *createdKeyPair.KeyName))
+	excludeConfig := config.Config{
+		EC2KeyPairs: config.ResourceType{
+			ExcludeRule: config.FilterRule{
+				NamesRegExp: []config.Expression{
+					{
+						RE: *nameRegexExp,
+					},
+				},
+			},
+		},
+	}
+
+	testExcludeAfterTime := time.Now().Add(24 * time.Hour)
+	keyPairIds, err := getAllEc2KeyPairs(testSession, testExcludeAfterTime, excludeConfig)
+	assert.NotContains(t, awsgo.StringValueSlice(keyPairIds), *createdKeyPair.KeyPairId)
+	assert.Contains(t, awsgo.StringValueSlice(keyPairIds), *createdKeyPair2.KeyPairId)
+}

--- a/aws/ec2_key_pair_types.go
+++ b/aws/ec2_key_pair_types.go
@@ -1,0 +1,34 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+type EC2KeyPairs struct {
+	KeyPairIds []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (k EC2KeyPairs) ResourceName() string {
+	return "ec2-keypairs"
+}
+
+// ResourceIdentifiers - IDs of the ec2 key pairs
+func (k EC2KeyPairs) ResourceIdentifiers() []string {
+	return k.KeyPairIds
+}
+
+func (k EC2KeyPairs) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 200
+}
+
+func (k EC2KeyPairs) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllEc2KeyPairs(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	LaunchConfiguration   ResourceType `yaml:"LaunchConfiguration"`
 	ElasticIP             ResourceType `yaml:"ElasticIP"`
 	EC2                   ResourceType `yaml:"EC2"`
+	EC2KeyPairs           ResourceType `yaml:"EC2KeyPairs"`
 	CloudWatchLogGroup    ResourceType `yaml:"CloudWatchLogGroup"`
 	KMSCustomerKeys       ResourceType `yaml:"KMSCustomerKeys"`
 	EKSCluster            ResourceType `yaml:"EKSCluster"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,6 +43,7 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://gruntwork.atlassian.net/browse/CORE-284.

### Testing

* Tested running the cloud-nuke command line locally to delete an existing EC2 key pair

```
aws-vault exec gruntwork-customer-access-test -- go run main.go aws --resource-type ec2-keypairs
```

* Unit tests that creates & nuke an EC2 key pair. 
* Tested `aws-inspect` on ec2 key pair

```
aws-vault exec gruntwork-customer-access-test -- go run main.go inspect-aws --resource-type ec2-keypairs
```

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

