### PR TITLE
`defaults-aws` also nukes the SG's IPv6 egress rule

### DIFF
--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -707,6 +707,20 @@ func (sg DefaultSecurityGroup) getDefaultSecurityGroupEgressRule() *ec2.RevokeSe
 	}
 }
 
+func (sg DefaultSecurityGroup) getDefaultSecurityGroupIPv6EgressRule() *ec2.RevokeSecurityGroupEgressInput {
+	return &ec2.RevokeSecurityGroupEgressInput{
+		GroupId: awsgo.String(sg.GroupId),
+		IpPermissions: []*ec2.IpPermission{
+			{
+				IpProtocol: awsgo.String("-1"),
+				FromPort:   awsgo.Int64(0),
+				ToPort:     awsgo.Int64(0),
+				Ipv6Ranges: []*ec2.Ipv6Range{{CidrIpv6: awsgo.String("::/0")}},
+			},
+		},
+	}
+}
+
 func (sg DefaultSecurityGroup) nuke() error {
 	logging.Logger.Debugf("...revoking default rules from Security Group %s", sg.GroupId)
 	if sg.GroupName == "default" {
@@ -722,6 +736,16 @@ func (sg DefaultSecurityGroup) nuke() error {
 
 		egressRule := sg.getDefaultSecurityGroupEgressRule()
 		_, err = sg.svc.RevokeSecurityGroupEgress(egressRule)
+		if err != nil {
+			if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == "InvalidPermission.NotFound" {
+				logging.Logger.Debugf("Ingress rule not present (ok)")
+			} else {
+				return fmt.Errorf("error deleting eggress rule: %s", errors.WithStackTrace(err))
+			}
+		}
+
+		ipv6EgressRule := sg.getDefaultSecurityGroupIPv6EgressRule()
+		_, err = sg.svc.RevokeSecurityGroupEgress(ipv6EgressRule)
 		if err != nil {
 			if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == "InvalidPermission.NotFound" {
 				logging.Logger.Debugf("Ingress rule not present (ok)")

--- a/aws/ec2_unit_test.go
+++ b/aws/ec2_unit_test.go
@@ -245,10 +245,13 @@ func TestNukeDefaultSecurityGroups(t *testing.T) {
 		mockEC2.EXPECT().DescribeSecurityGroups(describeSecurityGroupsInput).DoAndReturn(describeSecurityGroupsFuncTwo),
 		mockEC2.EXPECT().RevokeSecurityGroupIngress(groups[0].getDefaultSecurityGroupIngressRule()),
 		mockEC2.EXPECT().RevokeSecurityGroupEgress(groups[0].getDefaultSecurityGroupEgressRule()),
+		mockEC2.EXPECT().RevokeSecurityGroupEgress(groups[0].getDefaultSecurityGroupIPv6EgressRule()),
 		mockEC2.EXPECT().RevokeSecurityGroupIngress(groups[1].getDefaultSecurityGroupIngressRule()),
 		mockEC2.EXPECT().RevokeSecurityGroupEgress(groups[1].getDefaultSecurityGroupEgressRule()),
+		mockEC2.EXPECT().RevokeSecurityGroupEgress(groups[1].getDefaultSecurityGroupIPv6EgressRule()),
 		mockEC2.EXPECT().RevokeSecurityGroupIngress(groups[2].getDefaultSecurityGroupIngressRule()),
 		mockEC2.EXPECT().RevokeSecurityGroupEgress(groups[2].getDefaultSecurityGroupEgressRule()),
+		mockEC2.EXPECT().RevokeSecurityGroupEgress(groups[2].getDefaultSecurityGroupIPv6EgressRule()),
 	)
 
 	for range regions {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #400.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `defaults-aws` to nuke IPv6 security group's egress rule

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

