### PR TITLE
Cloud nuke failing tests fixes

### DIFF
--- a/aws/ec2_unit_test.go
+++ b/aws/ec2_unit_test.go
@@ -112,6 +112,7 @@ func TestNukeMockVpcs(t *testing.T) {
 		}
 		detachInternetGatewayInput := getDetachInternetGatewayInput(vpc.VpcId, ExampleInternetGatewayId)
 		deleteInternetGatewayInput := getDeleteInternetGatewayInput(ExampleInternetGatewayId)
+		egressOnlyInternetGatewaysInput := getDescribeEgressOnlyInternetGatewaysInput()
 
 		describeEndpointsInput := getDescribeEndpointsInput(vpc.VpcId)
 		describeEndpointsOutput := getDescribeEndpointsOutput([]string{ExampleEndpointId})
@@ -154,7 +155,7 @@ func TestNukeMockVpcs(t *testing.T) {
 		describeSecurityGroupRulesFunc := func(input *ec2.DescribeSecurityGroupRulesInput) (*ec2.DescribeSecurityGroupRulesOutput, error) {
 			return describeSecurityGroupRulesOutput, nil
 		}
-		revokeSecurityGroupEgressInput := getRevokeSecurityGroupEgressInput(ExampleSecurityGroupId ,ExampleSecurityGroupRuleId)
+		revokeSecurityGroupEgressInput := getRevokeSecurityGroupEgressInput(ExampleSecurityGroupId, ExampleSecurityGroupRuleId)
 		revokeSecurityGroupIngressInput := getRevokeSecurityGroupIngressInput(ExampleSecurityGroupId, ExampleSecurityGroupRuleId)
 
 		describeSecurityGroupsInput := getDescribeSecurityGroupsInput(vpc.VpcId)
@@ -170,6 +171,7 @@ func TestNukeMockVpcs(t *testing.T) {
 			mockEC2.EXPECT().DescribeInternetGateways(describeInternetGatewaysInput).DoAndReturn(describeInternetGatewaysFunc),
 			mockEC2.EXPECT().DetachInternetGateway(detachInternetGatewayInput),
 			mockEC2.EXPECT().DeleteInternetGateway(deleteInternetGatewayInput),
+			mockEC2.EXPECT().DescribeEgressOnlyInternetGatewaysPages(egressOnlyInternetGatewaysInput, gomock.Any()),
 			mockEC2.EXPECT().DescribeVpcEndpoints(describeEndpointsInput).DoAndReturn(describeEndpointsFunc),
 			mockEC2.EXPECT().DeleteVpcEndpoints(deleteEndpointInput),
 			mockEC2.EXPECT().DescribeVpcEndpoints(describeEndpointsWaitForDeletionInput).DoAndReturn(describeEndpointsWaitForDeletionFunc),

--- a/aws/ec2_unit_test.go
+++ b/aws/ec2_unit_test.go
@@ -113,7 +113,7 @@ func TestNukeMockVpcs(t *testing.T) {
 		detachInternetGatewayInput := getDetachInternetGatewayInput(vpc.VpcId, ExampleInternetGatewayId)
 		deleteInternetGatewayInput := getDeleteInternetGatewayInput(ExampleInternetGatewayId)
 		egressOnlyInternetGatewaysInput := getDescribeEgressOnlyInternetGatewaysInput()
-
+		describeNetworkInterfacesInput := getDescribeNetworkInterfacesInput(vpc.VpcId)
 		describeEndpointsInput := getDescribeEndpointsInput(vpc.VpcId)
 		describeEndpointsOutput := getDescribeEndpointsOutput([]string{ExampleEndpointId})
 		describeEndpointsFunc := func(input *ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {
@@ -156,6 +156,7 @@ func TestNukeMockVpcs(t *testing.T) {
 			return describeSecurityGroupRulesOutput, nil
 		}
 		revokeSecurityGroupEgressInput := getRevokeSecurityGroupEgressInput(ExampleSecurityGroupId, ExampleSecurityGroupRuleId)
+		associateDhcpOptionsInput := getAssociateDhcpOptionsInput(vpc.VpcId)
 		revokeSecurityGroupIngressInput := getRevokeSecurityGroupIngressInput(ExampleSecurityGroupId, ExampleSecurityGroupRuleId)
 
 		describeSecurityGroupsInput := getDescribeSecurityGroupsInput(vpc.VpcId)
@@ -172,6 +173,7 @@ func TestNukeMockVpcs(t *testing.T) {
 			mockEC2.EXPECT().DetachInternetGateway(detachInternetGatewayInput),
 			mockEC2.EXPECT().DeleteInternetGateway(deleteInternetGatewayInput),
 			mockEC2.EXPECT().DescribeEgressOnlyInternetGatewaysPages(egressOnlyInternetGatewaysInput, gomock.Any()),
+			mockEC2.EXPECT().DescribeNetworkInterfacesPages(describeNetworkInterfacesInput, gomock.Any()),
 			mockEC2.EXPECT().DescribeVpcEndpoints(describeEndpointsInput).DoAndReturn(describeEndpointsFunc),
 			mockEC2.EXPECT().DeleteVpcEndpoints(deleteEndpointInput),
 			mockEC2.EXPECT().DescribeVpcEndpoints(describeEndpointsWaitForDeletionInput).DoAndReturn(describeEndpointsWaitForDeletionFunc),
@@ -188,6 +190,7 @@ func TestNukeMockVpcs(t *testing.T) {
 			mockEC2.EXPECT().RevokeSecurityGroupEgress(revokeSecurityGroupEgressInput),
 			mockEC2.EXPECT().RevokeSecurityGroupIngress(revokeSecurityGroupIngressInput),
 			mockEC2.EXPECT().DeleteSecurityGroup(deleteSecurityGroupInput),
+			mockEC2.EXPECT().AssociateDhcpOptions(associateDhcpOptionsInput),
 			mockEC2.EXPECT().DeleteVpc(deleteVpcInput),
 		)
 	}

--- a/aws/ecs_utils_for_test.go
+++ b/aws/ecs_utils_for_test.go
@@ -77,7 +77,7 @@ func createEcsEC2Cluster(t *testing.T, awsSession *session.Session, name string,
 	cluster := createEcsFargateCluster(t, awsSession, name)
 
 	ec2Svc := ec2.New(awsSession)
-	imageID, err := getAMIIdByName(ec2Svc, "amzn-ami-2018.03.g-amazon-ecs-optimized")
+	imageID, err := getAMIIdByName(ec2Svc, "amzn-ami-2018.03.20211120-amazon-ecs-optimized")
 	if err != nil {
 		assert.Fail(t, gruntworkerrors.WithStackTrace(err).Error())
 	}

--- a/aws/elasticache_test.go
+++ b/aws/elasticache_test.go
@@ -111,7 +111,7 @@ func TestListElasticacheClustersWithConfigFile(t *testing.T) {
 		Elasticache: config.ResourceType{
 			IncludeRule: config.FilterRule{
 				NamesRegExp: []config.Expression{
-					{RE: *regexp.MustCompile("^cloud-nuke-test-include-.*")},
+					{RE: *regexp.MustCompile("^" + includedClusterId + "^")},
 				},
 			},
 		},

--- a/aws/elasticache_test.go
+++ b/aws/elasticache_test.go
@@ -98,7 +98,8 @@ func TestListElasticacheClustersWithConfigFile(t *testing.T) {
 
 	require.NoError(t, err)
 
-	includedClusterId := "cloud-nuke-test-include-" + strings.ToLower(util.UniqueID())
+	clusterId := strings.ToLower(util.UniqueID())
+	includedClusterId := "cloud-nuke-test-include-" + clusterId + "-" + strings.ToLower(util.UniqueID())
 	excludedClusterId := "cloud-nuke-test-" + strings.ToLower(util.UniqueID())
 
 	createTestElasticacheCluster(t, session, includedClusterId)
@@ -111,7 +112,7 @@ func TestListElasticacheClustersWithConfigFile(t *testing.T) {
 		Elasticache: config.ResourceType{
 			IncludeRule: config.FilterRule{
 				NamesRegExp: []config.Expression{
-					{RE: *regexp.MustCompile("^" + includedClusterId + "^")},
+					{RE: *regexp.MustCompile("^cloud-nuke-test-include-" + clusterId + ".*")},
 				},
 			},
 		},

--- a/aws/mock_ec2_utils_for_test.go
+++ b/aws/mock_ec2_utils_for_test.go
@@ -48,6 +48,10 @@ func getDeleteInternetGatewayInput(gatewayId string) *ec2.DeleteInternetGatewayI
 	}
 }
 
+func getDescribeEgressOnlyInternetGatewaysInput() *ec2.DescribeEgressOnlyInternetGatewaysInput {
+	return &ec2.DescribeEgressOnlyInternetGatewaysInput{}
+}
+
 func getDescribeSubnetsInput(vpcId string) *ec2.DescribeSubnetsInput {
 	return &ec2.DescribeSubnetsInput{
 		Filters: []*ec2.Filter{
@@ -142,11 +146,11 @@ func getDescribeSecurityGroupRulesOutput(securityGroupRuleIds []string) *ec2.Des
 	var securityGroupRules []*ec2.SecurityGroupRule
 	for _, securityGroupRule := range securityGroupRuleIds {
 		securityGroupRules = append(securityGroupRules, &ec2.SecurityGroupRule{
-			IsEgress: awsgo.Bool(true), // egress rule
+			IsEgress:            awsgo.Bool(true), // egress rule
 			SecurityGroupRuleId: awsgo.String(securityGroupRule),
 		})
 		securityGroupRules = append(securityGroupRules, &ec2.SecurityGroupRule{
-			IsEgress: awsgo.Bool(false), // ingress rule
+			IsEgress:            awsgo.Bool(false), // ingress rule
 			SecurityGroupRuleId: awsgo.String(securityGroupRule),
 		})
 	}
@@ -155,14 +159,14 @@ func getDescribeSecurityGroupRulesOutput(securityGroupRuleIds []string) *ec2.Des
 
 func getRevokeSecurityGroupEgressInput(securityGroupId string, securityGroupRuleId string) *ec2.RevokeSecurityGroupEgressInput {
 	return &ec2.RevokeSecurityGroupEgressInput{
-		GroupId: awsgo.String(securityGroupId),
+		GroupId:              awsgo.String(securityGroupId),
 		SecurityGroupRuleIds: []*string{awsgo.String(securityGroupRuleId)},
 	}
 }
 
 func getRevokeSecurityGroupIngressInput(securityGroupId string, securityGroupRuleId string) *ec2.RevokeSecurityGroupIngressInput {
 	return &ec2.RevokeSecurityGroupIngressInput{
-		GroupId: awsgo.String(securityGroupId),
+		GroupId:              awsgo.String(securityGroupId),
 		SecurityGroupRuleIds: []*string{awsgo.String(securityGroupRuleId)},
 	}
 }

--- a/aws/mock_ec2_utils_for_test.go
+++ b/aws/mock_ec2_utils_for_test.go
@@ -52,6 +52,24 @@ func getDescribeEgressOnlyInternetGatewaysInput() *ec2.DescribeEgressOnlyInterne
 	return &ec2.DescribeEgressOnlyInternetGatewaysInput{}
 }
 
+func getDescribeNetworkInterfacesInput(vpcId string) *ec2.DescribeNetworkInterfacesInput {
+	return &ec2.DescribeNetworkInterfacesInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name:   awsgo.String("vpc-id"),
+				Values: awsgo.StringSlice([]string{vpcId}),
+			},
+		},
+	}
+}
+
+func getAssociateDhcpOptionsInput(vpcId string) *ec2.AssociateDhcpOptionsInput {
+	return &ec2.AssociateDhcpOptionsInput{
+		DhcpOptionsId: awsgo.String("default"),
+		VpcId:         awsgo.String(vpcId),
+	}
+}
+
 func getDescribeSubnetsInput(vpcId string) *ec2.DescribeSubnetsInput {
 	return &ec2.DescribeSubnetsInput{
 		Filters: []*ec2.Filter{


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
  * usage of newer image ID used in ECS tests
  * updated pattern used elasticate test to be more specific
  * updated missing mocks used in VPC removal tests

![image](https://user-images.githubusercontent.com/10694338/210820985-6493278c-f331-464a-841b-99f873795852.png)

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

