### PR TITLE
fix(aws): always session from externalcreds

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1686,12 +1686,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		logging.Logger.Debugf("Checking region [%d/%d]: %s", count, totalRegions, GlobalRegion)
 
 		// As there is no actual region named global we have to pick a valid one just to create the session
-		sessionRegion := defaultRegion
-		session, err := newAWSSession(sessionRegion)
-		if err != nil {
-			return nil, err
-		}
-
+		session := newSession(defaultRegion)
 		globalResources := AwsRegionResource{}
 
 		// IAM Users
@@ -2003,16 +1998,7 @@ func NukeAllResources(account *AwsAccountResources, regions []string) error {
 		}, map[string]interface{}{
 			"region": region,
 		})
-		session, err := newAWSSession(sessionRegion)
-		if err != nil {
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error creating session",
-			}, map[string]interface{}{
-				"region":        region,
-				"sessionRegion": sessionRegion,
-			})
-			return err
-		}
+		session := newSession(sessionRegion)
 		telemetry.TrackEvent(commonTelemetry.EventContext{
 			EventName: "Nuking Region",
 		}, map[string]interface{}{
@@ -2033,16 +2019,4 @@ func NukeAllResources(account *AwsAccountResources, regions []string) error {
 	}
 
 	return nil
-}
-
-func newAWSSession(awsRegion string) (*session.Session, error) {
-	sessionOptions := session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}
-	sess, err := session.NewSessionWithOptions(sessionOptions)
-	if err != nil {
-		return nil, errors.WithStackTrace(err)
-	}
-	sess.Config.Region = aws.String(awsRegion)
-	return sess, nil
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #463 

It uses `newSession` function  to get AWS Credentials from externalcreds instead of the old `newAWSSession` function which does not uses inputed config.

The inconsistent usage of this methods introduced the bug described in the attached issue.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks. --> TBD
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated: Uses AWS config stored in externalcreds for both regional and global resources, fixing #463 

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

N/A
