### PR TITLE
CORE-332 Document RDS, Neptune, Document DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The currently supported functionality includes:
 - Inspecting and deleting all ECS services in an AWS account
 - Inspecting and deleting all ECS clusters in an AWS account
 - Inspecting and deleting all EKS clusters in an AWS account
-- Inspecting and deleting all RDS DB instances in an AWS account
+- Inspecting and deleting all RDS, Neptune, and Document DB instances in an AWS account
+> **WARNING:** The RDS APIs also interact with neptune and document db resources.  Running `cloud-nuke aws --resource-type rds` without a config file will remove any neptune and document db resources in the account.
 - Inspecting and deleting all Lambda Functions in an AWS account
 - Inspecting and deleting all SQS queues in an AWS account
 - Inspecting and deleting all S3 buckets in an AWS account - except for buckets tagged with Key=cloud-nuke-excluded Value=true
@@ -396,6 +397,9 @@ The following resources support the Config file:
 - ECR Repositories
   - Resource type: `ecr`
   - Config key: `ECRRepository`
+- RDS, Neptune, and Document DB Resources
+  - Resource type: `rds`
+  - Config key: `DBInstances`
 
 
 
@@ -491,40 +495,41 @@ Be careful when nuking and append the `--dry-run` option if you're unsure. Even 
 
 To find out what we options are supported in the config file today, consult this table. Resource types at the top level of the file that are supported are listed here.
 
-| resource type                | names | names_regex | tags | tags_regex |
-|------------------------------|-------|-------------|------|------------|
-| s3                           | none  | ✅           | none | none       |
-| iam user                     | none  | ✅           | none | none       |
-| ecsserv                      | none  | ✅           | none | none       |
-| ecscluster                   | none  | ✅           | none | none       |
-| secretsmanager               | none  | ✅           | none | none       |
-| nat-gateway                  | none  | ✅           | none | none       |
-| accessanalyzer               | none  | ✅           | none | none       |
-| dynamodb                     | none  | ✅           | none | none       |
-| ebs                          | none  | ✅           | none | none       |
-| lambda                       | none  | ✅           | none | none       |
-| elbv2                        | none  | ✅           | none | none       |
-| ecs                          | none  | ✅           | none | none       |
-| elasticache                  | none  | ✅           | none | none       |
-| vpc                          | none  | ✅           | none | none       |
-| oidcprovider                 | none  | ✅           | none | none       |
-| cloudwatch-loggroup          | none  | ✅           | none | none       |
-| kmscustomerkeys              | none  | ✅           | none | none       |
-| asg                          | none  | ✅           | none | none       |
-| lc                           | none  | ✅           | none | none       |
-| eip                          | none  | ✅           | none | none       |
-| ec2                          | none  | ✅           | none | none       |
-| apigateway                   | none  | ✅           | none | none       |
-| apigatewayv2                 | none  | ✅           | none | none       |
-| eks                          | none  | ✅           | none | none       |
-| kinesis-stream               | none  | ✅           | none | none       |
-| efs                          | none  | ✅           | none | none       |
-| acmpca                       | none  | none         | none | none       |
-| iam role                     | none  | ✅           | none | none       |
-| iam policy                   | none  | ✅           | none | none       |
-| sagemaker-notebook-instances | none  | ✅           | none | none       |
-| ecr                          | none  | ✅           | none | none       |
-| ... (more to come)           | none  | none         | none | none       |
+| resource type                 | names | names_regex | tags | tags_regex |
+|-------------------------------|-------|-------------|------|------------|
+| s3                            | none  | ✅           | none | none       |
+| iam user                      | none  | ✅           | none | none       |
+| ecsserv                       | none  | ✅           | none | none       |
+| ecscluster                    | none  | ✅           | none | none       |
+| secretsmanager                | none  | ✅           | none | none       |
+| nat-gateway                   | none  | ✅           | none | none       |
+| accessanalyzer                | none  | ✅           | none | none       |
+| dynamodb                      | none  | ✅           | none | none       |
+| ebs                           | none  | ✅           | none | none       |
+| lambda                        | none  | ✅           | none | none       |
+| elbv2                         | none  | ✅           | none | none       |
+| ecs                           | none  | ✅           | none | none       |
+| elasticache                   | none  | ✅           | none | none       |
+| vpc                           | none  | ✅           | none | none       |
+| oidcprovider                  | none  | ✅           | none | none       |
+| cloudwatch-loggroup           | none  | ✅           | none | none       |
+| kmscustomerkeys               | none  | ✅           | none | none       |
+| asg                           | none  | ✅           | none | none       |
+| lc                            | none  | ✅           | none | none       |
+| eip                           | none  | ✅           | none | none       |
+| ec2                           | none  | ✅           | none | none       |
+| apigateway                    | none  | ✅           | none | none       |
+| apigatewayv2                  | none  | ✅           | none | none       |
+| eks                           | none  | ✅           | none | none       |
+| kinesis-stream                | none  | ✅           | none | none       |
+| efs                           | none  | ✅           | none | none       |
+| acmpca                        | none  | none         | none | none       |
+| iam role                      | none  | ✅           | none | none       |
+| iam policy                    | none  | ✅           | none | none       |
+| sagemaker-notebook-instances  | none  | ✅           | none | none       |
+| ecr                           | none  | ✅           | none | none       |
+| rds (+neptune and documentdb) | none  | ✅           | none | none       |
+| ... (more to come)            | none  | none         | none | none       |
 
 
 ### Log level

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -626,7 +626,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,
-					Description:  "Unable to retrieve RDS instances",
+					Description:  "Unable to retrieve DB instances",
 					ResourceType: dbInstances.ResourceName(),
 				}
 				report.RecordError(ge)

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -622,7 +622,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		// RDS DB Instances
 		dbInstances := DBInstances{}
 		if IsNukeable(dbInstances.ResourceName(), resourceTypes) {
-			instanceNames, err := getAllRdsInstances(cloudNukeSession, excludeAfter)
+			instanceNames, err := getAllRdsInstances(cloudNukeSession, excludeAfter, configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/rds_test.go
+++ b/aws/rds_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/config"
 	"strings"
 	"testing"
 	"time"
@@ -80,12 +81,12 @@ func TestNukeRDSInstance(t *testing.T) {
 	defer func() {
 		nukeAllRdsInstances(session, []*string{&rdsName})
 
-		rdsNames, _ := getAllRdsInstances(session, excludeAfter)
+		rdsNames, _ := getAllRdsInstances(session, excludeAfter, config.Config{})
 
 		assert.NotContains(t, awsgo.StringValueSlice(rdsNames), strings.ToLower(rdsName))
 	}()
 
-	instances, err := getAllRdsInstances(session, excludeAfter)
+	instances, err := getAllRdsInstances(session, excludeAfter, config.Config{})
 
 	if err != nil {
 		assert.Failf(t, "Unable to fetch list of RDS DB Instances", errors.WithStackTrace(err).Error())

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	ElasticFileSystem     ResourceType `yaml:"ElasticFileSystem"`
 	CloudtrailTrail       ResourceType `yaml:"CloudtrailTrail"`
 	ECRRepository         ResourceType `yaml:"ECRRepository"`
+	DBInstances           ResourceType `yaml:"DBInstances"`
 }
 
 type ResourceType struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -46,6 +46,7 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes #389. Adds documentation for RDS db resource type and adds support for Config file filtering for DBInstance resources

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

Added DBInstance resource type support to config files.


