### PR TITLE
Add cloudwatch alarm support (#429)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The currently supported functionality includes:
 - Inspecting and deleting all ECR Repositories in an AWS account
 - Inspecting and deleting all Config service recorders in an AWS account
 - Inspecting and deleting all Config service rules in an AWS account
+- Inspecting and deleting all CloudWatch Alarms in an AWS Account
 
 ### BEWARE!
 
@@ -386,33 +387,35 @@ The following resources support the Config file:
     - Resource type: `ec2-dedicated-hosts`
     - Config key: `EC2DedicatedHosts`
 - EC2 Key Pairs
-  - Resource type: `ec2-keypairs`
-  - Config key: `EC2KeyPairs`
+    - Resource type: `ec2-keypairs`
+    - Config key: `EC2KeyPairs`
 - EKS Clusters
     - Resource type: `ekscluster`
     - Config key: `EKSCluster`
 - SageMaker Notebook Instances
-  - Resource type: `sagemaker-notebook-instances`
-  - Config key: `SageMakerNotebook`
+    - Resource type: `sagemaker-notebook-instances`
+    - Config key: `SageMakerNotebook`
 - API Gateways (v1)
-  - Resource type: `apigateway`
-  - Config key: `APIGateway`
+    - Resource type: `apigateway`
+    - Config key: `APIGateway`
 - API Gateways (v2)
-  - Resource type: `apigatewayv2`
-  - Config key: `APIGatewayV2`
+    - Resource type: `apigatewayv2`
+    - Config key: `APIGatewayV2`
 - Elastic FileSystems (efs)
-  - Resource type: `efs`
-  - Config key: `ElasticFileSystem`
+    - Resource type: `efs`
+    - Config key: `ElasticFileSystem`
 - ECR Repositories
-  - Resource type: `ecr`
-  - Config key: `ECRRepository`
+    - Resource type: `ecr`
+    - Config key: `ECRRepository`
 - RDS, Neptune, and Document DB Resources
-  - Resource type: `rds`
-  - Config key: `DBInstances`
+    - Resource type: `rds`
+    - Config key: `DBInstances`
 - Launch Templates
-  - Resource type: `lt`
-  - Config key: `LaunchTemplate`
-
+    - Resource type: `lt`
+    - Config key: `LaunchTemplate`
+- CloudWatch Alarms
+    - Resource type: `cloudwatch-alarm`
+    - Config key: `CloudWatchAlarm`
 
 
 
@@ -545,6 +548,7 @@ To find out what we options are supported in the config file today, consult this
 | lt                            | none  | ✅           | none | none       |
 | config-recorders              | none  | ✅           | none | none       |
 | config-rules                  | none  | ✅           | none | none       |
+| cloudwatch-alarm              | none  | ✅           | none | none       |
 | ... (more to come)            | none  | none         | none | none       |
 
 

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1156,6 +1156,25 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End Config service recorders
 
+		// CloudWatchAlarm
+		cloudwatchAlarms := CloudWatchAlarms{}
+		if IsNukeable(cloudwatchAlarms.ResourceName(), resourceTypes) {
+			cwalNames, err := getAllCloudWatchAlarms(cloudNukeSession, excludeAfter, configObj)
+			if err != nil {
+				ge := report.GeneralError{
+					Error:        err,
+					Description:  "Unable to retrieve CloudWatch alarms",
+					ResourceType: cloudwatchAlarms.ResourceName(),
+				}
+				report.RecordError(ge)
+			}
+			if len(cwalNames) > 0 {
+				cloudwatchAlarms.AlarmNames = awsgo.StringValueSlice(cwalNames)
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, cloudwatchAlarms)
+			}
+		}
+		// End CloudWatchAlarm
+
 		if len(resourcesInRegion.Resources) > 0 {
 			account.Resources[region] = resourcesInRegion
 		}
@@ -1344,6 +1363,7 @@ func ListResourceTypes() []string {
 		LaunchTemplates{}.ResourceName(),
 		ConfigServiceRule{}.ResourceName(),
 		ConfigServiceRecorders{}.ResourceName(),
+		CloudWatchAlarms{}.ResourceName(),
 	}
 	sort.Strings(resourceTypes)
 	return resourceTypes

--- a/aws/cloudwatch_alarm.go
+++ b/aws/cloudwatch_alarm.go
@@ -1,0 +1,141 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/go-commons/errors"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/gruntwork-io/cloud-nuke/config"
+)
+
+func getAllCloudWatchAlarms(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
+	svc := cloudwatch.New(session)
+
+	allAlarms := []*string{}
+	input := &cloudwatch.DescribeAlarmsInput{
+		AlarmTypes: aws.StringSlice([]string{cloudwatch.AlarmTypeMetricAlarm, cloudwatch.AlarmTypeCompositeAlarm}),
+	}
+	err := svc.DescribeAlarmsPages(
+		input,
+		func(page *cloudwatch.DescribeAlarmsOutput, lastPage bool) bool {
+			for _, alarm := range page.MetricAlarms {
+				if shouldIncludeCloudWatchMetricAlarm(alarm, excludeAfter, configObj) {
+					allAlarms = append(allAlarms, alarm.AlarmName)
+				}
+			}
+			for _, alarm := range page.CompositeAlarms {
+				if shouldIncludeCloudWatchCompositeAlarm(alarm, excludeAfter, configObj) {
+					allAlarms = append(allAlarms, alarm.AlarmName)
+				}
+			}
+			return !lastPage
+		},
+	)
+	return allAlarms, errors.WithStackTrace(err)
+}
+
+func shouldIncludeCloudWatchCompositeAlarm(alarm *cloudwatch.CompositeAlarm, excludeAfter time.Time, configObj config.Config) bool {
+	if alarm == nil {
+		return false
+	}
+
+	if alarm.AlarmConfigurationUpdatedTimestamp != nil && excludeAfter.Before(*alarm.AlarmConfigurationUpdatedTimestamp) {
+		return false
+	}
+
+	return config.ShouldInclude(
+		aws.StringValue(alarm.AlarmName),
+		configObj.CloudWatchAlarm.IncludeRule.NamesRegExp,
+		configObj.CloudWatchAlarm.ExcludeRule.NamesRegExp,
+	)
+}
+
+func shouldIncludeCloudWatchMetricAlarm(alarm *cloudwatch.MetricAlarm, excludeAfter time.Time, configObj config.Config) bool {
+	if alarm == nil {
+		return false
+	}
+
+	if alarm.AlarmConfigurationUpdatedTimestamp != nil && excludeAfter.Before(*alarm.AlarmConfigurationUpdatedTimestamp) {
+		return false
+	}
+
+	return config.ShouldInclude(
+		aws.StringValue(alarm.AlarmName),
+		configObj.CloudWatchAlarm.IncludeRule.NamesRegExp,
+		configObj.CloudWatchAlarm.ExcludeRule.NamesRegExp,
+	)
+}
+
+func nukeAllCloudWatchAlarms(session *session.Session, identifiers []*string) error {
+	region := aws.StringValue(session.Config.Region)
+
+	svc := cloudwatch.New(session)
+
+	if len(identifiers) == 0 {
+		logging.Logger.Debugf("No CloudWatch Alarms to nuke in region %s", region)
+		return nil
+	}
+
+	// NOTE: we don't need to do pagination here, because the pagination is handled by the caller to this function,
+	// based on CloudWatchAlarm.MaxBatchSize, however we add a guard here to warn users when the batching fails and has a
+	// chance of throttling AWS. Since we concurrently make one call for each identifier, we pick 100 for the limit here
+	// because many APIs in AWS have a limit of 100 requests per second.
+	if len(identifiers) > 100 {
+		logging.Logger.Errorf("Nuking too many CloudWatch Alarms at once (100): halting to avoid hitting AWS API rate limiting")
+		return TooManyCloudWatchAlarmsErr{}
+	}
+
+	logging.Logger.Debugf("Deleting CloudWatch Alarms in region %s", region)
+
+	// If the alarm's type is composite alarm, remove the dependency by removing the rule.
+	alarms, err := svc.DescribeAlarms(&cloudwatch.DescribeAlarmsInput{
+		AlarmTypes: aws.StringSlice([]string{cloudwatch.AlarmTypeMetricAlarm, cloudwatch.AlarmTypeCompositeAlarm}),
+		AlarmNames: identifiers,
+	})
+	if err != nil {
+		logging.Logger.Debugf("[Failed] %s", err)
+	}
+
+	for _, compositeAlarm := range alarms.CompositeAlarms {
+		_, err := svc.PutCompositeAlarm(&cloudwatch.PutCompositeAlarmInput{
+			AlarmName: compositeAlarm.AlarmName,
+			AlarmRule: aws.String("FALSE"),
+		})
+		if err != nil {
+			logging.Logger.Debugf("[Failed] %s", err)
+		}
+	}
+
+	input := cloudwatch.DeleteAlarmsInput{AlarmNames: identifiers}
+	_, err = svc.DeleteAlarms(&input)
+
+	// Record status of this resource
+	e := report.BatchEntry{
+		Identifiers:  aws.StringValueSlice(identifiers),
+		ResourceType: "CloudWatch Alarm",
+		Error:        err,
+	}
+	report.RecordBatch(e)
+
+	if err != nil {
+		logging.Logger.Debugf("[Failed] %s", err)
+		return errors.WithStackTrace(err)
+	}
+
+	for _, alarmName := range identifiers {
+		logging.Logger.Debugf("[OK] CloudWatch Alarm %s was deleted in %s", aws.StringValue(alarmName), region)
+	}
+	return nil
+}
+
+// Custom errors
+
+type TooManyCloudWatchAlarmsErr struct{}
+
+func (err TooManyCloudWatchAlarmsErr) Error() string {
+	return "Too many CloudWatch Alarms requested at once."
+}

--- a/aws/cloudwatch_alarm_test.go
+++ b/aws/cloudwatch_alarm_test.go
@@ -1,0 +1,174 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListCloudWatchAlarms(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+	svc := cloudwatch.New(session)
+
+	// cwal : CloudWatch ALarms (recommended by ChatGPT)
+	cwalName := createCloudWatchAlarm(t, svc, region)
+	defer deleteCloudWatchAlarm(t, svc, cwalName, true)
+
+	cwalNames, err := getAllCloudWatchAlarms(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.Contains(t, aws.StringValueSlice(cwalNames), aws.StringValue(cwalName))
+}
+
+func TestTimeFilterExclusionNewlyCreatedCloudWatchAlarm(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+	svc := cloudwatch.New(session)
+
+	cwalName := createCloudWatchAlarm(t, svc, region)
+	defer deleteCloudWatchAlarm(t, svc, cwalName, true)
+
+	// Assert CloudWatch Alarm is picked up without filters
+	cwalNamesNewer, err := getAllCloudWatchAlarms(session, time.Now(), config.Config{})
+	require.NoError(t, err)
+	assert.Contains(t, aws.StringValueSlice(cwalNamesNewer), aws.StringValue(cwalName))
+
+	// Assert user doesn't appear when we look at users older than 1 Hour
+	olderThan := time.Now().Add(-1 * time.Hour)
+	cwalNamesOlder, err := getAllCloudWatchAlarms(session, olderThan, config.Config{})
+	require.NoError(t, err)
+	assert.NotContains(t, aws.StringValueSlice(cwalNamesOlder), aws.StringValue(cwalName))
+}
+
+func TestNukeCloudWatchAlarmOne(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+	svc := cloudwatch.New(session)
+
+	// We ignore errors in the delete call here, because it is intended to be a stop gap in case there is a bug in nuke.
+	cwalName := createCloudWatchAlarm(t, svc, region)
+	defer deleteCloudWatchAlarm(t, svc, cwalName, false)
+	identifiers := []*string{cwalName}
+
+	require.NoError(
+		t,
+		nukeAllCloudWatchAlarms(session, identifiers),
+	)
+
+	// Make sure the CloudWatch Alar m is deleted.
+	assertCloudWatchAlarmsDeleted(t, svc, identifiers)
+}
+
+func TestNukeCloudWatchAlarmsMoreThanOne(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+	svc := cloudwatch.New(session)
+
+	cwalNames := []*string{}
+	for i := 0; i < 3; i++ {
+		// We ignore errors in the delete call here, because it is intended to be a stop gap in case there is a bug in nuke.
+		cwalName := createCloudWatchAlarm(t, svc, region)
+		defer deleteCloudWatchAlarm(t, svc, cwalName, false)
+		cwalNames = append(cwalNames, cwalName)
+	}
+
+	require.NoError(
+		t,
+		nukeAllCloudWatchAlarms(session, cwalNames),
+	)
+
+	// Make sure the CloudWatch Alarm is deleted.
+	assertCloudWatchAlarmsDeleted(t, svc, cwalNames)
+}
+
+// Helper functions for driving the CloudWatch Alarm tests
+
+// createCloudWatchAlarm will create a new CloudWatch Alarm with a simple metric.
+func createCloudWatchAlarm(t *testing.T, svc *cloudwatch.CloudWatch, region string) *string {
+	uniqueID := util.UniqueID()
+	name := fmt.Sprintf("cloud-nuke-testing-%s", strings.ToLower(uniqueID))
+	metric := []*cloudwatch.MetricDataQuery{}
+	metric = append(metric, &cloudwatch.MetricDataQuery{})
+
+	_, err := svc.PutMetricAlarm(&cloudwatch.PutMetricAlarmInput{
+		ActionsEnabled:     aws.Bool(true),
+		AlarmActions:       aws.StringSlice([]string{}),
+		AlarmDescription:   aws.String(`Test alarm for cloud-nuke.`),
+		AlarmName:          aws.String(name),
+		ComparisonOperator: aws.String(`GreaterThanThreshold`),
+		DatapointsToAlarm:  aws.Int64(1),
+		Dimensions: []*cloudwatch.Dimension{
+			{Name: aws.String(`InstanceId`), Value: aws.String(`i-0123456789abcdefg`)},
+		},
+		EvaluationPeriods:       aws.Int64(60),
+		InsufficientDataActions: aws.StringSlice([]string{}),
+		MetricName:              aws.String(`CPUUtilization`),
+		Namespace:               aws.String(`AWS/EC2`),
+		OKActions:               aws.StringSlice([]string{}),
+		Period:                  aws.Int64(60),
+		Statistic:               aws.String(cloudwatch.StatisticAverage),
+		Threshold:               aws.Float64(0.0),
+		TreatMissingData:        aws.String(`missing`),
+	})
+	require.NoError(t, err)
+
+	// Verify that the alarm is generated well
+	resp, err := svc.DescribeAlarms(&cloudwatch.DescribeAlarmsInput{
+		AlarmNames: []*string{&name},
+	})
+	require.NoError(t, err)
+	if len(resp.MetricAlarms) <= 0 {
+		t.Fatalf("Error creating Alarm %s", name)
+	}
+	// Add an arbitrary sleep to account for eventual consistency
+	time.Sleep(15 * time.Second)
+	return &name
+}
+
+// deleteCloudWatchAlarm is a function to delete the given CloudWatch Alarm.
+func deleteCloudWatchAlarm(t *testing.T, svc *cloudwatch.CloudWatch, name *string, checkErr bool) {
+	input := &cloudwatch.DeleteAlarmsInput{AlarmNames: []*string{name}}
+	_, err := svc.DeleteAlarms(input)
+	if checkErr {
+		require.NoError(t, err)
+	}
+}
+
+func assertCloudWatchAlarmsDeleted(t *testing.T, svc *cloudwatch.CloudWatch, identifiers []*string) {
+	for _, name := range identifiers {
+		resp, err := svc.DescribeAlarms(&cloudwatch.DescribeAlarmsInput{AlarmNames: []*string{name}})
+		require.NoError(t, err)
+		if len(resp.MetricAlarms) > 0 {
+			t.Fatalf("Alarm %s is not deleted", aws.StringValue(name))
+		}
+	}
+}

--- a/aws/cloudwatch_alarm_types.go
+++ b/aws/cloudwatch_alarm_types.go
@@ -1,0 +1,35 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+// CloudWatchAlarms - represents all CloudWatchAlarms that should be deleted.
+type CloudWatchAlarms struct {
+	AlarmNames []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (cwal CloudWatchAlarms) ResourceName() string {
+	return "cloudwatch-alarm"
+}
+
+// ResourceIdentifiers - The name of cloudwatch alarms
+func (cwal CloudWatchAlarms) ResourceIdentifiers() []string {
+	return cwal.AlarmNames
+}
+
+func (cwal CloudWatchAlarms) MaxBatchSize() int {
+	return 99
+}
+
+// Nuke - nuke 'em all!!!
+func (cwal CloudWatchAlarms) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllCloudWatchAlarms(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/aws/cloudwatch_dashboard_types.go
+++ b/aws/cloudwatch_dashboard_types.go
@@ -16,7 +16,7 @@ func (cwdb CloudWatchDashboards) ResourceName() string {
 	return "cloudwatch-dashboard"
 }
 
-// ResourceIdentifiers - The instance ids of the ec2 instances
+// ResourceIdentifiers - The dashboard names of the cloudwatch dashboards
 func (cwdb CloudWatchDashboards) ResourceIdentifiers() []string {
 	return cwdb.DashboardNames
 }

--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	LaunchTemplate        ResourceType `yaml:"LaunchTemplate"`
 	ConfigServiceRule     ResourceType `yaml:"ConfigServiceRule"`
 	ConfigServiceRecorder ResourceType `yaml:"ConfigServiceRecorder"`
+	CloudWatchAlarm       ResourceType `yaml:"CloudWatchAlarm"`
 }
 
 type ResourceType struct {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #429 .

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Add CloudWatch Alarm support (include MetricAlarm and CompositeAlarm).

