### PR TITLE
[CORE-312] Implement Launch Template Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,13 +385,13 @@ The following resources support the Config file:
 - SageMaker Notebook Instances
   - Resource type: `sagemaker-notebook-instances`
   - Config key: `SageMakerNotebook`
-- API Gateways (v1) 
+- API Gateways (v1)
   - Resource type: `apigateway`
   - Config key: `APIGateway`
-- API Gateways (v2) 
+- API Gateways (v2)
   - Resource type: `apigatewayv2`
   - Config key: `APIGatewayV2`
-- Elastic FileSystems (efs) 
+- Elastic FileSystems (efs)
   - Resource type: `efs`
   - Config key: `ElasticFileSystem`
 - ECR Repositories
@@ -400,6 +400,9 @@ The following resources support the Config file:
 - RDS, Neptune, and Document DB Resources
   - Resource type: `rds`
   - Config key: `DBInstances`
+- Launch Templates
+  - Resource type: `lt`
+  - Config key: `LaunchTemplate`
 
 
 
@@ -529,13 +532,14 @@ To find out what we options are supported in the config file today, consult this
 | sagemaker-notebook-instances  | none  | ✅           | none | none       |
 | ecr                           | none  | ✅           | none | none       |
 | rds (+neptune and documentdb) | none  | ✅           | none | none       |
+| lt                            | none  | ✅           | none | none       |
 | ... (more to come)            | none  | none         | none | none       |
 
 
 ### Log level
-By default, cloud-nuke sends most output to the `Debug` level logger, to enhance legibility, since the results of every deletion attempt will be displayed in the report that cloud-nuke prints after each run. 
+By default, cloud-nuke sends most output to the `Debug` level logger, to enhance legibility, since the results of every deletion attempt will be displayed in the report that cloud-nuke prints after each run.
 
-However, sometimes it's helpful to see all output, such as when you're debugging something. 
+However, sometimes it's helpful to see all output, such as when you're debugging something.
 
 You can set the log level by specifying the `--log-level` flag as per [logrus](https://github.com/sirupsen/logrus) log levels:
 

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -283,6 +283,26 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End Launch Configuration Names
 
+		// Launch Template Names
+		templates := LaunchTemplates{}
+		if IsNukeable(templates.ResourceName(), resourceTypes) {
+			templateNames, err := getAllLaunchTemplates(cloudNukeSession, region, excludeAfter, configObj)
+			if err != nil {
+				ge := report.GeneralError{
+					Error:        err,
+					Description:  "Unable to retrieve Launch templates",
+					ResourceType: templates.ResourceName(),
+				}
+				report.RecordError(ge)
+			}
+
+			if len(templateNames) > 0 {
+				templates.LaunchTemplateNames = awsgo.StringValueSlice(templateNames)
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, templates)
+			}
+		}
+		// End Launch Template Names
+
 		// LoadBalancer Names
 		loadBalancers := LoadBalancers{}
 		if IsNukeable(loadBalancers.ResourceName(), resourceTypes) {
@@ -1258,6 +1278,7 @@ func ListResourceTypes() []string {
 		CloudtrailTrail{}.ResourceName(),
 		EC2KeyPairs{}.ResourceName(),
 		ECR{}.ResourceName(),
+		LaunchTemplates{}.ResourceName(),
 	}
 	sort.Strings(resourceTypes)
 	return resourceTypes

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -286,7 +286,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		// Launch Template Names
 		templates := LaunchTemplates{}
 		if IsNukeable(templates.ResourceName(), resourceTypes) {
-			templateNames, err := getAllLaunchTemplates(cloudNukeSession, region, excludeAfter, configObj)
+			templateNames, err := getAllLaunchTemplates(cloudNukeSession, excludeAfter, configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/launch_template.go
+++ b/aws/launch_template.go
@@ -1,0 +1,87 @@
+package aws
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+// Returns a formatted string of Launch Template Names
+func getAllLaunchTemplates(session *session.Session, region string, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
+	svc := ec2.New(session)
+	result, err := svc.DescribeLaunchTemplates(&ec2.DescribeLaunchTemplatesInput{})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	var templateNames []*string
+	for _, template := range result.LaunchTemplates {
+		if shouldIncludeLaunchTemplate(template, excludeAfter, configObj) {
+			templateNames = append(templateNames, template.LaunchTemplateName)
+		}
+	}
+
+	return templateNames, nil
+}
+
+func shouldIncludeLaunchTemplate(lt *ec2.LaunchTemplate, excludeAfter time.Time, configObj config.Config) bool {
+	if lt == nil {
+		return false
+	}
+
+	if lt.CreateTime != nil && excludeAfter.Before(*lt.CreateTime) {
+		return false
+	}
+
+	return config.ShouldInclude(
+		awsgo.StringValue(lt.LaunchTemplateName),
+		configObj.LaunchTemplate.IncludeRule.NamesRegExp,
+		configObj.LaunchTemplate.ExcludeRule.NamesRegExp,
+	)
+}
+
+// Deletes all Launch Templates
+func nukeAllLaunchTemplates(session *session.Session, templateNames []*string) error {
+	svc := ec2.New(session)
+
+	if len(templateNames) == 0 {
+		logging.Logger.Debugf("No Launch Templates to nuke in region %s", *session.Config.Region)
+		return nil
+	}
+
+	logging.Logger.Debugf("Deleting all Launch Templates in region %s", *session.Config.Region)
+	var deletedTemplateNames []*string
+
+	for _, templateName := range templateNames {
+		params := &ec2.DeleteLaunchTemplateInput{
+			LaunchTemplateName: templateName,
+		}
+
+		_, err := svc.DeleteLaunchTemplate(params)
+
+		// Record status of this resource
+		e := report.Entry{
+			Identifier:   aws.StringValue(templateName),
+			ResourceType: "Launch template",
+			Error:        err,
+		}
+		report.Record(e)
+
+		if err != nil {
+			logging.Logger.Errorf("[Failed] %s", err)
+		} else {
+			deletedTemplateNames = append(deletedTemplateNames, templateName)
+			logging.Logger.Debugf("Deleted Launch template: %s", *templateName)
+		}
+	}
+
+	logging.Logger.Debugf("[OK] %d Launch Template(s) deleted in %s", len(deletedTemplateNames), *session.Config.Region)
+	return nil
+}

--- a/aws/launch_template.go
+++ b/aws/launch_template.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Returns a formatted string of Launch Template Names
-func getAllLaunchTemplates(session *session.Session, region string, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
+func getAllLaunchTemplates(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
 	svc := ec2.New(session)
 	result, err := svc.DescribeLaunchTemplates(&ec2.DescribeLaunchTemplatesInput{})
 	if err != nil {

--- a/aws/launch_template_test.go
+++ b/aws/launch_template_test.go
@@ -1,0 +1,189 @@
+package aws
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestLaunchTemplate(t *testing.T, session *session.Session, name string) {
+	svc := ec2.New(session)
+
+	param := &ec2.CreateLaunchTemplateInput{
+		LaunchTemplateName: &name,
+		LaunchTemplateData: &ec2.RequestLaunchTemplateData{
+			InstanceType: awsgo.String("t2.micro"),
+		},
+		VersionDescription: aws.String("cloud-nuke-test-v1"),
+	}
+
+	_, err := svc.CreateLaunchTemplate(param)
+	if err != nil {
+		assert.Failf(t, "Could not create test Launch template", errors.WithStackTrace(err).Error())
+	}
+
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+}
+
+func TestListLaunchTemplates(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
+
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	uniqueTestID := "cloud-nuke-test-" + util.UniqueID()
+	createTestLaunchTemplate(t, session, uniqueTestID)
+
+	// clean up after this test
+	defer nukeAllLaunchTemplates(session, []*string{&uniqueTestID})
+
+	templateNames, err := getAllLaunchTemplates(session, region, time.Now().Add(1*time.Hour*-1), config.Config{})
+	if err != nil {
+		assert.Fail(t, "Unable to fetch list of Launch Templates")
+	}
+
+	// Template should not be in the list due to the time filter
+	assert.NotContains(t, awsgo.StringValueSlice(templateNames), uniqueTestID)
+
+	templateNames, err = getAllLaunchTemplates(session, region, time.Now().Add(1*time.Hour), config.Config{})
+	if err != nil {
+		assert.Fail(t, "Unable to fetch list of Launch Templates")
+	}
+
+	assert.Contains(t, awsgo.StringValueSlice(templateNames), uniqueTestID)
+}
+
+func TestNukeLaunchTemplates(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
+	svc := ec2.New(session)
+
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	uniqueTestID := "cloud-nuke-test-" + util.UniqueID()
+	createTestLaunchTemplate(t, session, uniqueTestID)
+
+	_, err = svc.DescribeLaunchTemplates(&ec2.DescribeLaunchTemplatesInput{
+		LaunchTemplateNames: []*string{&uniqueTestID},
+	})
+
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	if err := nukeAllLaunchTemplates(session, []*string{&uniqueTestID}); err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	groupNames, err := getAllLaunchTemplates(session, region, time.Now().Add(1*time.Hour), config.Config{})
+	if err != nil {
+		assert.Fail(t, "Unable to fetch list of Launch Templates")
+	}
+
+	assert.NotContains(t, awsgo.StringValueSlice(groupNames), uniqueTestID)
+}
+
+func TestShouldIncludeLaunchTemplate(t *testing.T) {
+	mockLaunchTemplate := &ec2.LaunchTemplate{
+		LaunchTemplateName: awsgo.String("cloud-nuke-test"),
+		CreateTime:         awsgo.Time(time.Now()),
+	}
+
+	mockExpression, err := regexp.Compile("^cloud-nuke-*")
+	if err != nil {
+		logging.Logger.Fatalf("There was an error compiling regex expression %v", err)
+	}
+
+	mockExcludeConfig := config.Config{
+		LaunchTemplate: config.ResourceType{
+			ExcludeRule: config.FilterRule{
+				NamesRegExp: []config.Expression{
+					{
+						RE: *mockExpression,
+					},
+				},
+			},
+		},
+	}
+
+	mockIncludeConfig := config.Config{
+		LaunchTemplate: config.ResourceType{
+			IncludeRule: config.FilterRule{
+				NamesRegExp: []config.Expression{
+					{
+						RE: *mockExpression,
+					},
+				},
+			},
+		},
+	}
+
+	cases := []struct {
+		Name           string
+		LaunchTemplate *ec2.LaunchTemplate
+		Config         config.Config
+		ExcludeAfter   time.Time
+		Expected       bool
+	}{
+		{
+			Name:           "ConfigExclude",
+			LaunchTemplate: mockLaunchTemplate,
+			Config:         mockExcludeConfig,
+			ExcludeAfter:   time.Now().Add(1 * time.Hour),
+			Expected:       false,
+		},
+		{
+			Name:           "ConfigInclude",
+			LaunchTemplate: mockLaunchTemplate,
+			Config:         mockIncludeConfig,
+			ExcludeAfter:   time.Now().Add(1 * time.Hour),
+			Expected:       true,
+		},
+		{
+			Name:           "NotOlderThan",
+			LaunchTemplate: mockLaunchTemplate,
+			Config:         config.Config{},
+			ExcludeAfter:   time.Now().Add(1 * time.Hour * -1),
+			Expected:       false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			result := shouldIncludeLaunchTemplate(c.LaunchTemplate, c.ExcludeAfter, c.Config)
+			assert.Equal(t, c.Expected, result)
+		})
+	}
+}

--- a/aws/launch_template_types.go
+++ b/aws/launch_template_types.go
@@ -1,0 +1,36 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+// LaunchTemplates - represents all launch templates
+type LaunchTemplates struct {
+	LaunchTemplateNames []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (template LaunchTemplates) ResourceName() string {
+	return "lt"
+}
+
+func (template LaunchTemplates) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 49
+}
+
+// ResourceIdentifiers - The names of the launch templates
+func (template LaunchTemplates) ResourceIdentifiers() []string {
+	return template.LaunchTemplateNames
+}
+
+// Nuke - nuke 'em all!!!
+func (template LaunchTemplates) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllLaunchTemplates(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	CloudtrailTrail       ResourceType `yaml:"CloudtrailTrail"`
 	ECRRepository         ResourceType `yaml:"ECRRepository"`
 	DBInstances           ResourceType `yaml:"DBInstances"`
+	LaunchTemplate        ResourceType `yaml:"LaunchTemplate"`
 }
 
 type ResourceType struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -47,6 +47,7 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes [CORE-312](https://gruntwork.atlassian.net/browse/CORE-312).

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added support for Launch Templates

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



[CORE-312]: https://gruntwork.atlassian.net/browse/CORE-312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ