### PR TITLE
Document strange VPC deletion behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,10 @@ When nuking VPCs cloud-nuke will attempt to remove dependency resources undernea
 
 All other resources that get created within VPCs must be cleaned up prior to running cloud-nuke on VPC resources.
 
+> VPC resources may not be entirely cleaned up on the first run. We believe this is caused by an eventual consistency error in AWS.
+> 
+> If you see errors like `InvalidParameterValue: Network interface is currently in use.` We recommend waiting 30 minutes and trying again.
+
 Happy Nuking!!!
 
 ## Credentials


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds documentation to readme around VPC resource deletion bug

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated readme with instructions for VPC deletion


