### PR TITLE
chore(CORE-659): Improve filtering for EBS Volumes and Snapshots

### DIFF
--- a/aws/ebs.go
+++ b/aws/ebs.go
@@ -24,7 +24,7 @@ func getAllEbsVolumes(session *session.Session, region string, excludeAfter time
 	// Since the output of this function is used to delete the returned volumes
 	// We want to only list EBS volumes with a status of "available" or "creating"
 	// Since those are the only statuses that are eligible for deletion
-	statusFilter := ec2.Filter{Name: aws.String("status"), Values: []*string{aws.String("available"), aws.String("creating"), aws.String("error")}}
+	statusFilter := ec2.Filter{Name: aws.String("status"), Values: aws.StringSlice([]string{"available", "creating", "error"})}
 
 	result, err := svc.DescribeVolumes(&ec2.DescribeVolumesInput{
 		Filters: []*ec2.Filter{&statusFilter},

--- a/aws/ebs.go
+++ b/aws/ebs.go
@@ -24,10 +24,10 @@ func getAllEbsVolumes(session *session.Session, region string, excludeAfter time
 	// Since the output of this function is used to delete the returned volumes
 	// We want to only list EBS volumes with a status of "available" or "creating"
 	// Since those are the only statuses that are eligible for deletion
-	status_filter := ec2.Filter{Name: aws.String("status"), Values: []*string{aws.String("available"), aws.String("creating"), aws.String("error")}}
+	statusFilter := ec2.Filter{Name: aws.String("status"), Values: []*string{aws.String("available"), aws.String("creating"), aws.String("error")}}
 
 	result, err := svc.DescribeVolumes(&ec2.DescribeVolumesInput{
-		Filters: []*ec2.Filter{&status_filter},
+		Filters: []*ec2.Filter{&statusFilter},
 	})
 	if err != nil {
 		return nil, errors.WithStackTrace(err)

--- a/aws/ebs.go
+++ b/aws/ebs.go
@@ -1,9 +1,10 @@
 package aws
 
 import (
+	"time"
+
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -19,7 +20,15 @@ import (
 func getAllEbsVolumes(session *session.Session, region string, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
 	svc := ec2.New(session)
 
-	result, err := svc.DescribeVolumes(&ec2.DescribeVolumesInput{})
+	// Available statuses: (creating | available | in-use | deleting | deleted | error).
+	// Since the output of this function is used to delete the returned volumes
+	// We want to only list EBS volumes with a status of "available" or "creating"
+	// Since those are the only statuses that are eligible for deletion
+	status_filter := ec2.Filter{Name: aws.String("status"), Values: []*string{aws.String("available"), aws.String("creating")}}
+
+	result, err := svc.DescribeVolumes(&ec2.DescribeVolumesInput{
+		Filters: []*ec2.Filter{&status_filter},
+	})
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
 	}

--- a/aws/ebs.go
+++ b/aws/ebs.go
@@ -24,7 +24,7 @@ func getAllEbsVolumes(session *session.Session, region string, excludeAfter time
 	// Since the output of this function is used to delete the returned volumes
 	// We want to only list EBS volumes with a status of "available" or "creating"
 	// Since those are the only statuses that are eligible for deletion
-	status_filter := ec2.Filter{Name: aws.String("status"), Values: []*string{aws.String("available"), aws.String("creating")}}
+	status_filter := ec2.Filter{Name: aws.String("status"), Values: []*string{aws.String("available"), aws.String("creating"), aws.String("error")}}
 
 	result, err := svc.DescribeVolumes(&ec2.DescribeVolumesInput{
 		Filters: []*ec2.Filter{&status_filter},

--- a/aws/ebs_test.go
+++ b/aws/ebs_test.go
@@ -87,7 +87,7 @@ func findEBSVolumesByNameTag(t *testing.T, session *session.Session, name string
 }
 
 func findallEBSVolumesByStatus(t *testing.T, session *session.Session, status string) ([]*string, error) {
-	statusFilter := ec2.Filter{Name: aws.String("status"), Values: []*string{aws.String(status)}}
+	statusFilter := ec2.Filter{Name: aws.String("status"), Values: aws.StringSlice([]string{status})}
 
 	output, err := ec2.New(session).DescribeVolumes(&ec2.DescribeVolumesInput{
 		Filters: []*ec2.Filter{&statusFilter},

--- a/aws/ebs_test.go
+++ b/aws/ebs_test.go
@@ -93,7 +93,7 @@ func findallEBSVolumesByStatus(t *testing.T, session *session.Session, status st
 		Filters: []*ec2.Filter{&statusFilter},
 	})
 	if err != nil {
-		return []*string{}, err
+		return nil, err
 	}
 
 	var volumeIds []*string

--- a/aws/ebs_test.go
+++ b/aws/ebs_test.go
@@ -1,10 +1,11 @@
 package aws
 
 import (
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"regexp"
 	"testing"
 	"time"
+
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
 
 	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
@@ -83,6 +84,24 @@ func findEBSVolumesByNameTag(t *testing.T, session *session.Session, name string
 	}
 
 	return volumeIds
+}
+
+func findallEBSVolumesByStatus(t *testing.T, session *session.Session, status string) ([]*string, error) {
+	statusFilter := ec2.Filter{Name: aws.String("status"), Values: []*string{aws.String(status)}}
+
+	output, err := ec2.New(session).DescribeVolumes(&ec2.DescribeVolumesInput{
+		Filters: []*ec2.Filter{&statusFilter},
+	})
+	if err != nil {
+		return []*string{}, err
+	}
+
+	var volumeIds []*string
+	for _, volume := range output.Volumes {
+		volumeIds = append(volumeIds, volume.VolumeId)
+	}
+
+	return volumeIds, nil
 }
 
 func TestListEBSVolumes(t *testing.T) {
@@ -250,8 +269,9 @@ func TestNukeEBSVolumesInUse(t *testing.T) {
 		assert.Fail(t, errors.WithStackTrace(err).Error())
 	}
 
-	volumeIds, err = getAllEbsVolumes(session, region, time.Now().Add(1*time.Hour), config.Config{})
+	volumeIds, err = findallEBSVolumesByStatus(t, session, "in-use")
 	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
 		assert.Fail(t, "Unable to fetch list of EBS Volumes")
 	}
 

--- a/aws/snapshot.go
+++ b/aws/snapshot.go
@@ -23,7 +23,7 @@ func getAllSnapshots(session *session.Session, region string, excludeAfter time.
 	// Since the output of this function is used to delete the returned snapshots
 	// We only want to list EBS Snapshots with a status of "completed"
 	// Since that is the only status that is eligible for deletion
-	status_filter := ec2.Filter{Name: awsgo.String("status"), Values: []*string{awsgo.String("completed")}}
+	status_filter := ec2.Filter{Name: awsgo.String("status"), Values: []*string{awsgo.String("completed"), awsgo.String("error")}}
 
 	params := &ec2.DescribeSnapshotsInput{
 		OwnerIds: []*string{awsgo.String("self")},

--- a/aws/snapshot.go
+++ b/aws/snapshot.go
@@ -23,7 +23,7 @@ func getAllSnapshots(session *session.Session, region string, excludeAfter time.
 	// Since the output of this function is used to delete the returned snapshots
 	// We only want to list EBS Snapshots with a status of "completed"
 	// Since that is the only status that is eligible for deletion
-	status_filter := ec2.Filter{Name: awsgo.String("status"), Values: []*string{awsgo.String("completed"), awsgo.String("error")}}
+	status_filter := ec2.Filter{Name: awsgo.String("status"), Values: aws.StringSlice([]string{"completed", "error"})}
 
 	params := &ec2.DescribeSnapshotsInput{
 		OwnerIds: []*string{awsgo.String("self")},


### PR DESCRIPTION
- Add filter to only list available and creating ebs volumes
- Add filter to only list completed ebs snapshots

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds filters for EBS Volumes and EBS Snapshots.

For EBS Volumes - Introduce a filter to only list volumes with the status of "available", "creating", or "error" This will filter out any volume in the "in-use", "deleting", or "deleted" status.

This change should reduce the number of "volume in use" errors seen by those running cloud-nuke, since volumes that are in the "in-use", "deleting", or "deleted" statuses can't be deleted.

For EBS Snapshots - Introduce a filter to only list ebs snapshots with a status of "completed" or "error". This will filter out any snapshot with either a "pending" status.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated filters used when listing EBS Volumes and Shapshots to not list resources being actively used.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

