### PR TITLE
Exclude service-linked IAM roles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
               --config ./.circleci/nuke_config.yml \
               --exclude-resource-type iam \
               --exclude-resource-type iam-group \
+              --exclude-resource-type iam-service-linked-role \
               --exclude-resource-type iam-policy \
               --exclude-resource-type ecr \
               --exclude-resource-type config-recorders \
@@ -68,6 +69,7 @@ jobs:
               --config ./.circleci/nuke_config.yml \
               --exclude-resource-type iam \
               --exclude-resource-type iam-group \
+              --exclude-resource-type iam-service-linked-role \
               --exclude-resource-type iam-policy \
               --exclude-resource-type vpc \
               --exclude-resource-type kmscustomerkeys \


### PR DESCRIPTION
Adds exclusion for service-linked roles for auto-nuking.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.
