### PR TITLE
Support deletion of KMS Key Aliases - CORE-292

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The currently supported functionality includes:
 - Inspecting and deleting all CloudWatch Dashboards in an AWS account
 - Inspecting and deleting all OpenSearch Domains in an AWS account
 - Inspecting and deleting all IAM OpenID Connect Providers
-- Inspecting and deleting all Customer managed keys from Key Management Service in an AWS account
+- Inspecting and deleting all Customer managed keys (and associated key aliases) from Key Management Service in an AWS account
 - Inspecting and deleting all CloudWatch Log Groups in an AWS Account
 - Inspecting and deleting all GuardDuty Detectors in an AWS Account
 - Inspecting and deleting all Macie member accounts in an AWS account - as long as those accounts were created by Invitation - and not via AWS Organizations

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -846,7 +846,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		// KMS Customer managed keys
 		customerKeys := KmsCustomerKeys{}
 		if IsNukeable(customerKeys.ResourceName(), resourceTypes) {
-			keys, err := getAllKmsUserKeys(cloudNukeSession, customerKeys.MaxBatchSize(), excludeAfter, configObj)
+			keys, aliases, err := getAllKmsUserKeys(cloudNukeSession, customerKeys.MaxBatchSize(), excludeAfter, configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,
@@ -856,7 +856,9 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 				report.RecordError(ge)
 			}
 			if len(keys) > 0 {
+				customerKeys.KeyAliases = aliases
 				customerKeys.KeyIds = awsgo.StringValueSlice(keys)
+
 				resourcesInRegion.Resources = append(resourcesInRegion.Resources, customerKeys)
 			}
 

--- a/aws/kms_customer_key_test.go
+++ b/aws/kms_customer_key_test.go
@@ -87,17 +87,17 @@ func TestRemoveKmsUserKeys(t *testing.T) {
 	err = nukeAllCustomerManagedKmsKeys(session, []*string{&createdKeyId}, map[string][]string{"keyid": {keyAlias}})
 	require.NoError(t, err)
 
-	// test if key is not included for removal second time
+	// test if key is not included for removal second time, after being marked for deletion
 	keys, aliases, err := getAllKmsUserKeys(session, KmsCustomerKeys{}.MaxBatchSize(), time.Now(), config.Config{})
 
 	require.NoError(t, err)
 	assert.NotContains(t, aws.StringValueSlice(keys), createdKeyId)
 	assert.NotContains(t, aliases[createdKeyId], keyAlias)
 
-	// test that the aliases were deleted from the key, even if the key was successfully marked for deletion
+	// test that all aliases were deleted from the key, even if the key was successfully marked for deletion
 	listedAliases, err := listAliasesForKey(session, &createdKeyId)
-	require.NoError(t, err)
 
+	require.NoError(t, err)
 	assert.Empty(t, listedAliases)
 }
 

--- a/aws/kms_customer_key_types.go
+++ b/aws/kms_customer_key_types.go
@@ -11,7 +11,8 @@ import (
 const kmsRemovalWindow = 7
 
 type KmsCustomerKeys struct {
-	KeyIds []string
+	KeyIds     []string
+	KeyAliases map[string][]string
 }
 
 // ResourceName - the simple name of the aws resource
@@ -19,7 +20,7 @@ func (c KmsCustomerKeys) ResourceName() string {
 	return "kmscustomerkeys"
 }
 
-// ResourceIdentifiers - The IAM UserNames
+// ResourceIdentifiers - The KMS Key IDs
 func (c KmsCustomerKeys) ResourceIdentifiers() []string {
 	return c.KeyIds
 }
@@ -31,7 +32,7 @@ func (r KmsCustomerKeys) MaxBatchSize() int {
 
 // Nuke - remove all customer managed keys
 func (c KmsCustomerKeys) Nuke(session *session.Session, keyIds []string) error {
-	if err := nukeAllCustomerManagedKmsKeys(session, awsgo.StringSlice(keyIds)); err != nil {
+	if err := nukeAllCustomerManagedKmsKeys(session, awsgo.StringSlice(keyIds), c.KeyAliases); err != nil {
 		return errors.WithStackTrace(err)
 	}
 


### PR DESCRIPTION
Closes [CORE-292](https://gruntwork.atlassian.net/browse/CORE-292)

This PR adds functionality to nuke KMS Key Aliases with KMS keys that are being nuked.

* This does not change existing cloud-nuke KMS Key filtering functionality
* Key aliases will only be nuked if they are attached to a KMS key that is being nuked

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.

## Release Notes

Added support for deletion of KMS Key Aliases 
