### PR TITLE
Add support for Security Hub - CORE-364

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Cloud-nuke suppports 🔎 inspecting and 🔥💀 deleting the following AWS res
 | ECR | Repositories                                             | 
 | Config | Service recorders                                        | 
 | Config | Service rules                                            | 
+| Security Hub | Hubs |
+| Security Hub | Members |
+| Security Hub | Administrators |
 
 > **WARNING:** The RDS APIs also interact with neptune and document db resources.  Running `cloud-nuke aws --resource-type rds` without a config file will remove any neptune and document db resources in the account.
 

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1650,7 +1650,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		securityHub := SecurityHub{}
 		if IsNukeable(securityHub.ResourceName(), resourceTypes) {
 			start := time.Now()
-			hubArns, err := getAllSecurityHubArns(cloudNukeSession)
+			hubArns, err := getAllSecurityHubArns(cloudNukeSession, excludeAfter)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1654,7 +1654,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,
-					Description:  "Unable to check if Security Hub is enabled",
+					Description:  "Unable to retrieve security hub status",
 					ResourceType: securityHub.ResourceName(),
 				}
 				report.RecordError(ge)

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1646,6 +1646,33 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End CloudWatchAlarm
 
+		//Security Hub
+		securityHub := SecurityHub{}
+		if IsNukeable(securityHub.ResourceName(), resourceTypes) {
+			start := time.Now()
+			hubArns, err := getAllSecurityHubArns(cloudNukeSession)
+			if err != nil {
+				ge := report.GeneralError{
+					Error:        err,
+					Description:  "Unable to check if Security Hub is enabled",
+					ResourceType: securityHub.ResourceName(),
+				}
+				report.RecordError(ge)
+			}
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Done Checking if Security Hub is enabled",
+			}, map[string]interface{}{
+				"region":      region,
+				"recordCount": len(hubArns),
+				"actionTime":  time.Since(start).Seconds(),
+			})
+			if len(hubArns) > 0 {
+				securityHub.HubArns = hubArns
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, securityHub)
+			}
+		}
+		//End Security Hub
+
 		if len(resourcesInRegion.Resources) > 0 {
 			account.Resources[region] = resourcesInRegion
 		}
@@ -1885,6 +1912,7 @@ func ListResourceTypes() []string {
 		LaunchTemplates{}.ResourceName(),
 		ConfigServiceRule{}.ResourceName(),
 		ConfigServiceRecorders{}.ResourceName(),
+		SecurityHub{}.ResourceName(),
 		CloudWatchAlarms{}.ResourceName(),
 	}
 	sort.Strings(resourceTypes)

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1660,7 +1660,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 				report.RecordError(ge)
 			}
 			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Done Checking if Security Hub is enabled",
+				EventName: "Done Listing Security Hub",
 			}, map[string]interface{}{
 				"region":      region,
 				"recordCount": len(hubArns),

--- a/aws/security_hub.go
+++ b/aws/security_hub.go
@@ -139,6 +139,11 @@ func disassociateAdministratorAccount(svc *securityhub.SecurityHub) {
 func nukeSecurityHub(session *session.Session, securityHubArns []string) error {
 	svc := securityhub.New(session)
 
+	if len(securityHubArns) == 0 {
+		logging.Logger.Debugf("No security hub resources to nuke in region %s", *session.Config.Region)
+		return nil
+	}
+
 	// Check for and remove any member accounts in security hub
 	// Security Hub cannot be disabled with active member accounts
 	memberAccountIds, err := getAllSecurityHubMembers(svc)

--- a/aws/security_hub.go
+++ b/aws/security_hub.go
@@ -1,0 +1,169 @@
+package aws
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/securityhub"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	"github.com/gruntwork-io/go-commons/errors"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
+)
+
+func getAllSecurityHubArns(session *session.Session) ([]string, error) {
+	svc := securityhub.New(session)
+	var securityHubArns []string
+
+	output, err := svc.DescribeHub(&securityhub.DescribeHubInput{})
+
+	if err != nil {
+		// If Security Hub is not enabled when we call DescribeHub, we get back an error
+		// so we should ignore the error if it's just telling us the account/region is not
+		// subscribed and return nil to indicate there are no resources to nuke
+		if strings.Contains(err.Error(), "is not subscribed to AWS Security Hub") {
+			return nil, nil
+		}
+		return nil, errors.WithStackTrace(err)
+	}
+
+	securityHubArns = append(securityHubArns, *output.HubArn)
+
+	return securityHubArns, nil
+}
+
+func getAllSecurityHubMembers(svc *securityhub.SecurityHub) ([]*string, error) {
+	var hubMemberAccountIds []*string
+	members, err := svc.ListMembers(&securityhub.ListMembersInput{OnlyAssociated: aws.Bool(false)})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+	for _, member := range members.Members {
+		hubMemberAccountIds = append(hubMemberAccountIds, member.AccountId)
+	}
+
+	for awsgo.StringValue(members.NextToken) != "" {
+		members, err = svc.ListMembers(&securityhub.ListMembersInput{NextToken: members.NextToken})
+		if err != nil {
+			return nil, errors.WithStackTrace(err)
+		}
+		for _, member := range members.Members {
+			hubMemberAccountIds = append(hubMemberAccountIds, member.AccountId)
+		}
+	}
+	logging.Logger.Debugf("Found %s member accounts attached to security hub", len(hubMemberAccountIds))
+	return hubMemberAccountIds, nil
+}
+
+func removeMembersFromHub(svc *securityhub.SecurityHub, accountIds []*string) {
+
+	// Member accounts must first be disassociated
+	_, err := svc.DisassociateMembers(&securityhub.DisassociateMembersInput{AccountIds: accountIds})
+	if err != nil {
+		logging.Logger.Errorf("[Failed] Failed to disassociate members from security hub")
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Error disassociating members from security hub",
+		}, map[string]interface{}{
+			"region": *svc.Config.Region,
+			"reason": "Unable to disassociate",
+		})
+		return
+	}
+	logging.Logger.Debugf("%s member accounts disassociated", len(accountIds))
+
+	// Once disassociated, member accounts can be deleted
+	_, err = svc.DeleteMembers(&securityhub.DeleteMembersInput{AccountIds: accountIds})
+	if err != nil {
+		logging.Logger.Errorf("[Failed] Failed to delete members from security hub")
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Error deleting members from security hub",
+		}, map[string]interface{}{
+			"region": *svc.Config.Region,
+			"reason": "Unable to delete",
+		})
+		return
+	}
+	logging.Logger.Debugf("%s member accounts deleted", len(accountIds))
+}
+
+func disassociateAdministratorAccount(svc *securityhub.SecurityHub) {
+
+	// Check for an associated admin account as it must be disassociated before disabling security hub
+	adminAccount, err := svc.GetAdministratorAccount(&securityhub.GetAdministratorAccountInput{})
+	if err != nil {
+		logging.Logger.Errorf("[Failed] Failed to check for administrator account")
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Error checking for administrator account in security hub",
+		}, map[string]interface{}{
+			"region": *svc.Config.Region,
+			"reason": "Unable to find admin account",
+		})
+	}
+	// Disassociate if one exists
+	if adminAccount.Administrator != nil {
+		_, err := svc.DisassociateFromAdministratorAccount(&securityhub.DisassociateFromAdministratorAccountInput{})
+		if err != nil {
+			logging.Logger.Errorf("[Failed] Failed to disassociate from administrator account")
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error disassociating administrator account in security hub",
+			}, map[string]interface{}{
+				"region": *svc.Config.Region,
+				"reason": "Unable to disassociate admin account",
+			})
+		} else {
+			logging.Logger.Debugf("Successfully disassociated from administrator account")
+		}
+	}
+}
+
+func nukeSecurityHub(session *session.Session, securityHubArns []string) error {
+	svc := securityhub.New(session)
+
+	// Check for and remove any member accounts in security hub
+	// Security Hub cannot be disabled with active member accounts
+	memberAccountIds, err := getAllSecurityHubMembers(svc)
+	if err != nil {
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Error finding security hub member accounts",
+		}, map[string]interface{}{
+			"region": *svc.Config.Region,
+			"reason": "Error finding security hub member accounts",
+		})
+	}
+	if err == nil && len(memberAccountIds) > 0 {
+		removeMembersFromHub(svc, memberAccountIds)
+	}
+
+	// Disassociate account from any administrator accounts
+	// Security hub cannot be disable with an active administrator account
+	disassociateAdministratorAccount(svc)
+
+	// Disable security hub
+	_, err = svc.DisableSecurityHub(&securityhub.DisableSecurityHubInput{})
+	if err != nil {
+		logging.Logger.Errorf("[Failed] Failed to disable security hub.")
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Error disabling security hub",
+		}, map[string]interface{}{
+			"region": *svc.Config.Region,
+			"reason": "Error disabling security hub",
+		})
+		e := report.Entry{
+			Identifier:   aws.StringValue(&securityHubArns[0]),
+			ResourceType: "Security Hub",
+			Error:        err,
+		}
+		report.Record(e)
+	} else {
+		logging.Logger.Debugf("[OK] Security Hub %s disabled", securityHubArns[0])
+		e := report.Entry{
+			Identifier:   aws.StringValue(&securityHubArns[0]),
+			ResourceType: "Security Hub",
+		}
+		report.Record(e)
+	}
+	return nil
+}

--- a/aws/security_hub.go
+++ b/aws/security_hub.go
@@ -41,7 +41,7 @@ func getAllSecurityHubArns(session *session.Session, excludeAfter time.Time) ([]
 func shouldIncludeHub(hub *securityhub.DescribeHubOutput, excludeAfter time.Time) bool {
 	subscribedAt, err := time.Parse(time.RFC3339, *hub.SubscribedAt)
 	if err != nil {
-		logging.Logger.Debugf("Could not parse last modified timestamp (%s) of security hub. Excluding from delete.", *hub.SubscribedAt)
+		logging.Logger.Debugf("Could not parse subscribedAt timestamp (%s) of security hub. Excluding from delete.", *hub.SubscribedAt)
 		return false
 	}
 	if excludeAfter.Before(subscribedAt) {

--- a/aws/security_hub.go
+++ b/aws/security_hub.go
@@ -39,7 +39,11 @@ func getAllSecurityHubArns(session *session.Session, excludeAfter time.Time) ([]
 }
 
 func shouldIncludeHub(hub *securityhub.DescribeHubOutput, excludeAfter time.Time) bool {
-	subscribedAt, _ := time.Parse(time.RFC3339, *hub.SubscribedAt)
+	subscribedAt, err := time.Parse(time.RFC3339, *hub.SubscribedAt)
+	if err != nil {
+		logging.Logger.Debugf("Could not parse last modified timestamp (%s) of security hub. Excluding from delete.", *hub.SubscribedAt)
+		return false
+	}
 	if excludeAfter.Before(subscribedAt) {
 		return false
 	}

--- a/aws/security_hub.go
+++ b/aws/security_hub.go
@@ -54,7 +54,7 @@ func getAllSecurityHubMembers(svc *securityhub.SecurityHub) ([]*string, error) {
 			hubMemberAccountIds = append(hubMemberAccountIds, member.AccountId)
 		}
 	}
-	logging.Logger.Debugf("Found %s member accounts attached to security hub", len(hubMemberAccountIds))
+	logging.Logger.Debugf("Found %d member accounts attached to security hub", len(hubMemberAccountIds))
 	return hubMemberAccountIds, nil
 }
 
@@ -72,7 +72,7 @@ func removeMembersFromHub(svc *securityhub.SecurityHub, accountIds []*string) {
 		})
 		return
 	}
-	logging.Logger.Debugf("%s member accounts disassociated", len(accountIds))
+	logging.Logger.Debugf("%d member accounts disassociated", len(accountIds))
 
 	// Once disassociated, member accounts can be deleted
 	_, err = svc.DeleteMembers(&securityhub.DeleteMembersInput{AccountIds: accountIds})
@@ -86,7 +86,7 @@ func removeMembersFromHub(svc *securityhub.SecurityHub, accountIds []*string) {
 		})
 		return
 	}
-	logging.Logger.Debugf("%s member accounts deleted", len(accountIds))
+	logging.Logger.Debugf("%d member accounts deleted", len(accountIds))
 }
 
 func disassociateAdministratorAccount(svc *securityhub.SecurityHub) {

--- a/aws/security_hub_test.go
+++ b/aws/security_hub_test.go
@@ -55,7 +55,7 @@ func TestSecurityHub(t *testing.T) {
 	require.NoError(t, err)
 
 	logging.Logger.Infof("Nuking security hub")
-	nukeSecurityHub(session, hubArns)
+	require.NoError(t, nukeSecurityHub(session, hubArns))
 
 	hubArns, err = getAllSecurityHubArns(session, time.Now())
 	require.NoError(t, err)

--- a/aws/security_hub_test.go
+++ b/aws/security_hub_test.go
@@ -1,0 +1,61 @@
+package aws
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/securityhub"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Security Hub tests are limited to testing the ability to find and disable security hub
+// basic features. The functionality of cloud-nuke disassociating/deleting members and
+// disassociating administrator accounts requires the use of multiple AWS accounts and the
+// ability to send and accept invitations within those accounts.
+
+func TestSecurityHub(t *testing.T) {
+	telemetry.InitTelemetry("cloud-nuke", "", "")
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, err)
+	logging.Logger.Infof("Region: %s", region)
+
+	region = "us-east-1"
+
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	svc := securityhub.New(session)
+
+	// Check if Security Hub is enabled
+	_, err = svc.DescribeHub(&securityhub.DescribeHubInput{})
+
+	if err != nil {
+		// DescribeHub throws an error if Security Hub is not enabled
+		if strings.Contains(err.Error(), "is not subscribed to AWS Security Hub") {
+			logging.Logger.Infof("Security Hub not enabled.")
+			logging.Logger.Infof("Enabling Security Hub")
+			_, err := svc.EnableSecurityHub(&securityhub.EnableSecurityHubInput{})
+			require.NoError(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+	} else {
+		logging.Logger.Infof("Security Hub already enabled")
+	}
+
+	hubArns, err := getAllSecurityHubArns(session)
+	require.NoError(t, err)
+
+	nukeSecurityHub(session, hubArns)
+
+	hubArns, err = getAllSecurityHubArns(session)
+	require.NoError(t, err)
+	assert.Empty(t, hubArns)
+}

--- a/aws/security_hub_test.go
+++ b/aws/security_hub_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -50,12 +51,12 @@ func TestSecurityHub(t *testing.T) {
 		logging.Logger.Infof("Security Hub already enabled")
 	}
 
-	hubArns, err := getAllSecurityHubArns(session)
+	hubArns, err := getAllSecurityHubArns(session, time.Now())
 	require.NoError(t, err)
 
 	nukeSecurityHub(session, hubArns)
 
-	hubArns, err = getAllSecurityHubArns(session)
+	hubArns, err = getAllSecurityHubArns(session, time.Now())
 	require.NoError(t, err)
 	assert.Empty(t, hubArns)
 }

--- a/aws/security_hub_test.go
+++ b/aws/security_hub_test.go
@@ -54,6 +54,7 @@ func TestSecurityHub(t *testing.T) {
 	hubArns, err := getAllSecurityHubArns(session, time.Now())
 	require.NoError(t, err)
 
+	logging.Logger.Infof("Nuking security hub")
 	nukeSecurityHub(session, hubArns)
 
 	hubArns, err = getAllSecurityHubArns(session, time.Now())

--- a/aws/security_hub_types.go
+++ b/aws/security_hub_types.go
@@ -1,0 +1,30 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+type SecurityHub struct {
+	HubArns []string
+}
+
+func (h SecurityHub) ResourceName() string {
+	return "security-hub"
+}
+
+func (h SecurityHub) ResourceIdentifiers() []string {
+	return h.HubArns
+}
+
+func (h SecurityHub) MaxBatchSize() int {
+	return 5
+}
+
+func (h SecurityHub) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeSecurityHub(session, identifiers); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Closes CORE-364

Adds support for nuking Security Hub

Security Hub itself is simply enabled/disabled for each region, however each instance must be cleared of Member Account links and administrator account links. 

This PR adds the ability for cloud-nuke to:
* Check if security hub is enabled, disable if so after
  * Disassociating and deleting any member accounts
  * Disassociating any administrator accounts

Supports the use of time filter, but does not support the use of configObj regex filtering (as there is only one instance per region that is enabled or disabled - technically it is named `default` but there is no control over this).

Additional testing was done manually with multiple AWS accounts to ensure the proper functionality of the member disassociation/deletion and administrator deletion.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes

<!-- One-line description of the PR that can be included in the final release notes. -->
Added support for Security Hub