### PR TITLE
CORE-188 rate limits

### DIFF
--- a/aws/ami_types.go
+++ b/aws/ami_types.go
@@ -23,7 +23,7 @@ func (image AMIs) ResourceIdentifiers() []string {
 
 func (image AMIs) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // Nuke - nuke 'em all!!!

--- a/aws/asg_types.go
+++ b/aws/asg_types.go
@@ -18,7 +18,7 @@ func (group ASGroups) ResourceName() string {
 
 func (group ASGroups) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // ResourceIdentifiers - The group names of the auto scaling groups

--- a/aws/cloudwatch_dashboard_types.go
+++ b/aws/cloudwatch_dashboard_types.go
@@ -22,7 +22,7 @@ func (cwdb CloudWatchDashboards) ResourceIdentifiers() []string {
 }
 
 func (cwdb CloudWatchDashboards) MaxBatchSize() int {
-	return 100
+	return 49
 }
 
 // Nuke - nuke 'em all!!!

--- a/aws/dynamodb_types.go
+++ b/aws/dynamodb_types.go
@@ -20,7 +20,7 @@ func (tables DynamoDB) ResourceIdentifiers() []string {
 
 func (tables DynamoDB) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 100
+	return 49
 }
 
 // Nuke - nuke all Dynamo DB Tables

--- a/aws/ebs_types.go
+++ b/aws/ebs_types.go
@@ -23,7 +23,7 @@ func (volume EBSVolumes) ResourceIdentifiers() []string {
 
 func (volume EBSVolumes) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // Nuke - nuke 'em all!!!

--- a/aws/ec2_types.go
+++ b/aws/ec2_types.go
@@ -23,7 +23,7 @@ func (instance EC2Instances) ResourceIdentifiers() []string {
 
 func (instance EC2Instances) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // Nuke - nuke 'em all!!!
@@ -52,7 +52,7 @@ func (v EC2VPCs) ResourceIdentifiers() []string {
 
 func (v EC2VPCs) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // Nuke - nuke 'em all!!!

--- a/aws/ecs_cluster_types.go
+++ b/aws/ecs_cluster_types.go
@@ -10,8 +10,8 @@ import (
 // into batches when the function `NukeAllResources` is executed.
 // A batch max number has been chosen for most modules.
 // However, for ECS clusters there is no explicit limiting described in the AWS CLI docs.
-// Therefore this `maxBatchSize` here is set to 100 as a safe maximum.
-const maxBatchSize = 100
+// Therefore this `maxBatchSize` here is set to 49 as a safe maximum.
+const maxBatchSize = 49
 
 // ECSClusters - Represents all ECS clusters found in a region
 type ECSClusters struct {

--- a/aws/ecs_service_types.go
+++ b/aws/ecs_service_types.go
@@ -23,7 +23,7 @@ func (services ECSServices) ResourceIdentifiers() []string {
 }
 
 func (services ECSServices) MaxBatchSize() int {
-	return 200
+	return 49
 }
 
 // Nuke - nuke all ECS service resources

--- a/aws/eip_types.go
+++ b/aws/eip_types.go
@@ -23,7 +23,7 @@ func (address EIPAddresses) ResourceIdentifiers() []string {
 
 func (address EIPAddresses) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // Nuke - nuke 'em all!!!

--- a/aws/elasticache_types.go
+++ b/aws/elasticache_types.go
@@ -23,7 +23,7 @@ func (cache Elasticaches) ResourceIdentifiers() []string {
 
 func (cache Elasticaches) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // Nuke - nuke 'em all!!!

--- a/aws/elb_types.go
+++ b/aws/elb_types.go
@@ -23,7 +23,7 @@ func (balancer LoadBalancers) ResourceIdentifiers() []string {
 
 func (balancer LoadBalancers) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // Nuke - nuke 'em all!!!

--- a/aws/elbv2_types.go
+++ b/aws/elbv2_types.go
@@ -18,7 +18,7 @@ func (balancer LoadBalancersV2) ResourceName() string {
 
 func (balancer LoadBalancersV2) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // ResourceIdentifiers - The arns of the load balancers

--- a/aws/iam_group_types.go
+++ b/aws/iam_group_types.go
@@ -6,12 +6,12 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-//IAMGroups - represents all IAMGroups on the AWS Account
+// IAMGroups - represents all IAMGroups on the AWS Account
 type IAMGroups struct {
 	GroupNames []string
 }
 
-//ResourceName - the simple name of the AWS resource
+// ResourceName - the simple name of the AWS resource
 func (u IAMGroups) ResourceName() string {
 	return "iam-group"
 }
@@ -24,7 +24,7 @@ func (g IAMGroups) ResourceIdentifiers() []string {
 // Tentative batch size to ensure AWS doesn't throttle
 // There's a global max of 500 groups so it shouldn't take long either way
 func (g IAMGroups) MaxBatchSize() int {
-	return 80
+	return 49
 }
 
 // Nuke - Destroy every group in this collection

--- a/aws/iam_policy_types.go
+++ b/aws/iam_policy_types.go
@@ -23,7 +23,7 @@ func (p IAMPolicies) ResourceIdentifiers() []string {
 
 // MaxBatchSize Tentative batch size to ensure AWS doesn't throttle
 func (p IAMPolicies) MaxBatchSize() int {
-	return 80
+	return 49
 }
 
 // Nuke - Destroy every group in this collection

--- a/aws/iam_role_test.go
+++ b/aws/iam_role_test.go
@@ -1,8 +1,6 @@
 package aws
 
 import (
-	"fmt"
-	"github.com/gruntwork-io/cloud-nuke/logging"
 	"testing"
 	"time"
 
@@ -126,37 +124,6 @@ func TestNukeIamRoles(t *testing.T) {
 	require.NoError(t, err)
 
 	err = nukeAllIamRoles(session, []*string{&name})
-	require.NoError(t, err)
-}
-
-func TestIamRoleRateLimit(t *testing.T) {
-	t.Parallel()
-
-	region := "us-east-2" //getRandomRegion()
-	//require.NoError(t, err)
-
-	session, err := session.NewSession(&awsgo.Config{
-		Region: awsgo.String(region)},
-	)
-	require.NoError(t, err)
-
-	baseName := "cloud-nuke-test-" + util.UniqueID()
-	testRoles := []string{}
-	for i := 1; i < 50; i++ {
-		name := fmt.Sprintf("%s-%d", baseName, i)
-		logging.Logger.Infof("Name: %s", name)
-		testRoles = append(testRoles, name)
-		err = createTestRole(t, session, name)
-		require.NoError(t, err)
-	}
-
-	testPtrs := []*string{}
-	for _, v := range testRoles {
-		v2 := v
-		testPtrs = append(testPtrs, &v2)
-	}
-
-	err = nukeAllIamRoles(session, testPtrs)
 	require.NoError(t, err)
 }
 

--- a/aws/iam_role_types.go
+++ b/aws/iam_role_types.go
@@ -23,7 +23,7 @@ func (r IAMRoles) ResourceIdentifiers() []string {
 
 // Tentative batch size to ensure AWS doesn't throttle
 func (r IAMRoles) MaxBatchSize() int {
-	return 80
+	return 49
 }
 
 // Nuke - nuke 'em all!!!

--- a/aws/iam_types.go
+++ b/aws/iam_types.go
@@ -23,7 +23,7 @@ func (u IAMUsers) ResourceIdentifiers() []string {
 
 // Tentative batch size to ensure AWS doesn't throttle
 func (u IAMUsers) MaxBatchSize() int {
-	return 200
+	return 49
 }
 
 // Nuke - nuke 'em all!!!

--- a/aws/kms_customer_key_types.go
+++ b/aws/kms_customer_key_types.go
@@ -26,7 +26,7 @@ func (c KmsCustomerKeys) ResourceIdentifiers() []string {
 
 // MaxBatchSize - Requests batch size
 func (r KmsCustomerKeys) MaxBatchSize() int {
-	return 100
+	return 49
 }
 
 // Nuke - remove all customer managed keys

--- a/aws/lambda_types.go
+++ b/aws/lambda_types.go
@@ -21,7 +21,7 @@ func (lambda LambdaFunctions) ResourceIdentifiers() []string {
 
 func (lambda LambdaFunctions) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // Nuke - nuke 'em all!!!

--- a/aws/launch_config_types.go
+++ b/aws/launch_config_types.go
@@ -18,7 +18,7 @@ func (config LaunchConfigs) ResourceName() string {
 
 func (config LaunchConfigs) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // ResourceIdentifiers - The names of the launch configurations

--- a/aws/rds_cluster_types.go
+++ b/aws/rds_cluster_types.go
@@ -21,7 +21,7 @@ func (instance DBClusters) ResourceIdentifiers() []string {
 
 func (instance DBClusters) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // Nuke - nuke 'em all!!!

--- a/aws/rds_types.go
+++ b/aws/rds_types.go
@@ -21,7 +21,7 @@ func (instance DBInstances) ResourceIdentifiers() []string {
 
 func (instance DBInstances) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // Nuke - nuke 'em all!!!

--- a/aws/sagemaker_notebook_instance_types.go
+++ b/aws/sagemaker_notebook_instance_types.go
@@ -21,7 +21,7 @@ func (instance SageMakerNotebookInstances) ResourceIdentifiers() []string {
 
 func (instance SageMakerNotebookInstances) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // Nuke - nuke 'em all!!!

--- a/aws/snapshot_types.go
+++ b/aws/snapshot_types.go
@@ -23,7 +23,7 @@ func (snapshot Snapshots) ResourceIdentifiers() []string {
 
 func (snapshot Snapshots) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // Nuke - nuke 'em all!!!

--- a/aws/sqs_types.go
+++ b/aws/sqs_types.go
@@ -18,7 +18,7 @@ func (queue SqsQueue) ResourceName() string {
 
 func (queue SqsQueue) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
-	return 200
+	return 49
 }
 
 // ResourceIdentifiers - The arns of the sqs queues


### PR DESCRIPTION
## Description

Reduces the batch sizes on all resources where the AWS rate limits were a guess such that two instances of cloud nuke could be running on an account without expecting any issues.  This should enable cloud-nuke to run better in automated environments as well as reduce the likelihood of manual activity in the AWS account interfering.

This is a stopgap solution to the rate limit issue and we plan to implement a more robust approach in the future.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

Updated max batch size on many resources to reduce rate limit errors.

