### PR TITLE
Implement nukeAllRdsDbSubnetGroups to delete all RDS subnet groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ The following resources support the Config file:
     - Resource type: `rds`
     - Config key: `DBInstances`
 - RDS DB Subnet Groups
-  - Resource type: `rds`
+  - Resource type: `rds-subnet-group`
   - Config key: `DBSubnetGroups`
 - Launch Templates
     - Resource type: `lt`

--- a/README.md
+++ b/README.md
@@ -453,6 +453,9 @@ The following resources support the Config file:
 - RDS, Neptune, and Document DB Resources
     - Resource type: `rds`
     - Config key: `DBInstances`
+- RDS DB Subnet Groups
+  - Resource type: `rds`
+  - Config key: `DBSubnetGroups`
 - Launch Templates
     - Resource type: `lt`
     - Config key: `LaunchTemplate`
@@ -593,6 +596,7 @@ To find out what we options are supported in the config file today, consult this
 | sagemaker-notebook-instances  | none  | ✅           | none | none       |
 | ecr                           | none  | ✅           | none | none       |
 | rds (+neptune and documentdb) | none  | ✅           | none | none       |
+| rds subnet groups             | none  | ✅           | none | none       |
 | lt                            | none  | ✅           | none | none       |
 | config-recorders              | none  | ✅           | none | none       |
 | config-rules                  | none  | ✅           | none | none       |

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -851,7 +851,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 
 			// Note: the `DescribeDBSubnetGroups` API response does not contain any information
 			// about when the subnet group was created, so we cannot apply the `excludeAfter` filter
-			subnetGroups, err := getAllRdsDbSubnetGroups(cloudNukeSession)
+			subnetGroups, err := getAllRdsDbSubnetGroups(cloudNukeSession, configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -844,6 +844,37 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End RDS DB Instances
 
+		// RDS DB Subnet Groups
+		dbSubnetGroups := DBSubnetGroups{}
+		if IsNukeable(dbSubnetGroups.ResourceName(), resourceTypes) {
+			start := time.Now()
+
+			// Note: the `DescribeDBSubnetGroups` API response does not contain any information
+			// about when the subnet group was created, so we cannot apply the `excludeAfter` filter
+			subnetGroups, err := getAllRdsDbSubnetGroups(cloudNukeSession)
+			if err != nil {
+				ge := report.GeneralError{
+					Error:        err,
+					Description:  "Unable to retrieve DB subnet groups",
+					ResourceType: dbSubnetGroups.ResourceName(),
+				}
+				report.RecordError(ge)
+			}
+
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Done Listing RDS Subnet Groups",
+			}, map[string]interface{}{
+				"region":      region,
+				"recordCount": len(subnetGroups),
+				"actionTime":  time.Since(start).Seconds(),
+			})
+			if len(subnetGroups) > 0 {
+				dbSubnetGroups.InstanceNames = awsgo.StringValueSlice(subnetGroups)
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, dbSubnetGroups)
+			}
+		}
+		// End RDS DB Subnet Groups
+
 		// RDS DB Clusters
 		// These reference the Aurora Clusters, for the use it's the same resource (rds), but AWS
 		// has different abstractions for each.

--- a/aws/rds_subnet_group.go
+++ b/aws/rds_subnet_group.go
@@ -1,0 +1,104 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	"github.com/gruntwork-io/go-commons/errors"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
+)
+
+func waitUntilRdsDbSubnetGroupDeleted(svc *rds.RDS, name *string) error {
+	// wait up to 15 minutes
+	for i := 0; i < 90; i++ {
+		_, err := svc.DescribeDBSubnetGroups(&rds.DescribeDBSubnetGroupsInput{DBSubnetGroupName: name})
+		if err != nil {
+			if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == rds.ErrCodeDBSubnetGroupNotFoundFault {
+				return nil
+			}
+
+			return err
+		}
+
+		time.Sleep(10 * time.Second)
+		logging.Logger.Debug("Waiting for RDS Cluster to be deleted")
+	}
+
+	return RdsDeleteError{name: *name}
+}
+
+func getAllRdsDbSubnetGroups(session *session.Session) ([]*string, error) {
+	svc := rds.New(session)
+
+	result, err := svc.DescribeDBSubnetGroups(&rds.DescribeDBSubnetGroupsInput{})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	var names []*string
+
+	for _, sg := range result.DBSubnetGroups {
+		names = append(names, sg.DBSubnetGroupName)
+	}
+
+	return names, nil
+}
+
+func nukeAllRdsDbSubnetGroups(session *session.Session, names []*string) error {
+	svc := rds.New(session)
+
+	if len(names) == 0 {
+		logging.Logger.Debugf("No DB Subnet groups in region %s", *session.Config.Region)
+		return nil
+	}
+
+	logging.Logger.Debugf("Deleting all DB Subnet groups in region %s", *session.Config.Region)
+	deletedNames := []*string{}
+
+	for _, name := range names {
+		_, err := svc.DeleteDBSubnetGroup(&rds.DeleteDBSubnetGroupInput{
+			DBSubnetGroupName: name,
+		})
+
+		// Record status of this resource
+		e := report.Entry{
+			Identifier:   aws.StringValue(name),
+			ResourceType: "RDS DB Subnet Group",
+			Error:        err,
+		}
+		report.Record(e)
+
+		if err != nil {
+			logging.Logger.Debugf("[Failed] %s: %s", *name, err)
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Error Nuking RDS DB subnet group",
+			}, map[string]interface{}{
+				"region": *session.Config.Region,
+			})
+		} else {
+			deletedNames = append(deletedNames, name)
+			logging.Logger.Debugf("Deleted RDS DB subnet group: %s", awsgo.StringValue(name))
+		}
+	}
+
+	if len(deletedNames) > 0 {
+		for _, name := range deletedNames {
+
+			err := waitUntilRdsDbSubnetGroupDeleted(svc, name)
+			if err != nil {
+				logging.Logger.Errorf("[Failed] %s", err)
+				return errors.WithStackTrace(err)
+			}
+		}
+	}
+
+	logging.Logger.Debugf("[OK] %d RDS DB subnet group(s) nuked in %s", len(deletedNames), *session.Config.Region)
+	return nil
+}

--- a/aws/rds_subnet_group_test.go
+++ b/aws/rds_subnet_group_test.go
@@ -1,0 +1,58 @@
+package aws
+
+import (
+	"fmt"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"strings"
+	"testing"
+)
+
+func createTestRDSSubnetGroup(t *testing.T, session *session.Session, name string) {
+	t.Logf("Creating RDS subnet group in region %s", awsgo.StringValue(session.Config.Region))
+
+	defaultVpc := aws.GetDefaultVpc(t, *session.Config.Region)
+	defaultAzSubnets := aws.GetDefaultSubnetIDsForVpc(t, *defaultVpc)
+	var subnetIds []*string
+	for _, subnet := range defaultAzSubnets {
+		subnetIds = append(subnetIds, awsgo.String(subnet))
+	}
+
+	svc := rds.New(session)
+	_, err := svc.CreateDBSubnetGroup(&rds.CreateDBSubnetGroupInput{
+		DBSubnetGroupName:        awsgo.String(name),
+		DBSubnetGroupDescription: awsgo.String(fmt.Sprintf("Test DB subnet for %s", t.Name())),
+		SubnetIds:                subnetIds,
+	})
+
+	require.NoError(t, err)
+}
+
+func TestNukeRDSSubnetGroup(t *testing.T) {
+	telemetry.InitTelemetry("cloud-nuke", "", "")
+	t.Parallel()
+
+	region, err := getRandomRegion()
+	require.NoError(t, errors.WithStackTrace(err))
+
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
+
+	subnetGroupName := "cloud-nuke-test-" + util.UniqueID()
+	createTestRDSSubnetGroup(t, session, subnetGroupName)
+
+	defer func() {
+		nukeAllRdsDbSubnetGroups(session, []*string{&subnetGroupName})
+		subnetGroupNames, _ := getAllRdsDbSubnetGroups(session)
+		assert.NotContains(t, awsgo.StringValueSlice(subnetGroupNames), strings.ToLower(subnetGroupName))
+	}()
+}

--- a/aws/rds_subnet_group_test.go
+++ b/aws/rds_subnet_group_test.go
@@ -2,18 +2,19 @@ package aws
 
 import (
 	"fmt"
+	"strings"
+	"testing"
+
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"strings"
-	"testing"
 )
 
 func createTestRDSSubnetGroup(t *testing.T, session *session.Session, name string) {
@@ -52,7 +53,7 @@ func TestNukeRDSSubnetGroup(t *testing.T) {
 
 	defer func() {
 		nukeAllRdsDbSubnetGroups(session, []*string{&subnetGroupName})
-		subnetGroupNames, _ := getAllRdsDbSubnetGroups(session)
+		subnetGroupNames, _ := getAllRdsDbSubnetGroups(session, config.Config{})
 		assert.NotContains(t, awsgo.StringValueSlice(subnetGroupNames), strings.ToLower(subnetGroupName))
 	}()
 }

--- a/aws/rds_subnet_group_types.go
+++ b/aws/rds_subnet_group_types.go
@@ -11,7 +11,7 @@ type DBSubnetGroups struct {
 }
 
 func (instance DBSubnetGroups) ResourceName() string {
-	return "rds"
+	return "rds-subnet-group"
 }
 
 // ResourceIdentifiers - The instance names of the rds db instances

--- a/aws/rds_subnet_group_types.go
+++ b/aws/rds_subnet_group_types.go
@@ -1,0 +1,34 @@
+package aws
+
+import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+type DBSubnetGroups struct {
+	InstanceNames []string
+}
+
+func (instance DBSubnetGroups) ResourceName() string {
+	return "rds"
+}
+
+// ResourceIdentifiers - The instance names of the rds db instances
+func (instance DBSubnetGroups) ResourceIdentifiers() []string {
+	return instance.InstanceNames
+}
+
+func (instance DBSubnetGroups) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 49
+}
+
+// Nuke - nuke 'em all!!!
+func (instance DBSubnetGroups) Nuke(session *session.Session, identifiers []string) error {
+	if err := nukeAllRdsDbSubnetGroups(session, awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	CloudtrailTrail            ResourceType `yaml:"CloudtrailTrail"`
 	ECRRepository              ResourceType `yaml:"ECRRepository"`
 	DBInstances                ResourceType `yaml:"DBInstances"`
+	DBSubnetGroups             ResourceType `yaml:"DBSubnetGroups"`
 	LaunchTemplate             ResourceType `yaml:"LaunchTemplate"`
 	ConfigServiceRule          ResourceType `yaml:"ConfigServiceRule"`
 	ConfigServiceRecorder      ResourceType `yaml:"ConfigServiceRecorder"`


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/471. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].
Added [Added a new resource DB Subnet Groups to cloud-nuke functionality]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

