### PR TITLE
[WIP] Add functionality to delete KMS keys that dont have aliases

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -2,13 +2,14 @@ package aws
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"math/rand"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 
 	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
@@ -205,7 +206,7 @@ func GetTargetRegions(enabledRegions []string, selectedRegions []string, exclude
 }
 
 // GetAllResources - Lists all aws resources
-func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTypes []string, configObj config.Config) (*AwsAccountResources, error) {
+func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTypes []string, configObj config.Config, allowDeleteUnaliasedKeys bool) (*AwsAccountResources, error) {
 	account := AwsAccountResources{
 		Resources: make(map[string]AwsRegionResource),
 	}
@@ -1287,7 +1288,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region": region,
 			})
-			keys, aliases, err := getAllKmsUserKeys(cloudNukeSession, customerKeys.MaxBatchSize(), excludeAfter, configObj)
+			keys, aliases, err := getAllKmsUserKeys(cloudNukeSession, customerKeys.MaxBatchSize(), excludeAfter, configObj, allowDeleteUnaliasedKeys)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/inspect.go
+++ b/aws/inspect.go
@@ -92,5 +92,5 @@ func InspectResources(q *Query) (*AwsAccountResources, error) {
 	}
 
 	// NOTE: The inspect functionality currently does not support config file, so we short circuit the logic with an empty struct.
-	return GetAllResources(q.Regions, q.ExcludeAfter, q.ResourceTypes, config.Config{})
+	return GetAllResources(q.Regions, q.ExcludeAfter, q.ResourceTypes, config.Config{}, false)
 }

--- a/aws/inspect.go
+++ b/aws/inspect.go
@@ -78,7 +78,7 @@ func HandleResourceTypeSelections(
 	return resourceTypes, nil
 }
 
-func InspectResources(q *Query) (*AwsAccountResources, error) {
+func InspectResources(q *Query, listUnaliasedKMSKeys bool) (*AwsAccountResources, error) {
 	// Log which resource types will be inspected
 	logging.Logger.Info("The following resource types will be inspected:")
 	if len(q.ResourceTypes) > 0 {
@@ -92,5 +92,5 @@ func InspectResources(q *Query) (*AwsAccountResources, error) {
 	}
 
 	// NOTE: The inspect functionality currently does not support config file, so we short circuit the logic with an empty struct.
-	return GetAllResources(q.Regions, q.ExcludeAfter, q.ResourceTypes, config.Config{}, false)
+	return GetAllResources(q.Regions, q.ExcludeAfter, q.ResourceTypes, config.Config{}, listUnaliasedKMSKeys)
 }

--- a/aws/kms_customer_key_test.go
+++ b/aws/kms_customer_key_test.go
@@ -2,10 +2,11 @@ package aws
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"regexp"
 	"testing"
 	"time"
+
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
 
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/util"
@@ -32,14 +33,14 @@ func TestListKmsUserKeys(t *testing.T) {
 	createdKeyId := createKmsCustomerManagedKey(t, session, keyAlias)
 
 	// test if listing of keys will return new key and alias
-	keys, aliases, err := getAllKmsUserKeys(session, KmsCustomerKeys{}.MaxBatchSize(), time.Now(), config.Config{})
+	keys, aliases, err := getAllKmsUserKeys(session, KmsCustomerKeys{}.MaxBatchSize(), time.Now(), config.Config{}, false)
 	require.NoError(t, err)
 	assert.Contains(t, aws.StringValueSlice(keys), createdKeyId)
 	assert.Contains(t, aliases[createdKeyId], keyAlias)
 
 	// test if time shift works
 	olderThan := time.Now().Add(-1 * time.Hour)
-	keys, aliases, err = getAllKmsUserKeys(session, KmsCustomerKeys{}.MaxBatchSize(), olderThan, config.Config{})
+	keys, aliases, err = getAllKmsUserKeys(session, KmsCustomerKeys{}.MaxBatchSize(), olderThan, config.Config{}, false)
 	require.NoError(t, err)
 	assert.NotContains(t, aws.StringValueSlice(keys), createdKeyId)
 	assert.NotContains(t, aliases[createdKeyId], keyAlias)
@@ -53,7 +54,7 @@ func TestListKmsUserKeys(t *testing.T) {
 				},
 			},
 		},
-	})
+	}, false)
 	require.NoError(t, err)
 	assert.Contains(t, aws.StringValueSlice(keys), createdKeyId)
 	assert.Contains(t, aliases[createdKeyId], keyAlias)
@@ -68,7 +69,7 @@ func TestListKmsUserKeys(t *testing.T) {
 				},
 			},
 		},
-	})
+	}, false)
 	require.NoError(t, err)
 	assert.NotContains(t, aws.StringValueSlice(keys), createdKeyId)
 	assert.NotContains(t, aliases[createdKeyId], keyAlias)
@@ -91,7 +92,7 @@ func TestRemoveKmsUserKeys(t *testing.T) {
 	require.NoError(t, err)
 
 	// test if key is not included for removal second time, after being marked for deletion
-	keys, aliases, err := getAllKmsUserKeys(session, KmsCustomerKeys{}.MaxBatchSize(), time.Now(), config.Config{})
+	keys, aliases, err := getAllKmsUserKeys(session, KmsCustomerKeys{}.MaxBatchSize(), time.Now(), config.Config{}, false)
 
 	require.NoError(t, err)
 	assert.NotContains(t, aws.StringValueSlice(keys), createdKeyId)

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -146,7 +146,7 @@ func CreateCli(version string, mixPanelClientId string) *cli.App {
 					Value: "0s",
 				},
 				&cli.BoolFlag{
-					Name:  "delete-unaliased-kms-keys",
+					Name:  "list-unaliased-kms-keys",
 					Usage: "Delete KMS keys that do not have aliases associated with them.",
 				},
 				&cli.StringFlag{
@@ -641,7 +641,7 @@ func awsInspect(c *cli.Context) error {
 		return aws.QueryCreationError{Underlying: err}
 	}
 
-	accountResources, err := aws.InspectResources(query)
+	accountResources, err := aws.InspectResources(query, c.Bool("list-unaliased-kms-keys"))
 	if err != nil {
 		telemetry.TrackEvent(commonTelemetry.EventContext{
 			EventName: "Error inspecting resources",

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -2,10 +2,11 @@ package commands
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"strings"
 	"time"
+
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 
 	"github.com/gruntwork-io/cloud-nuke/aws"
 	"github.com/gruntwork-io/cloud-nuke/config"
@@ -77,6 +78,10 @@ func CreateCli(version string, mixPanelClientId string) *cli.App {
 					Usage:   "Set log level",
 					EnvVars: []string{"LOG_LEVEL"},
 				},
+				&cli.BoolFlag{
+					Name:  "delete-unaliased-kms-keys",
+					Usage: "Delete KMS keys that do not have aliases associated with them.",
+				},
 				&cli.StringFlag{
 					Name:  "config",
 					Usage: "YAML file specifying matching rules.",
@@ -139,6 +144,10 @@ func CreateCli(version string, mixPanelClientId string) *cli.App {
 					Name:  "older-than",
 					Usage: "Only inspect resources older than this specified value. Can be any valid Go duration, such as 10m or 8h.",
 					Value: "0s",
+				},
+				&cli.BoolFlag{
+					Name:  "delete-unaliased-kms-keys",
+					Usage: "Delete KMS keys that do not have aliases associated with them.",
 				},
 				&cli.StringFlag{
 					Name:    "log-level",
@@ -285,7 +294,7 @@ func awsNuke(c *cli.Context) error {
 		return errors.WithStackTrace(spinnerErr)
 	}
 
-	account, err := aws.GetAllResources(targetRegions, *excludeAfter, resourceTypes, configObj)
+	account, err := aws.GetAllResources(targetRegions, *excludeAfter, resourceTypes, configObj, c.Bool("delete-unaliased-kms-keys"))
 	// Stop the spinner
 	spinnerSuccess.Stop()
 	if err != nil {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes issue where KMS keys without aliases were not being removed.

Adds delete-unaliased-kms-keys flag for aws command and list-unaliased-kms-keys for inspect-aws command

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

