### PR TITLE
Fix secrets manager can nuke secret replica.

### DIFF
--- a/aws/secrets_manager_test.go
+++ b/aws/secrets_manager_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	terraws "github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/random"
@@ -126,6 +127,30 @@ func TestNukeSecretMoreThanOne(t *testing.T) {
 	}
 }
 
+func TestNukeSecretReplica(t *testing.T) {
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	secretName := fmt.Sprintf("test-cloud-nuke-secretsmanager-one-%s", random.UniqueId())
+	// We use the E version and ignore the error, as this is meant to be a stop gap deletion in case nuke has a bug.
+	defer terraws.DeleteSecretE(t, region, secretName, true)
+	arn := createSecretStringReplicaWithDefaultKey(t, region, secretName)
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	require.NoError(
+		t,
+		nukeAllSecretsManagerSecrets(session, aws.StringSlice([]string{arn})),
+	)
+
+	// Make sure the secret is deleted.
+	_, err = terraws.GetSecretValueE(t, region, arn)
+	assert.Error(t, err)
+}
+
 // Helper functions for driving the secrets manager tests
 
 // createSecretStringWithDefaultKey creates a new secret with a random value in Secrets Manager using the default
@@ -138,6 +163,53 @@ func createSecretStringWithDefaultKey(t *testing.T, awsRegion string, name strin
 	// https://github.com/gruntwork-io/cloud-nuke/issues/227
 	awsSession, err := session.NewSession(&aws.Config{Region: aws.String(awsRegion)})
 	require.NoError(t, err)
+	err = retry.DoWithRetry(
+		logging.Logger,
+		"Check if created secret is available",
+		4,
+		15*time.Second,
+		func() error {
+			secretARNPtrs, err := getAllSecretsManagerSecrets(awsSession, time.Now(), config.Config{})
+			if err != nil {
+				return err
+			}
+			if collections.ListContainsElement(aws.StringValueSlice(secretARNPtrs), arn) {
+				return nil
+			}
+			return fmt.Errorf("not found secret %s", arn)
+		},
+	)
+	require.NoError(t, err)
+	return arn
+}
+
+// createSecretStringReplicaWithDefaultKey creates a new secret and replicate other random region with a random value in
+// Secrets Manager using the default "aws/secretsmanager" KMS key and returns the secret ARN
+func createSecretStringReplicaWithDefaultKey(t *testing.T, awsRegion string, name string) string {
+	description := "Random secret created for cloud-nuke testing."
+	secretVal := random.UniqueId()
+	arn := terraws.CreateSecretStringWithDefaultKey(t, awsRegion, description, name, secretVal)
+	// Check if created secret is available by checking secret ARN in list of all secrets
+	// https://github.com/gruntwork-io/cloud-nuke/issues/227
+	awsSession, err := session.NewSession(&aws.Config{Region: aws.String(awsRegion)})
+	require.NoError(t, err)
+
+	// Replicate other random region
+	svc := secretsmanager.New(awsSession)
+	replicaRegion, err := getRandomRegion()
+	require.NoError(t, err)
+
+	_, err = svc.ReplicateSecretToRegions(&secretsmanager.ReplicateSecretToRegionsInput{
+		AddReplicaRegions: []*secretsmanager.ReplicaRegionType{
+			{
+				Region: aws.String(replicaRegion),
+			},
+		},
+		SecretId:                    aws.String(arn),
+		ForceOverwriteReplicaSecret: aws.Bool(true),
+	})
+	require.NoError(t, err)
+
 	err = retry.DoWithRetry(
 		logging.Logger,
 		"Check if created secret is available",


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #435 .

Added test for deletion secret replica.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->

Update nuking secrets manager can nuke secret replica.


### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

