### PR TITLE
Refactor RDS Cluster ResourceType

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -12,10 +12,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/acm"
-	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/externalcreds"
@@ -884,10 +882,13 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		// RDS DB Clusters
 		// These reference the Aurora Clusters, for the use it's the same resource (rds), but AWS
 		// has different abstractions for each.
-		dbClusters := DBClusters{}
+		dbClusters := DBClusters{
+			Client: rds.New(cloudNukeSession),
+			Region: region,
+		}
 		if IsNukeable(dbClusters.ResourceName(), resourceTypes) {
 			start := time.Now()
-			clustersNames, err := getAllRdsClusters(cloudNukeSession, excludeAfter)
+			clustersNames, err := dbClusters.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/rds_cluster.go
+++ b/aws/rds_cluster.go
@@ -69,7 +69,6 @@ func (instance DBClusters) nukeAll(names []*string) error {
 			SkipFinalSnapshot:   awsgo.Bool(true),
 		}
 
-		print("deleting1")
 		_, err := instance.Client.DeleteDBCluster(params)
 
 		// Record status of this resource
@@ -93,23 +92,19 @@ func (instance DBClusters) nukeAll(names []*string) error {
 		}
 	}
 
-	print("deleting2")
 	if len(deletedNames) > 0 {
 		for _, name := range deletedNames {
 
-			print("deleting3")
 			err := instance.waitUntilRdsClusterDeleted(&rds.DescribeDBClustersInput{
 				DBClusterIdentifier: name,
 			})
-			print("deleting4")
 			if err != nil {
 				logging.Logger.Errorf("[Failed] %s", err)
 				return errors.WithStackTrace(err)
 			}
 		}
 	}
-	//
-	//print("deleting5")
-	//logging.Logger.Debugf("[OK] %d RDS DB Cluster(s) nuked in %s", len(deletedNames), instance.Region)
+
+	logging.Logger.Debugf("[OK] %d RDS DB Cluster(s) nuked in %s", len(deletedNames), instance.Region)
 	return nil
 }

--- a/aws/rds_cluster_types.go
+++ b/aws/rds_cluster_types.go
@@ -3,10 +3,13 @@ package aws
 import (
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
 type DBClusters struct {
+	Client        rdsiface.RDSAPI
+	Region        string
 	InstanceNames []string
 }
 
@@ -26,7 +29,7 @@ func (instance DBClusters) MaxBatchSize() int {
 
 // Nuke - nuke 'em all!!!
 func (instance DBClusters) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllRdsClusters(session, awsgo.StringSlice(identifiers)); err != nil {
+	if err := instance.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	ACM                        ResourceType               `yaml:"ACM"`
 	SNS                        ResourceType               `yaml:"SNS"`
 	BackupVault                ResourceType               `yaml:"BackupVault"`
+	DBClusters                 ResourceType               `yaml:"DBClusters"`
 }
 
 type KMSCustomerKeyResourceType struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -62,6 +62,7 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 	}
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Tackling issue: https://github.com/gruntwork-io/cloud-nuke/issues/494

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated [Refactor RDS Cluster ResourceType]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

