### PR TITLE
[CORE-562] Delete VPCs and unaliased KMS keys in sandbox account

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,11 +70,10 @@ jobs:
               --exclude-resource-type iam \
               --exclude-resource-type iam-group \
               --exclude-resource-type iam-service-linked-role \
-              --exclude-resource-type vpc \
-              --exclude-resource-type kmscustomerkeys \
               --exclude-resource-type ecr \
               --exclude-resource-type config-recorders \
-              --exclude-resource-type config-rules
+              --exclude-resource-type config-rules \
+              --delete-unaliased-kms-keys
           no_output_timeout: 1h
   deploy:
     <<: *defaults
@@ -89,7 +88,7 @@ workflows:
     # Make sure this pipeline doesn't run when a schedule is triggered
     when:
       not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       - test:
           filters:
@@ -121,8 +120,8 @@ workflows:
   nuke_phxdevops:
     when:
       and:
-        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-        - equal: [ "every 3 hours", << pipeline.schedule.name >> ]
+        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - equal: ["every 3 hours", << pipeline.schedule.name >>]
     jobs:
       - nuke_phx_devops:
           context:
@@ -132,8 +131,8 @@ workflows:
   nuke_sandbox:
     when:
       and:
-        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-        - equal: [ "nightly", << pipeline.schedule.name >> ]
+        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - equal: ["nightly", << pipeline.schedule.name >>]
     jobs:
       - nuke_sandbox:
           context:


### PR DESCRIPTION
## Description

Fixes [CORE-562].

- Updates `nuke-sandbox` job to clean VPCs & unaliased KMS keys older than 24h

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].



[CORE-562]: https://gruntwork.atlassian.net/browse/CORE-562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ