### PR TITLE
don't nuke deploy runners

### DIFF
--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -115,7 +115,6 @@ CloudWatchLogGroup:
       - "openvpn-server-[a-zA-Z0-9]{6}_log_group$"
       - "vpc-test-[a-zA-Z0-9]{6}.*"
       - "cloud-nuke-test-[a-zA-Z0-9]{6}"
-
 IAMUsers:
   exclude:
     names_regex:
@@ -239,3 +238,11 @@ VPC:
   exclude:
     names_regex:
       - "^mgmt"
+ECSCluster:
+  exclude:
+    names_regex:
+      - "^ecs-deploy-runner"
+LambdaFunction:
+  exclude:
+    names_regex:
+      - "^ecs-deploy-runner-invoker"


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Prevents nuking ecs-deploy-runner in default config

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)


