### PR TITLE
Bug: Filter out AMIs created by AWS Backup - CORE-664

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Cloud-nuke suppports 🔎 inspecting and 🔥💀 deleting the following AWS res
 
 > **WARNING:** The RDS APIs also interact with neptune and document db resources.  Running `cloud-nuke aws --resource-type rds` without a config file will remove any neptune and document db resources in the account.
 
+> **NOTE: AWS Backup Resource:** Resources (such as AMIs) created by AWS Backup, while owned by your AWS account, are managed specifically by AWS Backup and cannot be deleted through standard APIs calls for that resource. These resources are tagged by AWS Backup and are filtered out so that `cloud-nuke` does not fail when trying to delete resources it cannot delete.
+
 ### BEWARE!
 
 When executed as `cloud-nuke aws`, this tool is **HIGHLY DESTRUCTIVE** and deletes all resources! This mode should never be used in a production environment!

--- a/aws/ami.go
+++ b/aws/ami.go
@@ -21,14 +21,6 @@ func getAllAMIs(session *session.Session, region string, excludeAfter time.Time)
 
 	params := &ec2.DescribeImagesInput{
 		Owners: []*string{awsgo.String("self")},
-		// Filters: []*ec2.Filter{
-		// 	{
-		// 		Name: awsgo.String("tag-key"),
-		// 		Values: []*string{
-		// 			awsgo.String("!aws2:backup:source-resource"),
-		// 		},
-		// 	},
-		// },
 	}
 
 	output, err := svc.DescribeImages(params)
@@ -44,8 +36,6 @@ func getAllAMIs(session *session.Session, region string, excludeAfter time.Time)
 			return nil, err
 		}
 
-		//isAWSBackupImage := ImageHasAWSBackupTag(image.Tags)
-
 		if excludeAfter.After(createdTime) && !ImageHasAWSBackupTag(image.Tags) {
 			imageIds = append(imageIds, image.ImageId)
 		}
@@ -54,6 +44,9 @@ func getAllAMIs(session *session.Session, region string, excludeAfter time.Time)
 	return imageIds, nil
 }
 
+// Check if the image has an AWS Backup tag
+// Resources created by AWS Backup are listed as owned by self, but are actually
+// AWS managed resources and cannot be deleted here.
 func ImageHasAWSBackupTag(tags []*ec2.Tag) bool {
 	t := make(map[string]string)
 

--- a/util/has_aws_backup_tag.go
+++ b/util/has_aws_backup_tag.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// Check if the image has an AWS Backup tag
+// Resources created by AWS Backup are listed as owned by self, but are actually
+// AWS managed resources and cannot be deleted here.
+func HasAWSBackupTag(tags []*ec2.Tag) bool {
+	t := make(map[string]string)
+
+	for _, v := range tags {
+		t[awsgo.StringValue(v.Key)] = awsgo.StringValue(v.Value)
+	}
+
+	if _, ok := t["aws:backup:source-resource"]; ok {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Closes [CORE-664](https://gruntwork.atlassian.net/browse/CORE-664)

Updated AMI filtering to exclude any images created by AWS Backup by checking for the reserved `aws:backup:source-resource` tag

Test run against `phxdevops` excluded the two images created by AWS Backup in `us-west-2`

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated AMI filtering to exclude images created by AWS Backup


[CORE-664]: https://gruntwork.atlassian.net/browse/CORE-664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ