### PR TITLE
Don't log to `STDOUT` when being used as a library

### DIFF
--- a/aws/cli_nuke.go
+++ b/aws/cli_nuke.go
@@ -1,7 +1,0 @@
-package aws
-
-func NukeResourcesViaCLI(a *AwsAccountResources, regions []string) error {
-	// Log which resource types will be inspected
-	// NOTE: The inspect functionality currently does not support config file, so we short circuit the logic with an empty struct.
-	return NukeAllResources(a, regions)
-}

--- a/aws/cli_nuke.go
+++ b/aws/cli_nuke.go
@@ -1,0 +1,7 @@
+package aws
+
+func NukeResourcesViaCLI(a *AwsAccountResources, regions []string) error {
+	// Log which resource types will be inspected
+	// NOTE: The inspect functionality currently does not support config file, so we short circuit the logic with an empty struct.
+	return NukeAllResources(a, regions)
+}

--- a/aws/inspect.go
+++ b/aws/inspect.go
@@ -79,8 +79,6 @@ func HandleResourceTypeSelections(
 }
 
 func InspectResources(q *Query) (*AwsAccountResources, error) {
-	// Log which resource types will be inspected
-	logging.Logger.Info("The following resource types will be inspected:")
 	if len(q.ResourceTypes) > 0 {
 		for _, resourceType := range q.ResourceTypes {
 			logging.Logger.Infof("- %s", resourceType)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Obnoxiously, cloud-nuke currently logs to `STDOUT` by default, which interferes with several use-cases. For one, using the library in a Terminal User Interface (TUI) context.

These changes remove the hard-coded log line in the `InspectResources` method, which only accepts a query, and therefore exists squarely in the library usage context.

Required by https://github.com/gruntwork-io/gruntwork/pull/152

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

