### PR TITLE
Support nuking EC2 Dedicated Hosts - CORE-286

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,9 @@ The following resources support the Config file:
 - EC2 Instances
     - Resource type: `ec2`
     - Config key: `EC2`
+- EC2 Dedicated Hosts
+    - Resource type: `ec2-dedicated-hosts`
+    - Config key: `EC2DedicatedHosts`
 - EC2 Key Pairs
   - Resource type: `ec2-keypairs`
   - Config key: `EC2KeyPairs`

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -463,6 +463,26 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End EC2 Instances
 
+		// EC2 Dedicated Hosts
+		ec2DedicatedHosts := EC2DedicatedHosts{}
+		if IsNukeable(ec2DedicatedHosts.ResourceName(), resourceTypes) {
+			hostIds, err := getAllEc2DedicatedHosts(cloudNukeSession, region, excludeAfter, configObj)
+			if err != nil {
+				ge := report.GeneralError{
+					Error:        err,
+					Description:  "Unable to retrieve EC2 dedicated hosts",
+					ResourceType: ec2DedicatedHosts.ResourceName(),
+				}
+				report.RecordError(ge)
+			}
+			if len(hostIds) > 0 {
+				ec2DedicatedHosts.HostIds = awsgo.StringValueSlice(hostIds)
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, ec2DedicatedHosts)
+			}
+		}
+
+		// End EC2 Dedicated Hosts
+
 		// EBS Volumes
 		ebsVolumes := EBSVolumes{}
 		if IsNukeable(ebsVolumes.ResourceName(), resourceTypes) {
@@ -1182,6 +1202,7 @@ func ListResourceTypes() []string {
 		TransitGatewaysRouteTables{}.ResourceName(),
 		TransitGateways{}.ResourceName(),
 		EC2Instances{}.ResourceName(),
+		EC2DedicatedHosts{}.ResourceName(),
 		EBSVolumes{}.ResourceName(),
 		EIPAddresses{}.ResourceName(),
 		AMIs{}.ResourceName(),

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -466,7 +466,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		// EC2 Dedicated Hosts
 		ec2DedicatedHosts := EC2DedicatedHosts{}
 		if IsNukeable(ec2DedicatedHosts.ResourceName(), resourceTypes) {
-			hostIds, err := getAllEc2DedicatedHosts(cloudNukeSession, region, excludeAfter, configObj)
+			hostIds, err := getAllEc2DedicatedHosts(cloudNukeSession, excludeAfter, configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/ec2_dedicated_host.go
+++ b/aws/ec2_dedicated_host.go
@@ -1,0 +1,119 @@
+package aws
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+func getAllEc2DedicatedHosts(session *session.Session, region string, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
+	svc := ec2.New(session)
+	var hostIds []*string
+
+	describeHostsInput := &ec2.DescribeHostsInput{
+		Filter: []*ec2.Filter{
+			{
+				Name: awsgo.String("state"),
+				Values: []*string{
+					awsgo.String("available"),
+					awsgo.String("under-assessment"),
+					awsgo.String("permanent-failure"),
+				},
+			},
+		},
+	}
+
+	err := svc.DescribeHostsPages(
+		describeHostsInput,
+		func(page *ec2.DescribeHostsOutput, lastPage bool) bool {
+			for _, host := range page.Hosts {
+				if shouldIncludeHostId(host, excludeAfter, configObj) {
+					hostIds = append(hostIds, host.HostId)
+				}
+			}
+			return !lastPage
+		},
+	)
+
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	return hostIds, nil
+}
+
+func shouldIncludeHostId(host *ec2.Host, excludeAfter time.Time, configObj config.Config) bool {
+	if host == nil {
+		return false
+	}
+
+	if excludeAfter.Before(*host.AllocationTime) {
+		return false
+	}
+
+	// If an instance is using the host allocation we cannot release it
+	if len(host.Instances) != 0 {
+		logging.Logger.Debugf("Host %s has instance(s) still associated, unable to nuke.", *host.HostId)
+		return false
+	}
+
+	// If Name is unset, GetEC2ResourceNameTagValue returns error and zero value string
+	// Ignore this error and pass empty string to config.ShouldInclude
+	hostNameTagValue, _ := GetEC2ResourceNameTagValue(host.Tags)
+
+	return config.ShouldInclude(
+		hostNameTagValue,
+		configObj.EC2DedicatedHosts.IncludeRule.NamesRegExp,
+		configObj.EC2DedicatedHosts.ExcludeRule.NamesRegExp,
+	)
+}
+
+func nukeAllEc2DedicatedHosts(session *session.Session, hostIds []*string) error {
+	svc := ec2.New(session)
+
+	if len(hostIds) == 0 {
+		logging.Logger.Debugf("No EC2 dedicated hosts to nuke in region %s", *session.Config.Region)
+		return nil
+	}
+
+	logging.Logger.Debugf("Releasing all EC2 dedicated host allocations in region %s", *session.Config.Region)
+
+	input := &ec2.ReleaseHostsInput{HostIds: hostIds}
+
+	releaseResult, err := svc.ReleaseHosts(input)
+
+	if err != nil {
+		logging.Logger.Debugf("[Failed] %s", err)
+		return errors.WithStackTrace(err)
+	}
+
+	// Report successes and failures from release host request
+	for _, hostSuccess := range releaseResult.Successful {
+		logging.Logger.Debugf("[OK] Dedicated host %s was released in %s", aws.StringValue(hostSuccess), *session.Config.Region)
+		e := report.Entry{
+			Identifier:   aws.StringValue(hostSuccess),
+			ResourceType: "EC2 Dedicated Host",
+		}
+		report.Record(e)
+	}
+
+	for _, hostFailed := range releaseResult.Unsuccessful {
+		logging.Logger.Debugf("[ERROR] Unable to release dedicated host %s in %s: %s", aws.StringValue(hostFailed.ResourceId), *session.Config.Region, aws.StringValue(hostFailed.Error.Message))
+		e := report.Entry{
+			Identifier:   aws.StringValue(hostFailed.ResourceId),
+			ResourceType: "EC2 Dedicated Host",
+			Error:        fmt.Errorf(*hostFailed.Error.Message),
+		}
+		report.Record(e)
+	}
+
+	return nil
+}

--- a/aws/ec2_dedicated_host.go
+++ b/aws/ec2_dedicated_host.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-func getAllEc2DedicatedHosts(session *session.Session, region string, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
+func getAllEc2DedicatedHosts(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
 	svc := ec2.New(session)
 	var hostIds []*string
 

--- a/aws/ec2_dedicated_host_test.go
+++ b/aws/ec2_dedicated_host_test.go
@@ -39,14 +39,14 @@ func TestListDedicatedHosts(t *testing.T) {
 	defer nukeAllEc2DedicatedHosts(session, createdHostIds)
 
 	// test if created allocation matches get response
-	hostIds, err := getAllEc2DedicatedHosts(session, region, time.Now(), config.Config{})
+	hostIds, err := getAllEc2DedicatedHosts(session, time.Now(), config.Config{})
 
 	require.NoError(t, err)
 	assert.Equal(t, aws.StringValueSlice(hostIds), aws.StringValueSlice(createdHostIds))
 
 	//test time shift
 	olderThan := time.Now().Add(-1 * time.Hour)
-	hostIds, err = getAllEc2DedicatedHosts(session, region, olderThan, config.Config{})
+	hostIds, err = getAllEc2DedicatedHosts(session, olderThan, config.Config{})
 	require.NoError(t, err)
 	assert.NotEqual(t, aws.StringValueSlice(hostIds), aws.StringValueSlice(createdHostIds))
 }
@@ -70,7 +70,7 @@ func TestNukeDedicatedHosts(t *testing.T) {
 	err = nukeAllEc2DedicatedHosts(session, createdHostIds)
 	require.NoError(t, err)
 
-	hostIds, err := getAllEc2DedicatedHosts(session, region, time.Now(), config.Config{})
+	hostIds, err := getAllEc2DedicatedHosts(session, time.Now(), config.Config{})
 	require.NoError(t, err)
 	assert.NotContains(t, aws.StringValueSlice(hostIds), createdHostIds)
 }

--- a/aws/ec2_dedicated_host_test.go
+++ b/aws/ec2_dedicated_host_test.go
@@ -1,0 +1,153 @@
+package aws
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	gruntworkerrors "github.com/gruntwork-io/go-commons/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	TagNamePrefix  = "cloud-nuke-test-"
+	InstanceFamily = "c5"
+	InstanceType   = "c5.large"
+)
+
+func TestListDedicatedHosts(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	svc := ec2.New(session)
+
+	createdHostIds, err := allocateDedicatedHosts(svc, 1)
+	require.NoError(t, err)
+
+	defer nukeAllEc2DedicatedHosts(session, createdHostIds)
+
+	// test if created allocation matches get response
+	hostIds, err := getAllEc2DedicatedHosts(session, region, time.Now(), config.Config{})
+
+	require.NoError(t, err)
+	assert.Equal(t, aws.StringValueSlice(hostIds), aws.StringValueSlice(createdHostIds))
+
+	//test time shift
+	olderThan := time.Now().Add(-1 * time.Hour)
+	hostIds, err = getAllEc2DedicatedHosts(session, region, olderThan, config.Config{})
+	require.NoError(t, err)
+	assert.NotEqual(t, aws.StringValueSlice(hostIds), aws.StringValueSlice(createdHostIds))
+}
+
+func TestNukeDedicatedHosts(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	logging.Logger.Infof("region: %s", region)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	svc := ec2.New(session)
+
+	createdHostIds, err := allocateDedicatedHosts(svc, 1)
+	require.NoError(t, err)
+
+	err = nukeAllEc2DedicatedHosts(session, createdHostIds)
+	require.NoError(t, err)
+
+	hostIds, err := getAllEc2DedicatedHosts(session, region, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.NotContains(t, aws.StringValueSlice(hostIds), createdHostIds)
+}
+
+func allocateDedicatedHosts(svc *ec2.EC2, hostQuantity int64) (hostIds []*string, err error) {
+
+	usableAzs, err := getAzsForInstanceType(svc)
+
+	if err != nil {
+		logging.Logger.Debugf("[Failed] %s", err)
+		return nil, gruntworkerrors.WithStackTrace(err)
+	}
+
+	if usableAzs == nil {
+		logging.Logger.Debugf("[Failed] No AZs with InstanceType found.")
+	}
+
+	hostTagName := TagNamePrefix + util.UniqueID()
+
+	input := &ec2.AllocateHostsInput{
+		AvailabilityZone: aws.String(usableAzs[0]),
+		InstanceFamily:   aws.String(InstanceFamily),
+		Quantity:         aws.Int64(hostQuantity),
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String("dedicated-host"),
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String("Name"),
+						Value: aws.String(hostTagName),
+					},
+				},
+			},
+		},
+	}
+
+	hostIdsOutput, err := svc.AllocateHosts(input)
+
+	if err != nil {
+		logging.Logger.Debugf("[Failed] %s", err)
+		return nil, gruntworkerrors.WithStackTrace(err)
+	}
+
+	for i := range hostIdsOutput.HostIds {
+		hostIds = append(hostIds, hostIdsOutput.HostIds[i])
+	}
+
+	return hostIds, nil
+}
+
+func getAzsForInstanceType(svc *ec2.EC2) ([]string, error) {
+	var instanceOfferings []string
+	input := &ec2.DescribeInstanceTypeOfferingsInput{
+		MaxResults:   aws.Int64(5),
+		LocationType: aws.String("availability-zone"),
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("instance-type"),
+				Values: []*string{aws.String(InstanceType)},
+			},
+		},
+	}
+
+	az, err := svc.DescribeInstanceTypeOfferings(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(az.InstanceTypeOfferings) == 0 {
+		err := errors.New("No matching instance types found in region/az.")
+		return nil, gruntworkerrors.WithStackTrace(err)
+	}
+
+	for i := range az.InstanceTypeOfferings {
+		instanceOfferings = append(instanceOfferings, *az.InstanceTypeOfferings[i].Location)
+	}
+
+	return instanceOfferings, err
+}

--- a/aws/ec2_dedicated_host_types.go
+++ b/aws/ec2_dedicated_host_types.go
@@ -1,0 +1,36 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+// EC2DedicatedHosts - represents all host allocation IDs
+type EC2DedicatedHosts struct {
+	HostIds []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (h EC2DedicatedHosts) ResourceName() string {
+	return "ec2-dedicated-hosts"
+}
+
+// ResourceIdentifiers - The instance ids of the ec2 instances
+func (h EC2DedicatedHosts) ResourceIdentifiers() []string {
+	return h.HostIds
+}
+
+func (h EC2DedicatedHosts) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 49
+}
+
+// Nuke - nuke 'em all!!!
+func (h EC2DedicatedHosts) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllEc2DedicatedHosts(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	ElasticIP             ResourceType `yaml:"ElasticIP"`
 	EC2                   ResourceType `yaml:"EC2"`
 	EC2KeyPairs           ResourceType `yaml:"EC2KeyPairs"`
+	EC2DedicatedHosts     ResourceType `yaml:"EC2DedicatedHosts"`
 	CloudWatchLogGroup    ResourceType `yaml:"CloudWatchLogGroup"`
 	KMSCustomerKeys       ResourceType `yaml:"KMSCustomerKeys"`
 	EKSCluster            ResourceType `yaml:"EKSCluster"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,6 +44,7 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 


### PR DESCRIPTION
## Description

Closes [CORE-286](https://gruntwork.atlassian.net/browse/CORE-286)

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes

Add support for nuking EC2 Dedicated Hosts



[CORE-286]: https://gruntwork.atlassian.net/browse/CORE-286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-286]: https://gruntwork.atlassian.net/browse/CORE-286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ