### PR TITLE
Fix for cloud-nuke telemetry errors

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -253,7 +253,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 				EventName: "Done Listing ACMPA arns",
 			}, map[string]interface{}{
 				"recordCount": len(arns),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(arns) > 0 {
 				acmpca.ARNs = awsgo.StringValueSlice(arns)
@@ -280,7 +280,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(groupNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(groupNames) > 0 {
 				asGroups.GroupNames = awsgo.StringValueSlice(groupNames)
@@ -307,7 +307,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(configNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(configNames) > 0 {
 				configs.LaunchConfigurationNames = awsgo.StringValueSlice(configNames)
@@ -335,7 +335,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(templateNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(templateNames) > 0 {
 				templates.LaunchTemplateNames = awsgo.StringValueSlice(templateNames)
@@ -362,7 +362,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(elbNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(elbNames) > 0 {
 				loadBalancers.Names = awsgo.StringValueSlice(elbNames)
@@ -389,7 +389,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(elbv2Arns),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(elbv2Arns) > 0 {
 				loadBalancersV2.Arns = awsgo.StringValueSlice(elbv2Arns)
@@ -416,7 +416,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(queueUrls),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(queueUrls) > 0 {
 				sqsQueue.QueueUrls = awsgo.StringValueSlice(queueUrls)
@@ -452,7 +452,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(transitGatewayVpcAttachmentIds),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(transitGatewayVpcAttachmentIds) > 0 {
 				transitGatewayVpcAttachments.Ids = awsgo.StringValueSlice(transitGatewayVpcAttachmentIds)
@@ -479,7 +479,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(transitGatewayRouteTableIds),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(transitGatewayRouteTableIds) > 0 {
 				transitGatewayRouteTables.Ids = awsgo.StringValueSlice(transitGatewayRouteTableIds)
@@ -506,7 +506,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(transitGatewayIds),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(transitGatewayIds) > 0 {
 				transitGateways.Ids = awsgo.StringValueSlice(transitGatewayIds)
@@ -533,7 +533,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(ngwIDs),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(ngwIDs) > 0 {
 				natGateways.NatGatewayIDs = awsgo.StringValueSlice(ngwIDs)
@@ -560,7 +560,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(domainNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(domainNames) > 0 {
 				domains.DomainNames = awsgo.StringValueSlice(domainNames)
@@ -587,7 +587,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(instanceIds),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(instanceIds) > 0 {
 				ec2Instances.InstanceIds = awsgo.StringValueSlice(instanceIds)
@@ -614,7 +614,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(hostIds),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(hostIds) > 0 {
 				ec2DedicatedHosts.HostIds = awsgo.StringValueSlice(hostIds)
@@ -642,7 +642,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(volumeIds),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(volumeIds) > 0 {
 				ebsVolumes.VolumeIds = awsgo.StringValueSlice(volumeIds)
@@ -669,7 +669,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(allocationIds),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(allocationIds) > 0 {
 				eipAddresses.AllocationIds = awsgo.StringValueSlice(allocationIds)
@@ -696,7 +696,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(imageIds),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(imageIds) > 0 {
 				amis.ImageIds = awsgo.StringValueSlice(imageIds)
@@ -723,7 +723,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(snapshotIds),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(snapshotIds) > 0 {
 				snapshots.SnapshotIds = awsgo.StringValueSlice(snapshotIds)
@@ -759,7 +759,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(clusterArns),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 		}
 
@@ -780,7 +780,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(ecsClusterArns),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(ecsClusterArns) > 0 {
 				ecsClusters.ClusterArns = awsgo.StringValueSlice(ecsClusterArns)
@@ -807,7 +807,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(eksClusterNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(eksClusterNames) > 0 {
 				eksClusters.Clusters = awsgo.StringValueSlice(eksClusterNames)
@@ -835,7 +835,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(instanceNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(instanceNames) > 0 {
 				dbInstances.InstanceNames = awsgo.StringValueSlice(instanceNames)
@@ -865,7 +865,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(clustersNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(clustersNames) > 0 {
 				dbClusters.InstanceNames = awsgo.StringValueSlice(clustersNames)
@@ -893,7 +893,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(lambdaFunctionNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(lambdaFunctionNames) > 0 {
 				lambdaFunctions.LambdaFunctionNames = awsgo.StringValueSlice(lambdaFunctionNames)
@@ -921,7 +921,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(secrets),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 
 			if len(secrets) > 0 {
@@ -950,7 +950,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(analyzerNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(analyzerNames) > 0 {
 				accessAnalyzer.AnalyzerNames = awsgo.StringValueSlice(analyzerNames)
@@ -978,7 +978,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(cwdbNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(cwdbNames) > 0 {
 				cloudwatchDashboards.DashboardNames = awsgo.StringValueSlice(cwdbNames)
@@ -1005,7 +1005,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(lgNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(lgNames) > 0 {
 				cloudwatchLogGroups.Names = awsgo.StringValueSlice(lgNames)
@@ -1065,7 +1065,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(bucketNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if ok && len(bucketNames) > 0 {
 				s3Buckets.Names = aws.StringValueSlice(bucketNames)
@@ -1092,7 +1092,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(tablenames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(tablenames) > 0 {
 				DynamoDB.DynamoTableNames = awsgo.StringValueSlice(tablenames)
@@ -1120,7 +1120,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(vpcids),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(vpcids) > 0 {
 				ec2Vpcs.VPCIds = awsgo.StringValueSlice(vpcids)
@@ -1144,7 +1144,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(keyPairIds),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(keyPairIds) > 0 {
 				KeyPairs.KeyPairIds = awsgo.StringValueSlice(keyPairIds)
@@ -1172,7 +1172,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(clusterIds),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(clusterIds) > 0 {
 				elasticaches.ClusterIds = awsgo.StringValueSlice(clusterIds)
@@ -1199,7 +1199,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(keys),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(keys) > 0 {
 				customerKeys.KeyAliases = aliases
@@ -1228,7 +1228,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(detectors),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(detectors) > 0 {
 				guardDutyDetectors.detectorIds = detectors
@@ -1256,7 +1256,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(accountIds),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(accountIds) > 0 {
 				macieAccounts.AccountIds = accountIds
@@ -1284,7 +1284,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(instances),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(instances) > 0 {
 				notebookInstances.InstanceNames = awsgo.StringValueSlice(instances)
@@ -1311,7 +1311,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(streams),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(streams) > 0 {
 				kinesisStreams.Names = awsgo.StringValueSlice(streams)
@@ -1338,7 +1338,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(gatewayIds),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(gatewayIds) > 0 {
 				apiGateways.Ids = awsgo.StringValueSlice(gatewayIds)
@@ -1365,7 +1365,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(gatewayV2Ids),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(gatewayV2Ids) > 0 {
 				apiGatewaysV2.Ids = awsgo.StringValueSlice(gatewayV2Ids)
@@ -1392,7 +1392,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(elasticFileSystemsIds),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(elasticFileSystemsIds) > 0 {
 				elasticFileSystems.Ids = awsgo.StringValueSlice(elasticFileSystemsIds)
@@ -1419,7 +1419,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(snsTopicArns),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(snsTopicArns) > 0 {
 				snsTopics.Arns = awsgo.StringValueSlice(snsTopicArns)
@@ -1446,7 +1446,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(cloudtrailArns),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(cloudtrailArns) > 0 {
 				cloudtrailTrails.Arns = awsgo.StringValueSlice(cloudtrailArns)
@@ -1473,7 +1473,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(ecrRepositoryArns),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(ecrRepositoryArns) > 0 {
 				ecrRepositories.RepositoryNames = ecrRepositoryArns
@@ -1500,7 +1500,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(configServiceRuleNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(configServiceRuleNames) > 0 {
 				configServiceRules.RuleNames = configServiceRuleNames
@@ -1527,7 +1527,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(configServiceRecorderNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(configServiceRecorderNames) > 0 {
 				configServiceRecorders.RecorderNames = configServiceRecorderNames
@@ -1554,7 +1554,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(cwalNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(cwalNames) > 0 {
 				cloudwatchAlarms.AlarmNames = awsgo.StringValueSlice(cwalNames)
@@ -1602,7 +1602,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      "global",
 				"recordCount": len(userNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(userNames) > 0 {
 				iamUsers.UserNames = awsgo.StringValueSlice(userNames)
@@ -1624,7 +1624,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      "global",
 				"recordCount": len(groupNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(groupNames) > 0 {
 				iamGroups.GroupNames = awsgo.StringValueSlice(groupNames)
@@ -1646,7 +1646,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      "global",
 				"recordCount": len(policyArns),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(policyArns) > 0 {
 				iamPolicies.PolicyArns = awsgo.StringValueSlice(policyArns)
@@ -1674,7 +1674,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      "global",
 				"recordCount": len(providerARNs),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(providerARNs) > 0 {
 				oidcProviders.ProviderARNs = awsgo.StringValueSlice(providerARNs)
@@ -1701,7 +1701,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      "global",
 				"recordCount": len(roleNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(roleNames) > 0 {
 				iamRoles.RoleNames = awsgo.StringValueSlice(roleNames)
@@ -1728,7 +1728,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			}, map[string]interface{}{
 				"region":      "global",
 				"recordCount": len(roleNames),
-				"time":        time.Since(start).Seconds(),
+				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(roleNames) > 0 {
 				iamServiceLinkedRoles.RoleNames = awsgo.StringValueSlice(roleNames)

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -25,7 +25,7 @@ func CreateCli(version string, mixPanelClientId string) *cli.App {
 	logging.InitLogger("cloud-nuke", version)
 	_, disableTelemetryFlag := os.LookupEnv("DISABLE_TELEMETRY")
 	if !disableTelemetryFlag {
-		logging.Logger.Error("This program sends telemetry to Gruntwork. To disable, set DISABLE_TELEMETRY=true as an environment variable")
+		ui.WarningMessage("This program sends telemetry to Gruntwork. To disable, set DISABLE_TELEMETRY=true as an environment variable")
 	}
 	telemetry.InitTelemetry("cloud-nuke", version, mixPanelClientId)
 	telemetry.TrackEvent(commonTelemetry.EventContext{

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sns v1.17.13
 	github.com/charmbracelet/lipgloss v0.6.0
 	github.com/golang/mock v1.6.0
-	github.com/gruntwork-io/go-commons v0.16.1
+	github.com/gruntwork-io/go-commons v0.16.2
 	github.com/gruntwork-io/gruntwork-cli v0.7.0
 	github.com/gruntwork-io/terratest v0.41.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,14 @@ github.com/gruntwork-io/go-commons v0.15.0 h1:fB7T4wO/JWQEGBnpVg4PfrNYnNtqRSUHJg
 github.com/gruntwork-io/go-commons v0.15.0/go.mod h1:AlYVzB6p6d8IYakGPNq/pspRjI7da7FeAIffISO9878=
 github.com/gruntwork-io/go-commons v0.16.1 h1:EhrTKRg5XK/wDL/s99zisjL9+zhTaEcepEkJeyvj3s8=
 github.com/gruntwork-io/go-commons v0.16.1/go.mod h1:/nnLMhO4HpItt43K+8ACM66g67iMy3oo2nnwq59n3wg=
+github.com/gruntwork-io/go-commons v0.16.2-0.20230420155317-508d68dfa335 h1:K2cjf/h6LY/n0bTzvvFOk5m1ftCa0jR2orvX0NoGkmc=
+github.com/gruntwork-io/go-commons v0.16.2-0.20230420155317-508d68dfa335/go.mod h1:/nnLMhO4HpItt43K+8ACM66g67iMy3oo2nnwq59n3wg=
+github.com/gruntwork-io/go-commons v0.16.2-0.20230420160245-9448bca80495 h1:htRD5zber0tFzi5cycXqzejgm63dFmsiAqDVXxa8OX0=
+github.com/gruntwork-io/go-commons v0.16.2-0.20230420160245-9448bca80495/go.mod h1:/nnLMhO4HpItt43K+8ACM66g67iMy3oo2nnwq59n3wg=
+github.com/gruntwork-io/go-commons v0.16.2-0.20230420160823-7d744d15fd40 h1:TriO7slE8LrP3olE8RmR6NDPVkwYegTxQ56J/0iJxGo=
+github.com/gruntwork-io/go-commons v0.16.2-0.20230420160823-7d744d15fd40/go.mod h1:/nnLMhO4HpItt43K+8ACM66g67iMy3oo2nnwq59n3wg=
+github.com/gruntwork-io/go-commons v0.16.2 h1:EmkS8344ggtQopFq6YJ5Nh3ohBF03AB7cxrgDiJ7C3Q=
+github.com/gruntwork-io/go-commons v0.16.2/go.mod h1:/nnLMhO4HpItt43K+8ACM66g67iMy3oo2nnwq59n3wg=
 github.com/gruntwork-io/gruntwork-cli v0.7.0 h1:YgSAmfCj9c61H+zuvHwKfYUwlMhu5arnQQLM4RH+CYs=
 github.com/gruntwork-io/gruntwork-cli v0.7.0/go.mod h1:jp6Z7NcLF2avpY8v71fBx6hds9eOFPELSuD/VPv7w00=
 github.com/gruntwork-io/terratest v0.41.0 h1:QKFK6m0EMVnrV7lw2L06TlG+Ha3t0CcOXuBVywpeNRU=

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -3,7 +3,6 @@ package telemetry
 import (
 	"github.com/gruntwork-io/go-commons/telemetry"
 	"os"
-	"strings"
 )
 
 var sendTelemetry = true
@@ -18,7 +17,7 @@ func InitTelemetry(name string, version string, clientId string) {
 	clientIdExists := clientId != ""
 	sendTelemetry = !disableTelemetryFlag && clientIdExists
 	if sendTelemetry {
-		cmd = strings.Join(os.Args[1:], " ")
+		cmd = os.Args[1]
 		telemetryClient = telemetry.NewMixPanelTelemetryClient(clientId, name, version)
 	}
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes issue where telemetry could kill the process.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated telemetry module to not exit when an error is encountered

