### PR TITLE
Hot patch: disable telemetry for library usage

### DIFF
--- a/externalcreds/creds.go
+++ b/externalcreds/creds.go
@@ -1,6 +1,10 @@
 package externalcreds
 
 import (
+	"os"
+
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
@@ -8,6 +12,10 @@ import (
 var externalConfig *aws.Config
 
 func Set(opts *aws.Config) {
+	os.Setenv("DISABLE_TELEMETRY", "true")
+
+	telemetry.InitTelemetry("", "", "")
+
 	externalConfig = opts
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Disable telemetry when cloud-nuke is used as a library. 

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

