### PR TITLE
cleanup vpcs and kms keys in phxdevops

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,14 +42,12 @@ jobs:
             # We explicitly list the resource types we want to nuke, as we are not ready to nuke some resource types in
             # the AWS account we use at Gruntwork for testing (Phx DevOps) (e.g., S3)
             go run main.go aws \
-              --older-than 1h \
+              --older-than 2h \
               --force \
               --config ./.circleci/nuke_config.yml \
               --exclude-resource-type iam \
               --exclude-resource-type iam-group \
               --exclude-resource-type iam-policy \
-              --exclude-resource-type vpc \
-              --exclude-resource-type kmscustomerkeys \
               --exclude-resource-type ecr \
               --exclude-resource-type config-recorders \
               --exclude-resource-type config-rules 

--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -125,3 +125,7 @@ IAMRoles:
   include: 
     names_regex: 
       - "^cloud-nuke-Test*"
+KMSCustomerKeys:
+  include:
+    names_regex:
+      - "^cloud-nuke-test-.*$"


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updates the internal cleanup job to delete kms keys and vpcs.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)


