### PR TITLE
Mocking AWS Calls for Unit Testing for API Gateway

### DIFF
--- a/aws/apigateway_test.go
+++ b/aws/apigateway_test.go
@@ -1,153 +1,111 @@
 package aws
 
 import (
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/aws/aws-sdk-go/service/apigateway/apigatewayiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
-	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type TestAPIGateway struct {
-	ID   *string
-	Name *string
+type mockedApiGateway struct {
+	apigatewayiface.APIGatewayAPI
+	GetRestApisResp   apigateway.GetRestApisOutput
+	DeleteRestApiResp apigateway.DeleteRestApiOutput
 }
 
-func createTestAPIGateway(t *testing.T, session *session.Session, name string) (*TestAPIGateway, error) {
-	svc := apigateway.New(session)
-
-	testGw := &TestAPIGateway{
-		Name: aws.String(name),
-	}
-
-	param := &apigateway.CreateRestApiInput{
-		Name: aws.String(name),
-	}
-
-	output, err := svc.CreateRestApi(param)
-	if err != nil {
-		assert.Failf(t, "Could not create test API Gateway: %s", errors.WithStackTrace(err).Error())
-	}
-
-	testGw.ID = output.Id
-
-	return testGw, nil
+func (m mockedApiGateway) GetRestApis(*apigateway.GetRestApisInput) (*apigateway.GetRestApisOutput, error) {
+	// Only need to return mocked response output
+	return &m.GetRestApisResp, nil
 }
 
-func TestListAPIGateways(t *testing.T) {
+func (m mockedApiGateway) DeleteRestApi(*apigateway.DeleteRestApiInput) (*apigateway.DeleteRestApiOutput, error) {
+	// Only need to return mocked response output
+	return &m.DeleteRestApiResp, nil
+}
+
+func TestAPIGatewayGetAllAndNukeAll(t *testing.T) {
 	telemetry.InitTelemetry("cloud-nuke", "")
 	t.Parallel()
 
-	region, err := getRandomRegion()
+	testApiID := "aws-nuke-test-" + util.UniqueID()
+	apiGateway := ApiGateway{
+		Client: mockedApiGateway{
+			GetRestApisResp: apigateway.GetRestApisOutput{
+				Items: []*apigateway.RestApi{
+					{Id: aws.String(testApiID)},
+				},
+			},
+			DeleteRestApiResp: apigateway.DeleteRestApiOutput{},
+		},
+	}
+
+	apis, err := apiGateway.getAll(time.Now(), config.Config{})
 	require.NoError(t, err)
-	session, err := session.NewSession(&awsgo.Config{
-		Region: awsgo.String(region),
-	},
-	)
-	if err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
+	require.Contains(t, awsgo.StringValueSlice(apis), testApiID)
 
-	apigwName := "aws-nuke-test-" + util.UniqueID()
-	testGw, createTestGwErr := createTestAPIGateway(t, session, apigwName)
-	require.NoError(t, createTestGwErr)
-	// clean up after this test
-	defer nukeAllAPIGateways(session, []*string{testGw.ID})
-
-	apigwIds, err := getAllAPIGateways(session, time.Now(), config.Config{})
-	if err != nil {
-		assert.Fail(t, "Unable to fetch list of API Gateways (v1)")
-	}
-
-	assert.Contains(t, awsgo.StringValueSlice(apigwIds), aws.StringValue(testGw.ID))
+	err = apiGateway.nukeAll([]*string{aws.String(testApiID)})
+	require.NoError(t, err)
 }
 
-func TestTimeFilterExclusionNewlyCreatedAPIGateway(t *testing.T) {
+func TestAPIGatewayGetAllTimeFilter(t *testing.T) {
 	telemetry.InitTelemetry("cloud-nuke", "")
 	t.Parallel()
 
-	region, err := getRandomRegion()
+	testApiID := "aws-nuke-test-" + util.UniqueID()
+	now := time.Now()
+	apiGateway := ApiGateway{
+		Client: mockedApiGateway{
+			GetRestApisResp: apigateway.GetRestApisOutput{
+				Items: []*apigateway.RestApi{{
+					Id:          aws.String(testApiID),
+					CreatedDate: aws.Time(now),
+				}},
+			},
+		},
+	}
+
+	// test API is not excluded from the filter
+	IDs, err := apiGateway.getAll(now.Add(1), config.Config{})
 	require.NoError(t, err)
+	assert.Contains(t, aws.StringValueSlice(IDs), testApiID)
 
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	// test API being excluded from the filter
+	apiGwIdsOlder, err := apiGateway.getAll(now.Add(-1), config.Config{})
 	require.NoError(t, err)
-
-	apigwName := "aws-nuke-test-" + util.UniqueID()
-
-	testGw, createTestGwErr := createTestAPIGateway(t, session, apigwName)
-	require.NoError(t, createTestGwErr)
-	defer nukeAllAPIGateways(session, []*string{testGw.ID})
-
-	// Assert API Gateway is picked up without filters
-	apigwIds, err := getAllAPIGateways(session, time.Now(), config.Config{})
-	require.NoError(t, err)
-	assert.Contains(t, aws.StringValueSlice(apigwIds), aws.StringValue(testGw.ID))
-
-	// Assert API Gateway doesn't appear when we look at API Gateways older than 1 Hour
-	olderThan := time.Now().Add(-1 * time.Hour)
-	apiGwIdsOlder, err := getAllAPIGateways(session, olderThan, config.Config{})
-	require.NoError(t, err)
-	assert.NotContains(t, aws.StringValueSlice(apiGwIdsOlder), aws.StringValue(testGw.ID))
-}
-
-func TestNukeAPIGatewayOne(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
-	t.Parallel()
-
-	region, err := getRandomRegion()
-	require.NoError(t, err)
-
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-
-	apigwName := "aws-nuke-test-" + util.UniqueID()
-	// We ignore errors in the delete call here, because it is intended to be a stop gap in case there is a bug in nuke.
-	testGw, createTestErr := createTestAPIGateway(t, session, apigwName)
-	require.NoError(t, createTestErr)
-
-	nukeErr := nukeAllAPIGateways(session, []*string{testGw.ID})
-	require.NoError(t, nukeErr)
-
-	// Make sure the API Gateway was deleted
-	apigwIds, err := getAllAPIGateways(session, time.Now(), config.Config{})
-	require.NoError(t, err)
-
-	assert.NotContains(t, aws.StringValueSlice(apigwIds), aws.StringValue(testGw.ID))
+	assert.NotContains(t, aws.StringValueSlice(apiGwIdsOlder), testApiID)
 }
 
 func TestNukeAPIGatewayMoreThanOne(t *testing.T) {
 	telemetry.InitTelemetry("cloud-nuke", "")
 	t.Parallel()
 
-	region, err := getRandomRegion()
+	testApiID1 := "aws-nuke-test-" + util.UniqueID()
+	testApiID2 := "aws-nuke-test-" + util.UniqueID()
+	apiGateway := ApiGateway{
+		Client: mockedApiGateway{
+			GetRestApisResp: apigateway.GetRestApisOutput{
+				Items: []*apigateway.RestApi{
+					{Id: aws.String(testApiID1)},
+					{Id: aws.String(testApiID2)},
+				},
+			},
+			DeleteRestApiResp: apigateway.DeleteRestApiOutput{},
+		},
+	}
+
+	apis, err := apiGateway.getAll(time.Now(), config.Config{})
 	require.NoError(t, err)
+	require.Contains(t, awsgo.StringValueSlice(apis), testApiID1)
+	require.Contains(t, awsgo.StringValueSlice(apis), testApiID2)
 
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	err = apiGateway.nukeAll([]*string{aws.String(testApiID1), aws.String(testApiID2)})
 	require.NoError(t, err)
-
-	apigwName := "aws-nuke-test-" + util.UniqueID()
-	apigwName2 := "aws-nuke-test-" + util.UniqueID()
-	// We ignore errors in the delete call here, because it is intended to be a stop gap in case there is a bug in nuke.
-	testGw, createTestErr := createTestAPIGateway(t, session, apigwName)
-	require.NoError(t, createTestErr)
-	testGw2, createTestErr2 := createTestAPIGateway(t, session, apigwName2)
-	require.NoError(t, createTestErr2)
-
-	nukeErr := nukeAllAPIGateways(session, []*string{testGw.ID, testGw2.ID})
-	require.NoError(t, nukeErr)
-
-	// Make sure the API Gateway was deleted
-	apigwIds, err := getAllAPIGateways(session, time.Now(), config.Config{})
-	require.NoError(t, err)
-
-	assert.NotContains(t, aws.StringValueSlice(apigwIds), aws.StringValue(testGw.ID))
-	assert.NotContains(t, aws.StringValueSlice(apigwIds), aws.StringValue(testGw2.ID))
 }

--- a/aws/apigateway_types.go
+++ b/aws/apigateway_types.go
@@ -3,29 +3,34 @@ package aws
 import (
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/apigateway/apigatewayiface"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
 type ApiGateway struct {
-	Ids []string
+	Client apigatewayiface.APIGatewayAPI
+	Region string
+	Ids    []string
 }
 
-func (apigateway ApiGateway) ResourceName() string {
+func (gateway ApiGateway) ResourceName() string {
 	return "apigateway"
 }
 
-func (apigateway ApiGateway) ResourceIdentifiers() []string {
-	return apigateway.Ids
+func (gateway ApiGateway) ResourceIdentifiers() []string {
+	return gateway.Ids
 }
 
-func (apigateway ApiGateway) MaxBatchSize() int {
+func (gateway ApiGateway) MaxBatchSize() int {
 	return 10
 }
 
-func (apigateway ApiGateway) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllAPIGateways(session, awsgo.StringSlice(identifiers)); err != nil {
+func (gateway ApiGateway) Nuke(session *session.Session, identifiers []string) error {
+	// TODO(james): stop passing in session argument as it is included as part of the gateway struct.
+	if err := gateway.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
+
 	return nil
 }
 

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"github.com/aws/aws-sdk-go/service/apigateway"
 	"math/rand"
 	"sort"
 	"strings"
@@ -1463,10 +1464,13 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		// End Redshift Clusters
 
 		// API Gateways (v1)
-		apiGateways := ApiGateway{}
+		apiGateways := ApiGateway{
+			Client: apigateway.New(cloudNukeSession),
+			Region: region,
+		}
 		if IsNukeable(apiGateways.ResourceName(), resourceTypes) {
 			start := time.Now()
-			gatewayIds, err := getAllAPIGateways(cloudNukeSession, excludeAfter, configObj)
+			gatewayIds, err := apiGateways.getAll(excludeAfter, configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/test_utils.go
+++ b/aws/test_utils.go
@@ -1,0 +1,19 @@
+package aws
+
+import (
+	"testing"
+
+	terratestaws "github.com/gruntwork-io/terratest/modules/aws"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/stretchr/testify/require"
+)
+
+func GetTestSession(t *testing.T, approvedRegions []string, forbiddenRegions []string) *session.Session {
+	region := terratestaws.GetRandomStableRegion(t, approvedRegions, forbiddenRegions)
+	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	require.NoError(t, err)
+
+	return session
+}

--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,7 @@ type ResourceType struct {
 
 type FilterRule struct {
 	NamesRegExp []Expression `yaml:"names_regex"`
+	// TODO(james): consider adding time filter rule here instead of passing in as function argument in other place.
 }
 
 type Expression struct {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Making changes in code to have proper unit testing without calling AWS API - https://aws.amazon.com/blogs/developer/mocking-out-then-aws-sdk-for-go-for-unit-testing/. 

Currently, we call AWS API within unit tests and it causes several problems: 
* QuotaLimit
* Timeout

Also, I believe we can reduce the code inside `GetAllResources` function significantly with the new pattern of encapsulating "get resource" logic inside the ResourceType. Afterall, a better name for `ResourceType` would be just `Resource` but will make changes incrementally once this change looks good for everyone. 

Tackling issue: https://github.com/gruntwork-io/cloud-nuke/issues/494

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated [Mocking AWS Calls for Unit Testing for API Gateway]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

