### PR TITLE
Refactor AMI Resource Type

### DIFF
--- a/aws/ami.go
+++ b/aws/ami.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Returns a formatted string of AMI Image ids
-func (ami AMI) getAll(configObj config.Config) ([]*string, error) {
+func (ami AMIs) getAll(configObj config.Config) ([]*string, error) {
 	params := &ec2.DescribeImagesInput{
 		Owners: []*string{awsgo.String("self")},
 	}
@@ -46,7 +46,7 @@ func (ami AMI) getAll(configObj config.Config) ([]*string, error) {
 }
 
 // Deletes all AMI
-func (ami AMI) nukeAll(imageIds []*string) error {
+func (ami AMIs) nukeAll(imageIds []*string) error {
 	if len(imageIds) == 0 {
 		logging.Logger.Debugf("No AMI to nuke in region %s", ami.Region)
 		return nil

--- a/aws/ami_test.go
+++ b/aws/ami_test.go
@@ -34,7 +34,7 @@ func TestAMIGetAll(t *testing.T) {
 	testName := "test-ami"
 	testImageId := "test-image-id"
 	now := time.Now()
-	acm := AMI{
+	acm := AMIs{
 		Client: mockedAMI{
 			DescribeImagesOutput: ec2.DescribeImagesOutput{
 				Images: []*ec2.Image{{
@@ -75,7 +75,7 @@ func TestAMINukeAll(t *testing.T) {
 	t.Parallel()
 
 	testName := "test-ami"
-	acm := AMI{
+	acm := AMIs{
 		Client: mockedAMI{
 			DeregisterImageOutput: ec2.DeregisterImageOutput{},
 		},

--- a/aws/ami_types.go
+++ b/aws/ami_types.go
@@ -15,23 +15,23 @@ type AMIs struct {
 }
 
 // ResourceName - the simple name of the aws resource
-func (image AMIs) ResourceName() string {
+func (ami AMIs) ResourceName() string {
 	return "ami"
 }
 
 // ResourceIdentifiers - The AMI image ids
-func (image AMIs) ResourceIdentifiers() []string {
-	return image.ImageIds
+func (ami AMIs) ResourceIdentifiers() []string {
+	return ami.ImageIds
 }
 
-func (image AMIs) MaxBatchSize() int {
+func (ami AMIs) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
 	return 49
 }
 
 // Nuke - nuke 'em all!!!
-func (image AMIs) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllAMIs(session, awsgo.StringSlice(identifiers)); err != nil {
+func (ami AMIs) Nuke(session *session.Session, identifiers []string) error {
+	if err := ami.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -764,7 +764,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		if IsNukeable(amis.ResourceName(), resourceTypes) {
 			start := time.Now()
-			imageIds, err := getAllAMIs(cloudNukeSession, region, excludeAfter)
+			imageIds, err := amis.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/commands/cli_test.go
+++ b/commands/cli_test.go
@@ -50,7 +50,7 @@ func TestIsValidResourceType(t *testing.T) {
 
 func TestIsNukeable(t *testing.T) {
 	ec2ResourceName := aws.EC2Instances{}.ResourceName()
-	amiResourceName := aws.AMI{}.ResourceName()
+	amiResourceName := aws.AMIs{}.ResourceName()
 
 	assert.Equal(t, aws.IsNukeable(ec2ResourceName, []string{ec2ResourceName}), true)
 	assert.Equal(t, aws.IsNukeable(ec2ResourceName, []string{"all"}), true)

--- a/commands/cli_test.go
+++ b/commands/cli_test.go
@@ -50,7 +50,7 @@ func TestIsValidResourceType(t *testing.T) {
 
 func TestIsNukeable(t *testing.T) {
 	ec2ResourceName := aws.EC2Instances{}.ResourceName()
-	amiResourceName := aws.AMIs{}.ResourceName()
+	amiResourceName := aws.AMI{}.ResourceName()
 
 	assert.Equal(t, aws.IsNukeable(ec2ResourceName, []string{ec2ResourceName}), true)
 	assert.Equal(t, aws.IsNukeable(ec2ResourceName, []string{"all"}), true)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Part of https://github.com/gruntwork-io/cloud-nuke/issues/494. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated [Refactor AMI Resource Type]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

