### PR TITLE
add support for redshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,9 @@ The following resources support the Config file:
 - CloudWatch Alarms
     - Resource type: `cloudwatch-alarm`
     - Config key: `CloudWatchAlarm`
+- Redshift
+  - Resource type: `redshift`
+  - Config key: `Redshift`
 
 
 
@@ -591,6 +594,7 @@ To find out what we options are supported in the config file today, consult this
 | config-recorders              | none  | ✅           | none | none       |
 | config-rules                  | none  | ✅           | none | none       |
 | cloudwatch-alarm              | none  | ✅           | none | none       |
+| redshift                      | none  | ✅           | none | none       |
 | ... (more to come)            | none  | none         | none | none       |
 
 

--- a/aws/elasticache.go
+++ b/aws/elasticache.go
@@ -272,8 +272,8 @@ func shouldIncludeElasticacheParameterGroup(paramGroup *elasticache.CacheParamet
 
 	return config.ShouldInclude(
 		aws.StringValue(paramGroup.CacheParameterGroupName),
-                configObj.ElasticacheParameterGroup.IncludeRule.NamesRegExp,
-		configObj.ElasticacheParameterGroup.ExcludeRule.NamesRegExp,
+		configObj.ElasticacheParameterGroups.IncludeRule.NamesRegExp,
+		configObj.ElasticacheParameterGroups.ExcludeRule.NamesRegExp,
 	)
 }
 
@@ -338,8 +338,8 @@ func shouldIncludeElasticacheSubnetGroup(subnetGroup *elasticache.CacheSubnetGro
 
 	return config.ShouldInclude(
 		aws.StringValue(subnetGroup.CacheSubnetGroupName),
-		configObj.ElasticacheSubnetGroup.IncludeRule.NamesRegExp,
-		configObj.ElasticacheSubnetGroup.ExcludeRule.NamesRegExp,
+		configObj.ElasticacheSubnetGroups.IncludeRule.NamesRegExp,
+		configObj.ElasticacheSubnetGroups.ExcludeRule.NamesRegExp,
 	)
 }
 

--- a/aws/redshift.go
+++ b/aws/redshift.go
@@ -1,0 +1,93 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/redshift"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	"github.com/gruntwork-io/go-commons/errors"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
+	"time"
+)
+
+func getAllRedshiftClusters(session *session.Session, region string, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
+	svc := redshift.New(session)
+	var clusterIds []*string
+	err := svc.DescribeClustersPages(
+		&redshift.DescribeClustersInput{},
+		func(page *redshift.DescribeClustersOutput, lastPage bool) bool {
+			for _, cluster := range page.Clusters {
+				if shouldIncludeRedshiftCluster(cluster, excludeAfter, configObj) {
+					clusterIds = append(clusterIds, cluster.ClusterIdentifier)
+				}
+			}
+			return !lastPage
+		},
+	)
+	return clusterIds, errors.WithStackTrace(err)
+}
+
+func shouldIncludeRedshiftCluster(cluster *redshift.Cluster, excludeAfter time.Time, configObj config.Config) bool {
+	if cluster == nil {
+		return false
+	}
+	if excludeAfter.Before(*cluster.ClusterCreateTime) {
+		return false
+	}
+	return config.ShouldInclude(
+		aws.StringValue(cluster.ClusterIdentifier),
+		configObj.Redshift.IncludeRule.NamesRegExp,
+		configObj.Redshift.ExcludeRule.NamesRegExp,
+	)
+}
+
+func nukeAllRedshiftClusters(session *session.Session, identifiers []*string) error {
+	svc := redshift.New(session)
+	if len(identifiers) == 0 {
+		logging.Logger.Debugf("No Redshift Clusters to nuke in region %s", *session.Config.Region)
+		return nil
+	}
+	logging.Logger.Debugf("Deleting all Redshift Clusters in region %s", *session.Config.Region)
+	deletedIds := []*string{}
+	for _, id := range identifiers {
+		_, err := svc.DeleteCluster(&redshift.DeleteClusterInput{ClusterIdentifier: id, SkipFinalClusterSnapshot: aws.Bool(true)})
+		if err != nil {
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking RedshiftCluster",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
+			logging.Logger.Errorf("[Failed] %s: %s", *id, err)
+		} else {
+			deletedIds = append(deletedIds, id)
+			logging.Logger.Debugf("Deleted Redshift Cluster: %s", aws.StringValue(id))
+		}
+	}
+
+	if len(deletedIds) > 0 {
+		for _, id := range deletedIds {
+			err := svc.WaitUntilClusterDeleted(&redshift.DescribeClustersInput{ClusterIdentifier: id})
+			// Record status of this resource
+			e := report.Entry{
+				Identifier:   aws.StringValue(id),
+				ResourceType: "Redshift Cluster",
+				Error:        err,
+			}
+			report.Record(e)
+			if err != nil {
+				telemetry.TrackEvent(commonTelemetry.EventContext{
+					EventName: "Error Nuking Redshift Cluster",
+				}, map[string]interface{}{
+					"region": *session.Config.Region,
+				})
+				logging.Logger.Errorf("[Failed] %s", err)
+				return errors.WithStackTrace(err)
+			}
+		}
+	}
+	logging.Logger.Debugf("[OK] %d Redshift Cluster(s) deleted in %s", len(deletedIds), *session.Config.Region)
+	return nil
+}

--- a/aws/redshift_test.go
+++ b/aws/redshift_test.go
@@ -1,0 +1,68 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	awsSession "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/redshift"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNukeRedshiftClusters(t *testing.T) {
+	telemetry.InitTelemetry("cloud-nuke", "", "")
+	t.Parallel()
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+
+	session, err := awsSession.NewSession(&aws.Config{
+		Region: aws.String(region),
+	})
+	require.NoError(t, err)
+
+	svc := redshift.New(session)
+
+	clusterName := "test-" + strings.ToLower(util.UniqueID())
+
+	//create cluster
+	_, err = svc.CreateCluster(
+		&redshift.CreateClusterInput{
+			ClusterIdentifier:  aws.String(clusterName),
+			MasterUsername:     aws.String("grunty"),
+			MasterUserPassword: aws.String("Gruntysecurepassword1"),
+			NodeType:           aws.String("dc2.large"),
+			NumberOfNodes:      aws.Int64(2),
+		},
+	)
+	require.NoError(t, err)
+	err = svc.WaitUntilClusterAvailable(&redshift.DescribeClustersInput{
+		ClusterIdentifier: aws.String(clusterName),
+	})
+	require.NoError(t, err)
+	defer svc.DeleteCluster(&redshift.DeleteClusterInput{ClusterIdentifier: aws.String(clusterName)})
+
+	//Sleep for a minute for consistency in aws
+	sleepTime, err := time.ParseDuration("1m")
+	time.Sleep(sleepTime)
+
+	//test list clusters
+	clusters, err := getAllRedshiftClusters(session, region, time.Now().Add(1*time.Hour), config.Config{})
+	require.NoError(t, err)
+
+	//Ensure our cluster exists
+	assert.Contains(t, aws.StringValueSlice(clusters), clusterName)
+
+	//nuke cluster
+	err = nukeAllRedshiftClusters(session, aws.StringSlice([]string{clusterName}))
+	require.NoError(t, err)
+
+	//check that the cluster no longer exists
+	clusters, err = getAllRedshiftClusters(session, region, time.Now().Add(1*time.Hour), config.Config{})
+	require.NoError(t, err)
+	assert.NotContains(t, aws.StringValueSlice(clusters), aws.StringSlice([]string{clusterName}))
+}

--- a/aws/redshift_types.go
+++ b/aws/redshift_types.go
@@ -1,0 +1,34 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+type RedshiftClusters struct {
+	ClusterIdentifiers []string
+}
+
+func (cluster RedshiftClusters) ResourceName() string {
+	return "redshift"
+}
+
+// ResourceIdentifiers - The instance names of the rds db instances
+func (cluster RedshiftClusters) ResourceIdentifiers() []string {
+	return cluster.ClusterIdentifiers
+}
+
+func (cluster RedshiftClusters) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 49
+}
+
+// Nuke - nuke 'em all!!!
+func (cluster RedshiftClusters) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllRedshiftClusters(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	ConfigServiceRule          ResourceType `yaml:"ConfigServiceRule"`
 	ConfigServiceRecorder      ResourceType `yaml:"ConfigServiceRecorder"`
 	CloudWatchAlarm            ResourceType `yaml:"CloudWatchAlarm"`
+	Redshift                   ResourceType `yaml:"Redshift"`
 }
 
 type ResourceType struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -54,6 +54,7 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds support for nuking redshift clusters

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added support for nuking redshift clusters

### Migration Guide

Warning, this PR adds support for a new resource! If you don't want to remove redshift clusters you will need to add configuration to a config file or using cli arguments

