### PR TITLE
Add --delete-unaliased-kms-keys to phx devops nuke config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,8 @@ jobs:
               --exclude-resource-type iam-service-linked-role \
               --exclude-resource-type ecr \
               --exclude-resource-type config-recorders \
-              --exclude-resource-type config-rules 
+              --exclude-resource-type config-rules \
+              --delete-unaliased-kms-keys
           no_output_timeout: 1h
   nuke_sandbox:
     <<: *defaults
@@ -73,7 +74,7 @@ jobs:
               --exclude-resource-type kmscustomerkeys \
               --exclude-resource-type ecr \
               --exclude-resource-type config-recorders \
-              --exclude-resource-type config-rules 
+              --exclude-resource-type config-rules
           no_output_timeout: 1h
   deploy:
     <<: *defaults


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updates CircleCI job for phxdevops to include new `--delete-unaliased-kms-keys` flag

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

