### PR TITLE
CORE-641 - Add telemetry to main nuke flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             # Run the tests. Note that we set the "-p 1" flag to tell Go to run tests in each package sequentially. Without
             # this, Go buffers all log output until all packages are done, which with slower running tests can cause CircleCI
             # to kill the build after more than 45 minutes without log output.
-            run-go-tests --extra-flags '-p 1' --timeout 45m | tee /tmp/logs/all.log
+            DISABLE_TELEMETRY=true run-go-tests --extra-flags '-p 1' --timeout 45m | tee /tmp/logs/all.log
           no_output_timeout: 45m
       - run:
           name: parse test output
@@ -29,7 +29,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: build-go-binaries --parallel 2 --app-name cloud-nuke --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG"
+      - run: build-go-binaries --parallel 2 --app-name cloud-nuke --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG -X 'main.MixPanelClientId=$MIXPANEL_CLIENT_ID'"
       - persist_to_workspace:
           root: .
           paths: bin
@@ -41,7 +41,7 @@ jobs:
           command: |
             # We explicitly list the resource types we want to nuke, as we are not ready to nuke some resource types in
             # the AWS account we use at Gruntwork for testing (Phx DevOps) (e.g., S3)
-            go run main.go aws \
+            go run  -ldflags="-X 'main.VERSION=$CIRCLE_SHA1' -X 'main.MixPanelClientId=$MIXPANEL_CLIENT_ID'" main.go aws \
               --older-than 2h \
               --force \
               --config ./.circleci/nuke_config.yml \
@@ -62,7 +62,7 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=$SANDBOX_AWS_SECRET_ACCESS_KEY
             # We explicitly list the resource types we want to nuke, as we are not ready to nuke some resource types in
             # the AWS account we use at Gruntwork for testing (Sandbox) (e.g., S3)
-            go run main.go aws \
+            go run -ldflags="-X 'main.VERSION=$CIRCLE_SHA1' -X 'main.MixPanelClientId=$MIXPANEL_CLIENT_ID'" main.go aws \
               --older-than 24h \
               --force \
               --config ./.circleci/nuke_config.yml \
@@ -104,6 +104,7 @@ workflows:
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
+            - MIXPANEL__TOKEN__gruntwork
       - deploy:
           requires:
             - build
@@ -115,6 +116,7 @@ workflows:
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
+            - MIXPANEL__TOKEN__gruntwork
   nuke_phxdevops:
     when:
       and:
@@ -125,6 +127,7 @@ workflows:
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
+            - MIXPANEL__TOKEN__gruntwork
   nuke_sandbox:
     when:
       and:
@@ -136,3 +139,4 @@ workflows:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
             - AWS__SANDBOX__circle-ci
+            - MIXPANEL__TOKEN__gruntwork

--- a/README.md
+++ b/README.md
@@ -610,6 +610,29 @@ Happy Nuking!!!
 
 In order for the `cloud-nuke` CLI tool to access your AWS, you will need to provide your AWS credentials. You can use one of the [standard AWS CLI credential mechanisms](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html).
 
+## Telemetry
+
+As of version `v0.29.0` cloud-nuke sends telemetry back to Gruntwork to help us better prioritize bug fixes and feature 
+improvements. The following metrics are included:
+
+- Command and Arguments
+- Version Number
+- Timestamps
+- Resource Types
+- Resource Counts
+- A randomly generated Run ID
+- AWS Account ID
+
+We never collect
+
+- IP Addresses
+- Resource Names
+
+Telemetry can be disabled entirely by setting the `DISABLE_TELEMETRY` environment variable on the command line.
+
+As an open source tool, you can see the exact statistics being collected by searching the code for 
+`telemetry.TrackEvent(...)`
+
 ## Running Tests
 
 ```shell

--- a/aws/access_analyzer.go
+++ b/aws/access_analyzer.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -81,6 +83,11 @@ func nukeAllAccessAnalyzers(session *session.Session, names []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking Access Analyzer",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/acmpca.go
+++ b/aws/acmpca.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"fmt"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -87,6 +89,11 @@ func nukeAllACMPCA(session *session.Session, arns []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Errorf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking ACMPCA",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 	return errors.WithStackTrace(allErrs.ErrorOrNil())

--- a/aws/ami.go
+++ b/aws/ami.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -70,6 +72,11 @@ func nukeAllAMIs(session *session.Session, imageIds []*string) error {
 
 		if err != nil {
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking AMI",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedCount++
 			logging.Logger.Debugf("Deleted AMI: %s", *imageID)

--- a/aws/apigateway.go
+++ b/aws/apigateway.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -79,6 +81,11 @@ func nukeAllAPIGateways(session *session.Session, identifiers []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking API Gateway",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/apigatewayv2.go
+++ b/aws/apigatewayv2.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -79,6 +81,11 @@ func nukeAllAPIGatewaysV2(session *session.Session, identifiers []*string) error
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking API Gateway V2",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/asg.go
+++ b/aws/asg.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
@@ -76,6 +78,11 @@ func nukeAllAutoScalingGroups(session *session.Session, groupNames []*string) er
 
 		if err != nil {
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking ASG",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedGroupNames = append(deletedGroupNames, groupName)
 			logging.Logger.Debugf("Deleted Auto Scaling Group: %s", *groupName)
@@ -88,6 +95,11 @@ func nukeAllAutoScalingGroups(session *session.Session, groupNames []*string) er
 		})
 		if err != nil {
 			logging.Logger.Errorf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking ASG",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 			return errors.WithStackTrace(err)
 		}
 	}

--- a/aws/cloudtrail.go
+++ b/aws/cloudtrail.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -76,6 +78,11 @@ func nukeAllCloudTrailTrails(session *session.Session, arns []*string) error {
 
 		if err != nil {
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking Cloudtrail",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedArns = append(deletedArns, arn)
 			logging.Logger.Debugf("Deleted Cloudtrail Trail: %s", aws.StringValue(arn))

--- a/aws/cloudwatch_alarm.go
+++ b/aws/cloudwatch_alarm.go
@@ -4,7 +4,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -98,6 +100,11 @@ func nukeAllCloudWatchAlarms(session *session.Session, identifiers []*string) er
 	})
 	if err != nil {
 		logging.Logger.Debugf("[Failed] %s", err)
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Error Nuking Cloudwatch Alarm Dependency",
+		}, map[string]interface{}{
+			"region": *session.Config.Region,
+		})
 	}
 
 	for _, compositeAlarm := range alarms.CompositeAlarms {
@@ -107,6 +114,11 @@ func nukeAllCloudWatchAlarms(session *session.Session, identifiers []*string) er
 		})
 		if err != nil {
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking Cloudwatch Composite Alarm",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 
@@ -123,6 +135,11 @@ func nukeAllCloudWatchAlarms(session *session.Session, identifiers []*string) er
 
 	if err != nil {
 		logging.Logger.Debugf("[Failed] %s", err)
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Error Nuking Cloudwatch Alarm",
+		}, map[string]interface{}{
+			"region": *session.Config.Region,
+		})
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/cloudwatch_dashboard.go
+++ b/aws/cloudwatch_dashboard.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -81,6 +83,11 @@ func nukeAllCloudWatchDashboards(session *session.Session, identifiers []*string
 
 	if err != nil {
 		logging.Logger.Debugf("[Failed] %s", err)
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Error Nuking Cloudwatch Dashboard",
+		}, map[string]interface{}{
+			"region": *session.Config.Region,
+		})
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/cloudwatch_loggroup.go
+++ b/aws/cloudwatch_loggroup.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -94,6 +96,11 @@ func nukeAllCloudWatchLogGroups(session *session.Session, identifiers []*string)
 		if err := <-errChan; err != nil {
 			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() != "OperationAbortedException" {
 				allErrs = multierror.Append(allErrs, err)
+				telemetry.TrackEvent(commonTelemetry.EventContext{
+					EventName: "Error Nuking Cloudwatch Log Group",
+				}, map[string]interface{}{
+					"region": *session.Config.Region,
+				})
 			}
 		}
 	}

--- a/aws/config_recorder.go
+++ b/aws/config_recorder.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -72,6 +74,11 @@ func nukeAllConfigRecorders(session *session.Session, configRecorderNames []stri
 
 		if err != nil {
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking Config Recorder",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedNames = append(deletedNames, aws.String(configRecorderName))
 			logging.Logger.Debugf("Deleted Config Recorder: %s", configRecorderName)

--- a/aws/config_service.go
+++ b/aws/config_service.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -74,6 +76,11 @@ func nukeAllConfigServiceRules(session *session.Session, configRuleNames []strin
 
 		if err != nil {
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking Config Service Rule",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedConfigRuleNames = append(deletedConfigRuleNames, aws.String(configRuleName))
 			logging.Logger.Debugf("Deleted Config service rule: %s", configRuleName)

--- a/aws/dynamodb.go
+++ b/aws/dynamodb.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"log"
 	"time"
 
@@ -102,6 +104,11 @@ func nukeAllDynamoDBTables(session *session.Session, tables []*string) error {
 
 		if err != nil {
 			if aerr, ok := err.(awserr.Error); ok {
+				telemetry.TrackEvent(commonTelemetry.EventContext{
+					EventName: "Error Nuking DynamoDB Table",
+				}, map[string]interface{}{
+					"region": *session.Config.Region,
+				})
 				switch aerr.Error() {
 				case dynamodb.ErrCodeInternalServerError:
 					return errors.WithStackTrace(aerr)

--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"fmt"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -112,6 +114,11 @@ func nukeAllEc2Instances(session *session.Session, instanceIds []*string) error 
 	_, err := svc.TerminateInstances(params)
 	if err != nil {
 		logging.Logger.Debugf("[Failed] %s", err)
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Error Nuking EC2 Instance",
+		}, map[string]interface{}{
+			"region": *session.Config.Region,
+		})
 		return errors.WithStackTrace(err)
 	}
 
@@ -130,6 +137,11 @@ func nukeAllEc2Instances(session *session.Session, instanceIds []*string) error 
 
 	if err != nil {
 		logging.Logger.Debugf("[Failed] %s", err)
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Error Nuking EC2 Instance",
+		}, map[string]interface{}{
+			"region": *session.Config.Region,
+		})
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/ec2_dedicated_host.go
+++ b/aws/ec2_dedicated_host.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"fmt"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -92,6 +94,11 @@ func nukeAllEc2DedicatedHosts(session *session.Session, hostIds []*string) error
 
 	if err != nil {
 		logging.Logger.Debugf("[Failed] %s", err)
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Error Nuking EC2 Dedicated Hosts",
+		}, map[string]interface{}{
+			"region": *session.Config.Region,
+		})
 		return errors.WithStackTrace(err)
 	}
 
@@ -106,6 +113,11 @@ func nukeAllEc2DedicatedHosts(session *session.Session, hostIds []*string) error
 	}
 
 	for _, hostFailed := range releaseResult.Unsuccessful {
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Error Nuking EC2 Dedicated Host",
+		}, map[string]interface{}{
+			"region": *session.Config.Region,
+		})
 		logging.Logger.Debugf("[ERROR] Unable to release dedicated host %s in %s: %s", aws.StringValue(hostFailed.ResourceId), *session.Config.Region, aws.StringValue(hostFailed.Error.Message))
 		e := report.Entry{
 			Identifier:   aws.StringValue(hostFailed.ResourceId),

--- a/aws/ec2_key_pair.go
+++ b/aws/ec2_key_pair.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -75,6 +77,11 @@ func nukeAllEc2KeyPairs(session *session.Session, keypairIds []*string) error {
 	var multiErr *multierror.Error
 	for _, keypair := range keypairIds {
 		if err := deleteKeyPair(svc, keypair); err != nil {
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking EC2 Key Pair",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 			logging.Logger.Errorf("[Failed] %s", err)
 			multiErr = multierror.Append(multiErr, err)
 		} else {

--- a/aws/ec2_vpc.go
+++ b/aws/ec2_vpc.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"fmt"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
@@ -152,6 +154,11 @@ func nukeAllVPCs(session *session.Session, vpcIds []string, vpcs []Vpc) error {
 		if err != nil {
 
 			logging.Logger.Errorf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking VPC",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 			multierror.Append(multiErr, err)
 		} else {
 			deletedVPCs++

--- a/aws/ecr.go
+++ b/aws/ecr.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -81,6 +83,11 @@ func nukeAllECRRepositories(session *session.Session, repositoryNames []string) 
 		report.Record(e)
 
 		if err != nil {
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking ECR Repo",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 			logging.Logger.Debugf("[Failed] %s", err)
 		} else {
 

--- a/aws/ecs_cluster.go
+++ b/aws/ecs_cluster.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -133,6 +135,11 @@ func nukeEcsClusters(awsSession *session.Session, ecsClusterArns []*string) erro
 
 		if err != nil {
 			logging.Logger.Debugf("Error, failed to delete cluster with ARN %s", aws.StringValue(clusterArn))
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking ECS Cluster",
+			}, map[string]interface{}{
+				"region": *awsSession.Config.Region,
+			})
 			return errors.WithStackTrace(err)
 		}
 

--- a/aws/efs.go
+++ b/aws/efs.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"context"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -90,6 +92,11 @@ func nukeAllElasticFileSystems(session *session.Session, identifiers []*string) 
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking EFS",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/eip.go
+++ b/aws/eip.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -131,8 +133,19 @@ func nukeAllEIPAddresses(session *session.Session, allocationIds []*string) erro
 			if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == "AuthFailure" {
 				// TODO: Figure out why we get an AuthFailure
 				logging.Logger.Debugf("EIP %s can't be deleted, it is still attached to an active resource", *allocationID)
+				telemetry.TrackEvent(commonTelemetry.EventContext{
+					EventName: "Error Nuking EIP",
+				}, map[string]interface{}{
+					"region": *session.Config.Region,
+					"reason": "Still Attached to an Active Resource",
+				})
 			} else {
 				logging.Logger.Debugf("[Failed] %s", err)
+				telemetry.TrackEvent(commonTelemetry.EventContext{
+					EventName: "Error Nuking EIP",
+				}, map[string]interface{}{
+					"region": *session.Config.Region,
+				})
 			}
 		} else {
 			deletedAllocationIDs = append(deletedAllocationIDs, allocationID)

--- a/aws/eks.go
+++ b/aws/eks.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -252,6 +254,11 @@ func nukeAllEksClusters(awsSession *session.Session, eksClusterNames []*string) 
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking EKS Cluster",
+			}, map[string]interface{}{
+				"region": *awsSession.Config.Region,
+			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/elasticache.go
+++ b/aws/elasticache.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"fmt"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -211,6 +213,11 @@ func nukeAllElasticacheClusters(session *session.Session, clusterIds []*string) 
 
 		if err != nil {
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking Elasticache Cluster",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedClusterIds = append(deletedClusterIds, clusterId)
 			logging.Logger.Debugf("Deleted Elasticache cluster: %s", *clusterId)

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -77,6 +79,11 @@ func nukeAllElbInstances(session *session.Session, names []*string) error {
 
 		if err != nil {
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking Load Balancer (v1)",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedNames = append(deletedNames, name)
 			logging.Logger.Debugf("Deleted ELB: %s", *name)

--- a/aws/elbv2.go
+++ b/aws/elbv2.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -76,6 +78,11 @@ func nukeAllElbv2Instances(session *session.Session, arns []*string) error {
 
 		if err != nil {
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking Load Balancer V2",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedArns = append(deletedArns, arn)
 			logging.Logger.Debugf("Deleted ELBv2: %s", *arn)

--- a/aws/guardduty.go
+++ b/aws/guardduty.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -121,6 +123,11 @@ func nukeAllGuardDutyDetectors(session *session.Session, detectorIds []string) e
 
 		if err != nil {
 			logging.Logger.Debugf("[Failed] %s: %s", detectorId, err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking GuardDuty Detector",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedIds = append(deletedIds, detectorId)
 			logging.Logger.Debugf("Deleted GuardDuty detector: %s", detectorId)

--- a/aws/iam.go
+++ b/aws/iam.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"fmt"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -363,6 +365,11 @@ func nukeAllIamUsers(session *session.Session, userNames []*string) error {
 		if err != nil {
 			logging.Logger.Errorf("[Failed] %s", err)
 			multierror.Append(multiErr, err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking IAM User",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedUsers++
 			logging.Logger.Debugf("Deleted IAM User: %s", *userName)

--- a/aws/iam_group.go
+++ b/aws/iam_group.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -67,6 +69,11 @@ func nukeAllIamGroups(session *session.Session, groupNames []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Errorf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking IAM Group",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/iam_policy.go
+++ b/aws/iam_policy.go
@@ -7,7 +7,9 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"github.com/hashicorp/go-multierror"
 	"sync"
 	"time"
@@ -69,6 +71,11 @@ func nukeAllIamPolicies(session *session.Session, policyArns []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Errorf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking IAM Policy",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/iam_role.go
+++ b/aws/iam_role.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"strings"
 	"sync"
 	"time"
@@ -164,6 +166,11 @@ func nukeAllIamRoles(session *session.Session, roleNames []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking IAM Role",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/iam_service_linked_role.go
+++ b/aws/iam_service_linked_role.go
@@ -3,6 +3,8 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"strings"
 	"sync"
 	"time"
@@ -118,6 +120,11 @@ func nukeAllIamServiceLinkedRoles(session *session.Session, roleNames []*string)
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking IAM Service Linked Role",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/kinesis_stream.go
+++ b/aws/kinesis_stream.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -83,6 +85,11 @@ func nukeAllKinesisStreams(session *session.Session, identifiers []*string) erro
 	for _, errChan := range errChans {
 		if err := <-errChan; err != nil {
 			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() != "OperationAbortedException" {
+				telemetry.TrackEvent(commonTelemetry.EventContext{
+					EventName: "Error Nuking Kinesis Stream",
+				}, map[string]interface{}{
+					"region": *session.Config.Region,
+				})
 				allErrs = multierror.Append(allErrs, err)
 			}
 		}

--- a/aws/kms_customer_key.go
+++ b/aws/kms_customer_key.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -176,6 +178,11 @@ func nukeAllCustomerManagedKmsKeys(session *session.Session, keyIds []*string, k
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking KMS Key",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 	return errors.WithStackTrace(allErrs.ErrorOrNil())

--- a/aws/lambda.go
+++ b/aws/lambda.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -99,6 +101,11 @@ func nukeAllLambdaFunctions(session *session.Session, names []*string) error {
 
 		if err != nil {
 			logging.Logger.Errorf("[Failed] %s: %s", *name, err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking Lambda Function",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedNames = append(deletedNames, name)
 			logging.Logger.Debugf("Deleted Lambda Function: %s", awsgo.StringValue(name))

--- a/aws/launch_config.go
+++ b/aws/launch_config.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -76,6 +78,11 @@ func nukeAllLaunchConfigurations(session *session.Session, configNames []*string
 
 		if err != nil {
 			logging.Logger.Errorf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking Launch Configuration",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedConfigNames = append(deletedConfigNames, configName)
 			logging.Logger.Debugf("Deleted Launch configuration: %s", *configName)

--- a/aws/launch_template.go
+++ b/aws/launch_template.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -76,6 +78,11 @@ func nukeAllLaunchTemplates(session *session.Session, templateNames []*string) e
 
 		if err != nil {
 			logging.Logger.Errorf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking Launch Template",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedTemplateNames = append(deletedTemplateNames, templateName)
 			logging.Logger.Debugf("Deleted Launch template: %s", *templateName)

--- a/aws/macie.go
+++ b/aws/macie.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	goerror "errors"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -73,6 +75,11 @@ func nukeAllMacieMemberAccounts(session *session.Session, identifiers []string) 
 		_, disassociateErr := svc.DisassociateFromAdministratorAccount(&macie2.DisassociateFromAdministratorAccountInput{})
 
 		if disassociateErr != nil {
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking MACIE",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 			return errors.WithStackTrace(disassociateErr)
 		}
 
@@ -87,6 +94,11 @@ func nukeAllMacieMemberAccounts(session *session.Session, identifiers []string) 
 		report.Record(e)
 
 		if err != nil {
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking MACIE",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 			return errors.WithStackTrace(err)
 		}
 

--- a/aws/nat_gateway.go
+++ b/aws/nat_gateway.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"fmt"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -108,6 +110,11 @@ func nukeAllNatGateways(session *session.Session, identifiers []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking NAT Gateway",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/oidc_provider.go
+++ b/aws/oidc_provider.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -173,6 +175,11 @@ func nukeAllOIDCProviders(session *session.Session, identifiers []*string) error
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking OIDC Provider",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/opensearch.go
+++ b/aws/opensearch.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"fmt"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -183,6 +185,11 @@ func nukeAllOpenSearchDomains(session *session.Session, identifiers []*string) e
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Errorf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking Opensearch",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/rds.go
+++ b/aws/rds.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -68,6 +70,11 @@ func nukeAllRdsInstances(session *session.Session, names []*string) error {
 		_, err := svc.DeleteDBInstance(params)
 
 		if err != nil {
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking RDS Instance",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 			logging.Logger.Errorf("[Failed] %s: %s", *name, err)
 		} else {
 			deletedNames = append(deletedNames, name)
@@ -91,6 +98,11 @@ func nukeAllRdsInstances(session *session.Session, names []*string) error {
 			report.Record(e)
 
 			if err != nil {
+				telemetry.TrackEvent(commonTelemetry.EventContext{
+					EventName: "Error Nuking RDS Instance",
+				}, map[string]interface{}{
+					"region": *session.Config.Region,
+				})
 				logging.Logger.Errorf("[Failed] %s", err)
 				return errors.WithStackTrace(err)
 			}

--- a/aws/rds_cluster.go
+++ b/aws/rds_cluster.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -80,6 +82,11 @@ func nukeAllRdsClusters(session *session.Session, names []*string) error {
 
 		if err != nil {
 			logging.Logger.Debugf("[Failed] %s: %s", *name, err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking RDS Cluster",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedNames = append(deletedNames, name)
 			logging.Logger.Debugf("Deleted RDS DB Cluster: %s", awsgo.StringValue(name))

--- a/aws/s3.go
+++ b/aws/s3.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"fmt"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"math"
 	"strings"
 	"sync"
@@ -500,6 +502,11 @@ func nukeAllS3Buckets(awsSession *session.Session, bucketNames []*string, object
 		err = nukeAllS3BucketObjects(svc, bucketName, objectBatchSize)
 		if err != nil {
 			logging.Logger.Debugf("[Failed] - %d/%d - Bucket: %s - object deletion error - %s", bucketIndex+1, totalCount, *bucketName, err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking S3 Bucket Objects",
+			}, map[string]interface{}{
+				"region": *awsSession.Config.Region,
+			})
 			multierror.Append(multiErr, err)
 			continue
 		}
@@ -507,6 +514,11 @@ func nukeAllS3Buckets(awsSession *session.Session, bucketNames []*string, object
 		err = nukeS3BucketPolicy(svc, bucketName)
 		if err != nil {
 			logging.Logger.Debugf("[Failed] - %d/%d - Bucket: %s - bucket policy cleanup error - %s", bucketIndex+1, totalCount, *bucketName, err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking S3 Bucket Polikcy",
+			}, map[string]interface{}{
+				"region": *awsSession.Config.Region,
+			})
 			multierror.Append(multiErr, err)
 			continue
 		}
@@ -514,6 +526,11 @@ func nukeAllS3Buckets(awsSession *session.Session, bucketNames []*string, object
 		err = nukeEmptyS3Bucket(svc, bucketName, verifyBucketDeletion)
 		if err != nil {
 			logging.Logger.Debugf("[Failed] - %d/%d - Bucket: %s - bucket deletion error - %s", bucketIndex+1, totalCount, *bucketName, err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking S3 Bucket",
+			}, map[string]interface{}{
+				"region": *awsSession.Config.Region,
+			})
 			multierror.Append(multiErr, err)
 			continue
 		}

--- a/aws/secrets_manager.go
+++ b/aws/secrets_manager.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -85,6 +87,11 @@ func nukeAllSecretsManagerSecrets(session *session.Session, identifiers []*strin
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Errorf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking Secrets Manager Secret",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 	return errors.WithStackTrace(allErrs.ErrorOrNil())

--- a/aws/snapshot.go
+++ b/aws/snapshot.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -64,6 +66,11 @@ func nukeAllSnapshots(session *session.Session, snapshotIds []*string) error {
 
 		if err != nil {
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking EBS Snapshot",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedSnapshotIDs = append(deletedSnapshotIDs, snapshotID)
 			logging.Logger.Debugf("Deleted Snapshot: %s", *snapshotID)

--- a/aws/sns.go
+++ b/aws/sns.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"context"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -73,6 +75,11 @@ func nukeAllSNSTopics(session *session.Session, identifiers []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Logger.Errorf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking SNS Topic",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/sqs.go
+++ b/aws/sqs.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"strconv"
 	"time"
 
@@ -88,6 +90,11 @@ func nukeAllSqsQueues(session *session.Session, urls []*string) error {
 
 		if err != nil {
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking SQS Queue",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedUrls = append(deletedUrls, url)
 			logging.Logger.Debugf("Deleted SQS Queue: %s", *url)

--- a/aws/transit_gateway.go
+++ b/aws/transit_gateway.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -65,6 +67,11 @@ func nukeAllTransitGatewayInstances(session *session.Session, ids []*string) err
 
 		if err != nil {
 			logging.Logger.Debugf("[Failed] %s", err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking Transit Gateway Instance",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
 		} else {
 			deletedIds = append(deletedIds, id)
 			logging.Logger.Debugf("Deleted Transit Gateway: %s", *id)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sns v1.17.13
 	github.com/charmbracelet/lipgloss v0.6.0
 	github.com/golang/mock v1.6.0
-	github.com/gruntwork-io/go-commons v0.15.0
+	github.com/gruntwork-io/go-commons v0.16.1
 	github.com/gruntwork-io/gruntwork-cli v0.7.0
 	github.com/gruntwork-io/terratest v0.41.0
 	github.com/hashicorp/go-multierror v1.1.1
@@ -67,4 +67,5 @@ require (
 	golang.org/x/term v0.1.0 // indirect
 	golang.org/x/text v0.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	vizzlo.com/mixpanel v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/gookit/color v1.5.0 h1:1Opow3+BWDwqor78DcJkJCIwnkviFi+rrOANki9BUFw=
 github.com/gookit/color v1.5.0/go.mod h1:43aQb+Zerm/BWh2GnrgOQm7ffz7tvQXEKV6BFMl7wAo=
 github.com/gruntwork-io/go-commons v0.15.0 h1:fB7T4wO/JWQEGBnpVg4PfrNYnNtqRSUHJgf2pTaVe/0=
 github.com/gruntwork-io/go-commons v0.15.0/go.mod h1:AlYVzB6p6d8IYakGPNq/pspRjI7da7FeAIffISO9878=
+github.com/gruntwork-io/go-commons v0.16.1 h1:EhrTKRg5XK/wDL/s99zisjL9+zhTaEcepEkJeyvj3s8=
+github.com/gruntwork-io/go-commons v0.16.1/go.mod h1:/nnLMhO4HpItt43K+8ACM66g67iMy3oo2nnwq59n3wg=
 github.com/gruntwork-io/gruntwork-cli v0.7.0 h1:YgSAmfCj9c61H+zuvHwKfYUwlMhu5arnQQLM4RH+CYs=
 github.com/gruntwork-io/gruntwork-cli v0.7.0/go.mod h1:jp6Z7NcLF2avpY8v71fBx6hds9eOFPELSuD/VPv7w00=
 github.com/gruntwork-io/terratest v0.41.0 h1:QKFK6m0EMVnrV7lw2L06TlG+Ha3t0CcOXuBVywpeNRU=
@@ -242,3 +244,5 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+vizzlo.com/mixpanel v1.2.0 h1:ip0yFM9mIgAKDB0yIkUB2y+C2n+6MXaQ0KQk3DyISjE=
+vizzlo.com/mixpanel v1.2.0/go.mod h1:bmKnyCOO+/6SRhjujPG6ARtNJdTRepmA/TH+Nt/1GyU=

--- a/main.go
+++ b/main.go
@@ -7,8 +7,9 @@ import (
 
 // VERSION - Set at build time
 var VERSION string
+var MixPanelClientId string
 
 func main() {
-	app := commands.CreateCli(VERSION)
+	app := commands.CreateCli(VERSION, MixPanelClientId)
 	entrypoint.RunApp(app)
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -1,0 +1,37 @@
+package telemetry
+
+import (
+	"github.com/gruntwork-io/go-commons/telemetry"
+	"os"
+	"strings"
+)
+
+var sendTelemetry = true
+var telemetryClient telemetry.MixpanelTelemetryTracker
+var cmd = ""
+var isCircleCi = false
+var account = ""
+
+func InitTelemetry(name string, version string, clientId string) {
+	_, disableTelemetryFlag := os.LookupEnv("DISABLE_TELEMETRY")
+	isCircleCi = os.Getenv("CIRCLECI") == "true"
+	clientIdExists := clientId != ""
+	sendTelemetry = !disableTelemetryFlag && clientIdExists
+	if sendTelemetry {
+		cmd = strings.Join(os.Args[1:], " ")
+		telemetryClient = telemetry.NewMixPanelTelemetryClient(clientId, name, version)
+	}
+}
+
+func SetAccountId(accountId string) {
+	account = accountId
+}
+
+func TrackEvent(ctx telemetry.EventContext, extraProperties map[string]interface{}) {
+	if sendTelemetry {
+		ctx.Command = cmd
+		extraProperties["isCircleCi"] = isCircleCi
+		extraProperties["accountId"] = account
+		telemetryClient.TrackEvent(ctx, extraProperties)
+	}
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds telemetry to main cloud nuke flows

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added telemetry throughout for tracking usage and errors.

### Migration Guide

This release adds telemetry and sends metrics back to gruntwork.  No Identifying information is recorded. The following metrics are included:

- Command and Arguments
- Version Number
- Timestamps
- Resource Types
- Resource Counts
- A randomly generated Run ID
- AWS Account ID

We never collect

- IP Addresses
- Resource Names

Telemetry can be disabled entirely by setting the `DISABLE_TELEMETRY` environment variable on the command line.

