### PR TITLE
add acm to resourcesInRegion

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1781,6 +1781,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 			})
 			if len(acmArns) > 0 {
 				acm.ARNs = acmArns
+				resourcesInRegion.Resources = append(resourcesInRegion.Resources, acm)
 			}
 		}
 		// End ACM


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds ACM resources to the resourcesInRegion list. 
Looks like this one slipped through the previous PR.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


