### PR TITLE
add more patterns to nuke

### DIFF
--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -95,6 +95,7 @@ CloudWatchLogGroup:
       - "/aws/lambda/cleanup-expired-iam-certs-[a-zA-Z0-9]{6}$"
       - "/aws/lambda/create-snapshot-example-(aurora|mysql)$"
       - "/aws/lambda/HoustonExpress[a-zA-Z0-9]{6}.*"
+      - "/aws/lambda/lambda-docker-[a-zA-Z0-9]{6}$"
       - "/aws/rds/cluster/test[a-zA-Z0-9]{6}.*"
       - "/aws/rds/cluster/test-aurora-[a-zA-Z0-9]{6}.*"
       - "eks-service-catalog-[a-zA-Z0-9]{6}$"
@@ -113,6 +114,7 @@ CloudWatchLogGroup:
       - "jenkins-[a-zA-Z0-9]{6}$"
       - "openvpn-server-[a-zA-Z0-9]{6}_log_group$"
       - "vpc-test-[a-zA-Z0-9]{6}.*"
+      - "cloud-nuke-test-[a-zA-Z0-9]{6}"
 
 IAMUsers:
   exclude:

--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -4,10 +4,19 @@ s3:
   include:
     names_regex:
       - "^cloudfront-example-[a-zA-Z0-9]{6}\\.gruntwork\\.in.*"
+      - "^cloudfront-example-failover-[a-zA-Z0-9]{6}\\.gruntwork\\.in.*"
+      - "^cf-example-[a-zA-Z0-9]{6}\\.gruntwork\\.in.*"
+      - "^cf-example-failover-[a-zA-Z0-9]{6}\\.gruntwork\\.in.*"
+      - "^gwtest-[a-zA-Z0-9]{6}-config-test"
+      - "^s3-test-tg-.*"
       - "^gruntwork-terratest-[a-zA-Z0-9]{6}$"
+      - ".*-terratest-aws-s3-example-[a-zA-Z0-9]{6}"
       - "^gw-cis-aws-config-all-regions-[a-zA-Z0-9]{6}-.*"
+      - "^gw-service-catalog-test-[a-zA-Z0-9]{6}.*"
+      - "^gruntwork-service-catalog-test-nginx-[a-zA-Z0-9]{6}.*"
       - "^gruntwork-test-[a-zA-Z0-9]{6}-config-test$"
       - "^gruntwork-test-[a-zA-Z0-9]{6}-cloudtrail-test.*"
+      - "^gruntwork-[a-zA-Z0-9]{6}-cloudtrail-test.*"
       - "^gruntwork-test-privs3bucket-[a-zA-Z0-9]{6}"
       - "^gruntwork-terratest-[a-zA-Z0-9]{6}-logs"
       - "^houston-static-[a-zA-Z0-9]{12}.*"
@@ -26,6 +35,10 @@ s3:
       - "^gruntwork-(test-)?ecs-deploy-runner-outputs-[a-zA-Z0-9]{6}"
       - "^test-bucket-.*"
       - "^test-private-s3-bucket-.*"
+      - "^testlambdas3deploymentpackage-[a-zA-Z0-9]{6}-s3-deployment-package-test"
+      - "^testlambdas3-[a-zA-Z0-9]{6}-images-test"
+      - "^s3-website-example-[a-zA-Z0-9]{6}\\.gruntwork\\.in.*"
+      - "^redirect-s3-website-example-[a-zA-Z0-9]{6}\\.gruntwork\\.in.*"
 
 SecretsManager:
   include:


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

I noticed there were some more buckets accumulating in phx devops account that were not listed here. So I added some more patterns to this list. I don't know where some of these buckets are coming from because they are from repos I don't have access to, so please do a sanity check if this list seems reasonable.

Also added some log group tests that were not in the list.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.



