### PR TITLE
add sns filter by name and time

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1212,7 +1212,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End Elasticaches
 
-		//Elasticache Parameter Groups
+		// Elasticache Parameter Groups
 		elasticacheParameterGroups := ElasticacheParameterGroups{}
 		if IsNukeable(elasticacheParameterGroups.ResourceName(), resourceTypes) {
 			start := time.Now()
@@ -1238,9 +1238,9 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 				resourcesInRegion.Resources = append(resourcesInRegion.Resources, elasticacheParameterGroups)
 			}
 		}
-		//End Elasticache Parameter Groups
+		// End Elasticache Parameter Groups
 
-		//Elasticache Subnet Groups
+		// Elasticache Subnet Groups
 		elasticacheSubnetGroups := ElasticacheSubnetGroups{}
 		if IsNukeable(elasticacheSubnetGroups.ResourceName(), resourceTypes) {
 			start := time.Now()
@@ -1266,7 +1266,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 				resourcesInRegion.Resources = append(resourcesInRegion.Resources, elasticacheSubnetGroups)
 			}
 		}
-		//End Elasticache Subnet Groups
+		// End Elasticache Subnet Groups
 
 		// KMS Customer managed keys
 		customerKeys := KmsCustomerKeys{}
@@ -1519,7 +1519,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		snsTopics := SNSTopic{}
 		if IsNukeable(snsTopics.ResourceName(), resourceTypes) {
 			start := time.Now()
-			snsTopicArns, err := getAllSNSTopics(cloudNukeSession, excludeAfter, configObj)
+			snsTopicArns, err := getAllSNSTopics(cloudNukeSession, configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,
@@ -1677,7 +1677,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		// End CloudWatchAlarm
 
-		//Security Hub
+		// Security Hub
 		securityHub := SecurityHub{}
 		if IsNukeable(securityHub.ResourceName(), resourceTypes) {
 			start := time.Now()
@@ -1702,7 +1702,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 				resourcesInRegion.Resources = append(resourcesInRegion.Resources, securityHub)
 			}
 		}
-		//End Security Hub
+		// End Security Hub
 
 		if len(resourcesInRegion.Resources) > 0 {
 			account.Resources[region] = resourcesInRegion

--- a/aws/ec2_vpc.go
+++ b/aws/ec2_vpc.go
@@ -2,9 +2,10 @@ package aws
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-	"time"
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -24,7 +25,7 @@ func setFirstSeenVpcTag(svc *ec2.EC2, vpc ec2.Vpc, key string, value time.Time) 
 		Tags: []*ec2.Tag{
 			{
 				Key:   awsgo.String(key),
-				Value: awsgo.String(value.Format(time.RFC3339)),
+				Value: awsgo.String(value.Format(firstSeenTimeFormat)),
 			},
 		},
 	})
@@ -39,7 +40,7 @@ func getFirstSeenVpcTag(vpc ec2.Vpc, key string) (*time.Time, error) {
 	tags := vpc.Tags
 	for _, tag := range tags {
 		if *tag.Key == key {
-			firstSeenTime, err := time.Parse(time.RFC3339, *tag.Value)
+			firstSeenTime, err := time.Parse(firstSeenTimeFormat, *tag.Value)
 			if err != nil {
 				return nil, errors.WithStackTrace(err)
 			}

--- a/aws/ecs_cluster.go
+++ b/aws/ecs_cluster.go
@@ -1,9 +1,10 @@
 package aws
 
 import (
+	"time"
+
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
@@ -208,7 +209,7 @@ func getFirstSeenEcsClusterTag(awsSession *session.Session, clusterArn *string) 
 }
 
 func parseTimestampTag(timestamp string) (time.Time, error) {
-	parsed, err := time.Parse(time.RFC3339, timestamp)
+	parsed, err := time.Parse(firstSeenTimeFormat, timestamp)
 	if err != nil {
 		logging.Logger.Debugf("Error parsing the timestamp into a `RFC3339` Time format")
 		return parsed, errors.WithStackTrace(err)
@@ -218,5 +219,5 @@ func parseTimestampTag(timestamp string) (time.Time, error) {
 }
 
 func formatTimestampTag(timestamp time.Time) string {
-	return timestamp.Format(time.RFC3339)
+	return timestamp.Format(firstSeenTimeFormat)
 }

--- a/aws/globals.go
+++ b/aws/globals.go
@@ -1,9 +1,15 @@
 package aws
 
-// A tag used to set custom AWS Tags to resources that do not support `created at` timestamp> - EIP & ECS Clusters.
-// This is used in relation to the `--older-than <duration>` filtering that `cloud-nuke` allows.
-// Due to its destructive nature, `cloud-nuke` has been configured not to delete AWS resources without known creation time,
-// and instead tag them with the `firstSeenTagKey`.
-// The next time `cloud-nuke aws --older-than <duration>` is run, it will use the tag to determine if the AWS resource should be deleted or not.
+import "time"
 
-const firstSeenTagKey = "cloud-nuke-first-seen"
+const (
+	// A tag used to set custom AWS Tags to resources that do not support `created at` timestamp> - EIP & ECS Clusters.
+	// This is used in relation to the `--older-than <duration>` filtering that `cloud-nuke` allows.
+	// Due to its destructive nature, `cloud-nuke` has been configured not to delete AWS resources without known creation time,
+	// and instead tag them with the `firstSeenTagKey`.
+	// The next time `cloud-nuke aws --older-than <duration>` is run, it will use the tag to determine if the AWS resource should be deleted or not.
+	firstSeenTagKey = "cloud-nuke-first-seen"
+
+	// The time format of the `firstSeenTagKey` tag value.
+	firstSeenTimeFormat = time.RFC3339
+)

--- a/aws/sns.go
+++ b/aws/sns.go
@@ -78,7 +78,7 @@ func getFirstSeenSNSTopicTag(ctx context.Context, svc *sns.Client, topicArn, key
 
 	for i := range response.Tags {
 		if *response.Tags[i].Key == key {
-			firstSeenTime, err := time.Parse(time.RFC3339, *response.Tags[i].Value)
+			firstSeenTime, err := time.Parse(firstSeenTimeFormat, *response.Tags[i].Value)
 			if err != nil {
 				return nil, err
 			}
@@ -92,7 +92,7 @@ func getFirstSeenSNSTopicTag(ctx context.Context, svc *sns.Client, topicArn, key
 
 // setFirstSeenSNSTopic will append a tag to the SNS Topic that details the first seen time.
 func setFirstSeenSNSTopicTag(ctx context.Context, svc *sns.Client, topicArn, key string, value time.Time) error {
-	timeValue := value.Format(time.RFC3339)
+	timeValue := value.Format(firstSeenTimeFormat)
 
 	_, err := svc.TagResource(
 		ctx,

--- a/aws/sns_test.go
+++ b/aws/sns_test.go
@@ -75,10 +75,10 @@ func TestListSNSTopics(t *testing.T) {
 	telemetry.InitTelemetry("cloud-nuke", "")
 	t.Parallel()
 
-	// region, err := getRandomRegion()
-	// require.NoError(t, err)
+	region, err := getRandomRegion()
+	require.NoError(t, err)
 	session, err := session.NewSession(&awsgo.Config{
-		Region: awsgo.String("us-east-1"),
+		Region: awsgo.String(region),
 	},
 	)
 	if err != nil {

--- a/aws/sns_test.go
+++ b/aws/sns_test.go
@@ -222,7 +222,7 @@ func TestSNSFirstSeenTagLogicIsCorrect(t *testing.T) {
 
 	// We lose some precision when we tag the resource with the time due to the format, so to compare like for like,
 	// cast both to the same string format, which is also the same format used by the firstSeenSNSTopicTag function
-	assert.Equal(t, now.Format(time.RFC3339), firstSeen.Format(time.RFC3339))
+	assert.Equal(t, now.Format(firstSeenTimeFormat), firstSeen.Format(firstSeenTimeFormat))
 }
 
 func TestNukeSNSTopicWithTimeExclusion(t *testing.T) {

--- a/aws/sns_test.go
+++ b/aws/sns_test.go
@@ -165,6 +165,9 @@ func TestNukeSNSTopicWithFilter(t *testing.T) {
 	testSNSTopic2, createTestErr2 := createTestSNSTopic(t, session, testSNSTopicName2)
 	require.NoError(t, createTestErr2)
 
+	// as sns topics are online, lets clean up after this test
+	defer nukeAllSNSTopics(session, []*string{testSNSTopic.Arn, testSNSTopic2.Arn})
+
 	topics, err := getAllSNSTopics(session, config.Config{
 		SNS: config.ResourceType{
 			ExcludeRule: config.FilterRule{
@@ -175,8 +178,7 @@ func TestNukeSNSTopicWithFilter(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	defer nukeAllSNSTopics(session, []*string{testSNSTopic.Arn, testSNSTopic2.Arn})
-
+	// with the filters, we expect to only see the testSNSTopic in the findings, and not the testSNSTopic2
 	assert.NotContains(t, aws.StringValueSlice(topics), aws.StringValue(testSNSTopic2.Arn))
 	assert.Contains(t, aws.StringValueSlice(topics), aws.StringValue(testSNSTopic.Arn))
 }

--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	ConfigServiceRecorder      ResourceType `yaml:"ConfigServiceRecorder"`
 	CloudWatchAlarm            ResourceType `yaml:"CloudWatchAlarm"`
 	Redshift                   ResourceType `yaml:"Redshift"`
+	SNS                        ResourceType `yaml:"SNS"`
 }
 
 type ResourceType struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,6 +56,7 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #359 and #480.

<!-- Description of the changes introduced by this PR. -->

Adds the ability to include/exclude SNS topic by name for nuking. Additionally, the ability to exclude SNS topics by time is also added.

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

Adds the ability to include/exclude SNS topic by name for nuking. Additionally, the ability to exclude SNS topics by time is also added.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

