### PR TITLE
Implement ECR support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,8 @@ jobs:
               --exclude-resource-type iam-group \
               --exclude-resource-type iam-policy \
               --exclude-resource-type vpc \
-              --exclude-resource-type kmscustomerkeys
+              --exclude-resource-type kmscustomerkeys \
+              --exclude-resource-type ecr
           no_output_timeout: 1h
   nuke_sandbox:
     <<: *defaults
@@ -69,7 +70,8 @@ jobs:
               --exclude-resource-type iam-group \
               --exclude-resource-type iam-policy \
               --exclude-resource-type vpc \
-              --exclude-resource-type kmscustomerkeys
+              --exclude-resource-type kmscustomerkeys \
+              --exclude-resource-type ecr
           no_output_timeout: 1h
   deploy:
     <<: *defaults

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The currently supported functionality includes:
 - Inspecting and deleting all Elastic FileSystems (efs) in an AWS account
 - Inspecting and deleting all SNS Topics in an AWS account
 - Inspecting and deleting all CloudTrail Trails in an AWS account
+- Inspecting and deleting all ECR Repositories in an AWS account
 
 ### BEWARE!
 
@@ -392,7 +393,9 @@ The following resources support the Config file:
 - Elastic FileSystems (efs) 
   - Resource type: `efs`
   - Config key: `ElasticFileSystem`
-
+- ECR Repositories
+  - Resource type: `ecr`
+  - Config key: `ECRRepository`
 
 
 
@@ -516,11 +519,12 @@ To find out what we options are supported in the config file today, consult this
 | eks                          | none  | ✅           | none | none       |
 | kinesis-stream               | none  | ✅           | none | none       |
 | efs                          | none  | ✅           | none | none       |
-| acmpca                       | none  | none        | none | none       |
+| acmpca                       | none  | none         | none | none       |
 | iam role                     | none  | ✅           | none | none       |
 | iam policy                   | none  | ✅           | none | none       |
 | sagemaker-notebook-instances | none  | ✅           | none | none       |
-| ... (more to come)           | none  | none        | none | none       |
+| ecr                          | none  | ✅           | none | none       |
+| ... (more to come)           | none  | none         | none | none       |
 
 
 ### Log level

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1091,7 +1091,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 				resourcesInRegion.Resources = append(resourcesInRegion.Resources, ecrRepositories)
 			}
 		}
-		// End Cloudtrail Trails
+		// End ECR Repositories
 
 		if len(resourcesInRegion.Resources) > 0 {
 			account.Resources[region] = resourcesInRegion
@@ -1257,6 +1257,7 @@ func ListResourceTypes() []string {
 		SNSTopic{}.ResourceName(),
 		CloudtrailTrail{}.ResourceName(),
 		EC2KeyPairs{}.ResourceName(),
+		ECR{}.ResourceName(),
 	}
 	sort.Strings(resourceTypes)
 	return resourceTypes

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1087,7 +1087,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 				report.RecordError(ge)
 			}
 			if len(ecrRepositoryArns) > 0 {
-				ecrRepositories.Arns = ecrRepositoryArns
+				ecrRepositories.RepositoryNames = ecrRepositoryArns
 				resourcesInRegion.Resources = append(resourcesInRegion.Resources, ecrRepositories)
 			}
 		}

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1074,6 +1074,25 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End Cloudtrail Trails
 
+		// ECR Repositories
+		ecrRepositories := ECR{}
+		if IsNukeable(ecrRepositories.ResourceName(), resourceTypes) {
+			ecrRepositoryArns, err := getAllECRRepositories(cloudNukeSession, excludeAfter, configObj)
+			if err != nil {
+				ge := report.GeneralError{
+					Error:        err,
+					Description:  "Unable to retrieve ECR repositories",
+					ResourceType: ecrRepositories.ResourceName(),
+				}
+				report.RecordError(ge)
+			}
+			if len(ecrRepositoryArns) > 0 {
+				ecrRepositories.Arns = ecrRepositoryArns
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, ecrRepositories)
+			}
+		}
+		// End Cloudtrail Trails
+
 		if len(resourcesInRegion.Resources) > 0 {
 			account.Resources[region] = resourcesInRegion
 		}

--- a/aws/ecr.go
+++ b/aws/ecr.go
@@ -13,7 +13,6 @@ import (
 )
 
 func getAllECRRepositories(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]string, error) {
-
 	svc := ecr.New(session)
 
 	repositoryNames := []string{}
@@ -58,7 +57,6 @@ func shouldIncludeECRRepository(repository *ecr.Repository, excludeAfter time.Ti
 }
 
 func nukeAllECRRepositories(session *session.Session, repositoryNames []string) error {
-
 	svc := ecr.New(session)
 
 	if len(repositoryNames) == 0 {

--- a/aws/ecr.go
+++ b/aws/ecr.go
@@ -66,7 +66,7 @@ func nukeAllECRRepositories(session *session.Session, repositoryNames []string) 
 		return nil
 	}
 
-	var deletedArns []*string
+	var deletedNames []*string
 
 	for _, repositoryName := range repositoryNames {
 		params := &ecr.DeleteRepositoryInput{
@@ -88,12 +88,12 @@ func nukeAllECRRepositories(session *session.Session, repositoryNames []string) 
 			logging.Logger.Debugf("[Failed] %s", err)
 		} else {
 
-			deletedArns = append(deletedArns, aws.String(repositoryName))
+			deletedNames = append(deletedNames, aws.String(repositoryName))
 			logging.Logger.Debugf("Deleted ECR Repository: %s", repositoryName)
 		}
 	}
 
-	logging.Logger.Debugf("[OK] %d ECR Repositories deleted in %s", len(deletedArns), *session.Config.Region)
+	logging.Logger.Debugf("[OK] %d ECR Repositories deleted in %s", len(deletedNames), *session.Config.Region)
 
 	return nil
 

--- a/aws/ecr.go
+++ b/aws/ecr.go
@@ -1,0 +1,100 @@
+package aws
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+func getAllECRRepositories(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]string, error) {
+
+	svc := ecr.New(session)
+
+	repositoryArns := []string{}
+
+	paginator := func(output *ecr.DescribeRepositoriesOutput, lastPage bool) bool {
+		for _, repository := range output.Repositories {
+			if shouldIncludeECRRepository(repository, excludeAfter, configObj) {
+				repositoryArns = append(repositoryArns, aws.StringValue(repository.RepositoryArn))
+			}
+		}
+		return !lastPage
+	}
+
+	param := &ecr.DescribeRepositoriesInput{}
+
+	err := svc.DescribeRepositoriesPages(param, paginator)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+
+	}
+
+	return repositoryArns, nil
+}
+
+func shouldIncludeECRRepository(repository *ecr.Repository, excludeAfter time.Time, configObj config.Config) bool {
+	if repository == nil {
+		return false
+	}
+
+	createdAtVal := aws.TimeValue(repository.CreatedAt)
+
+	if excludeAfter.Before(createdAtVal) {
+		return false
+	}
+
+	return config.ShouldInclude(
+		aws.StringValue(repository.RepositoryName),
+		configObj.ECRRepository.IncludeRule.NamesRegExp,
+		configObj.ECRRepository.ExcludeRule.NamesRegExp,
+	)
+
+}
+
+func nukeAllECRRepositories(session *session.Session, arns []string) error {
+
+	svc := ecr.New(session)
+
+	if len(arns) == 0 {
+		logging.Logger.Debugf("No ECR repositories to nuke in region %s", *session.Config.Region)
+		return nil
+	}
+
+	var deletedArns []*string
+
+	for _, arn := range arns {
+		params := &ecr.DeleteRepositoryInput{
+			Force:      aws.Bool(true),
+			RegistryId: aws.String(arn),
+		}
+
+		_, err := svc.DeleteRepository(params)
+
+		// Record status of this resource
+		e := report.Entry{
+			Identifier:   arn,
+			ResourceType: "ECR Repository",
+			Error:        err,
+		}
+		report.Record(e)
+
+		if err != nil {
+			logging.Logger.Debugf("[Failed] %s", err)
+		} else {
+
+			deletedArns = append(deletedArns, aws.String(arn))
+			logging.Logger.Debugf("Deleted ECR Repository: %s", arn)
+		}
+	}
+
+	logging.Logger.Debugf("[OK] %d ECR Repositories deleted in %s", len(deletedArns), *session.Config.Region)
+
+	return nil
+
+}

--- a/aws/ecr_test.go
+++ b/aws/ecr_test.go
@@ -93,6 +93,30 @@ func TestNukeECRRepositoryOne(t *testing.T) {
 	assertECRRepositoriesDeleted(t, region, identifiers)
 }
 
+func TestNukeECRRepositoryMoreThanOne(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	repositoryNames := []*string{}
+	for i := 0; i < 3; i++ {
+		repositoryName := createECRRepository(t, region)
+		defer deleteECRRepository(t, region, repositoryName, false)
+		repositoryNames = append(repositoryNames, repositoryName)
+	}
+
+	require.NoError(
+		t,
+		nukeAllECRRepositories(session, aws.StringValueSlice(repositoryNames)),
+	)
+
+	assertECRRepositoriesDeleted(t, region, repositoryNames)
+}
+
 func assertECRRepositoriesDeleted(t *testing.T, region string, repositoryNames []*string) {
 
 	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})

--- a/aws/ecr_test.go
+++ b/aws/ecr_test.go
@@ -118,7 +118,6 @@ func TestNukeECRRepositoryMoreThanOne(t *testing.T) {
 }
 
 func assertECRRepositoriesDeleted(t *testing.T, region string, repositoryNames []*string) {
-
 	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
 	require.NoError(t, err)
 	svc := ecr.New(session)

--- a/aws/ecr_test.go
+++ b/aws/ecr_test.go
@@ -1,0 +1,120 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListECRRepositories(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	repositoryName := createECRRepository(t, region)
+	defer deleteECRRepository(t, region, repositoryName, true)
+
+	repositoryNames, err := getAllECRRepositories(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.Contains(t, repositoryNames, aws.StringValue(repositoryName))
+}
+
+func deleteECRRepository(t *testing.T, region string, repositoryName *string, checkErr bool) {
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	ecrService := ecr.New(session)
+
+	param := &ecr.DeleteRepositoryInput{
+		RepositoryName: repositoryName,
+	}
+
+	_, deleteErr := ecrService.DeleteRepository(param)
+	if checkErr {
+		require.NoError(t, deleteErr)
+	}
+}
+
+func createECRRepository(t *testing.T, region string) *string {
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	ecrService := ecr.New(session)
+
+	name := strings.ToLower(fmt.Sprintf("cloud-nuke-test-%s-%s", util.UniqueID(), util.UniqueID()))
+
+	param := &ecr.CreateRepositoryInput{
+		RepositoryName: aws.String(name),
+	}
+
+	output, createRepositoryErr := ecrService.CreateRepository(param)
+
+	require.NoError(t, createRepositoryErr)
+
+	return output.Repository.RepositoryName
+
+}
+
+func TestNukeECRRepositoryOne(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	repositoryName := createECRRepository(t, region)
+
+	defer deleteECRRepository(t, region, repositoryName, true)
+
+	identifiers := []*string{repositoryName}
+
+	require.NoError(
+		t,
+		nukeAllECRRepositories(session, aws.StringValueSlice(identifiers)),
+	)
+
+	assertECRRepositoriesDeleted(t, region, identifiers)
+}
+
+func assertECRRepositoriesDeleted(t *testing.T, region string, repositoryNames []*string) {
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+	svc := ecr.New(session)
+
+	// Try to figure out which registries we have in play
+	registryParam := &ecr.DescribeRegistryInput{}
+
+	registryResp, registryErr := svc.DescribeRegistry(registryParam)
+	require.NoError(t, registryErr)
+
+	registryID := registryResp.RegistryId
+
+	param := &ecr.DescribeRepositoriesInput{
+		RegistryId:      registryID,
+		RepositoryNames: repositoryNames,
+	}
+
+	resp, err := svc.DescribeRepositories(param)
+
+	require.NoError(t, err)
+	if len(resp.Repositories) > 0 {
+		t.Logf("Repository: %+v\n", resp.Repositories)
+		t.Fatalf("At least one of the following ECR Repositories was not deleted: %+v\n", aws.StringValueSlice(repositoryNames))
+	}
+}

--- a/aws/ecr_types.go
+++ b/aws/ecr_types.go
@@ -1,0 +1,30 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+type ECR struct {
+	Arns []string
+}
+
+func (registry ECR) ResourceName() string {
+	return "ecr"
+}
+
+func (registry ECR) ResourceIdentifiers() []string {
+	return registry.Arns
+}
+
+func (registry ECR) MaxBatchSize() int {
+	return 50
+}
+
+func (registry ECR) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllECRRepositories(session, identifiers); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/aws/ecr_types.go
+++ b/aws/ecr_types.go
@@ -6,7 +6,7 @@ import (
 )
 
 type ECR struct {
-	Arns []string
+	RepositoryNames []string
 }
 
 func (registry ECR) ResourceName() string {
@@ -14,7 +14,7 @@ func (registry ECR) ResourceName() string {
 }
 
 func (registry ECR) ResourceIdentifiers() []string {
-	return registry.Arns
+	return registry.RepositoryNames
 }
 
 func (registry ECR) MaxBatchSize() int {

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	APIGatewayV2          ResourceType `yaml:"APIGatewayV2"`
 	ElasticFileSystem     ResourceType `yaml:"ElasticFileSystem"`
 	CloudtrailTrail       ResourceType `yaml:"CloudtrailTrail"`
+	ECRRepository         ResourceType `yaml:"ECRRepository"`
 }
 
 type ResourceType struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -45,6 +45,7 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes [CORE-381](https://gruntwork.atlassian.net/browse/CORE-381).

![cloud-nuke-ecr-demo](https://user-images.githubusercontent.com/1769996/213717169-15edc737-51bd-44f2-b8a7-00f94a16fdd9.gif)


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Add tests
- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



[CORE-381]: https://gruntwork.atlassian.net/browse/CORE-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ