### PR TITLE
Refactor EksCluster ResourceType

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/aws/aws-sdk-go/service/eks"
 	"math/rand"
 	"sort"
 	"strings"
@@ -791,10 +792,13 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		// End ECS resources
 
 		// EKS resources
-		eksClusters := EKSClusters{}
+		eksClusters := EKSClusters{
+			Client: eks.New(cloudNukeSession),
+			Region: region,
+		}
 		if IsNukeable(eksClusters.ResourceName(), resourceTypes) {
 			start := time.Now()
-			eksClusterNames, err := getAllEksClusters(cloudNukeSession, excludeAfter, configObj)
+			eksClusterNames, err := eksClusters.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/eks_types.go
+++ b/aws/eks_types.go
@@ -3,11 +3,14 @@ package aws
 import (
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
 // EKSClusters - Represents all EKS clusters found in a region
 type EKSClusters struct {
+	Client   eksiface.EKSAPI
+	Region   string
 	Clusters []string
 }
 
@@ -30,7 +33,7 @@ func (clusters EKSClusters) MaxBatchSize() int {
 
 // Nuke - nuke all EKS Cluster resources
 func (clusters EKSClusters) Nuke(awsSession *session.Session, identifiers []string) error {
-	if err := nukeAllEksClusters(awsSession, awsgo.StringSlice(identifiers)); err != nil {
+	if err := clusters.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 	return nil


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Tackling issue: https://github.com/gruntwork-io/cloud-nuke/issues/494

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated [Refactor EksCluster ResourceType]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

