### PR TITLE
fix iam groups nuke job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ jobs:
               --force \
               --config ./.circleci/nuke_config.yml \
               --exclude-resource-type iam \
-              --exclude-resource-type iam-group \
               --exclude-resource-type iam-service-linked-role \
               --exclude-resource-type ecr \
               --exclude-resource-type config-recorders \
@@ -68,7 +67,6 @@ jobs:
               --force \
               --config ./.circleci/nuke_config.yml \
               --exclude-resource-type iam \
-              --exclude-resource-type iam-group \
               --exclude-resource-type iam-service-linked-role \
               --exclude-resource-type ecr \
               --exclude-resource-type config-recorders \

--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -121,6 +121,36 @@ IAMUsers:
     names_regex:
       # We want to make sure the main circle-ci-test user is never deleted
       - "^circle-ci-test$"
+IAMGroups:
+  include:
+    names_regex:
+      - "^[a-zA-Z0-9]{6}-billing"
+      - "^[a-zA-Z0-9]{6}-developers"
+      - "^[a-zA-Z0-9]{6}-logs"
+      - "^[a-zA-Z0-9]{6}-read-only"
+      - "^[a-zA-Z0-9]{6}-iam-admin"
+      - "^[a-zA-Z0-9]{6}-ssh-grunt-sudo-users"
+      - "^[a-zA-Z0-9]{6}-ssh-grunt-users"
+      - "^[a-zA-Z0-9]{6}-support"
+      - "^[a-zA-Z0-9]{6}-full-access"
+      - "^[a-zA-Z0-9]{6}-use-existing-iam-roles"
+      - "^[a-zA-Z0-9]{6}-iam-user-self-mgmt"
+      - "^[a-zA-Z0-9]{6}-test-group-number-[0-9]"
+      - "^access-all-[a-zA-Z0-9]{6}"
+      - "^auto-deploy-[a-zA-Z0-9]{6}"
+      - "^cloud-nuke-test[a-zA-Z0-9]{6}"
+      - "^developers-[a-zA-Z0-9]{6}"
+      - "^full-access-[a-zA-Z0-9]{6}"
+      - "^group-cloud-nuke-test-full-user-[a-zA-Z0-9]{6}"
+      - "^iam-users-test-[0-9]-[a-zA-Z0-9]{6}"
+      - "^openvpn-server-[a-zA-Z0-9]{6}-Admins"
+      - "^openvpn-server-[a-zA-Z0-9]{6}-Users"
+      - "^read-only-[a-zA-Z0-9]{6}"
+      - "^test-group-[a-zA-Z0-9]{6}"
+      - "^test-group-[a-z]-[a-zA-Z0-9]{6}"
+      - "^test-iam-group-[a-zA-Z0-9]{6}"
+      - "^test-sudo-group-[a-z]-[a-zA-Z0-9]{6}"
+      - "^tst-openvpn-host-[a-zA-Z0-9]{6}-.*"
 IAMRoles:
   include:
     names_regex:


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes tests which depend on iam-groups.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

Added regex config for iam groups


