### PR TITLE
Refactor auto scaling group resource type

### DIFF
--- a/aws/asg_test.go
+++ b/aws/asg_test.go
@@ -1,197 +1,84 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"regexp"
 	"testing"
 	"time"
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/logging"
-	"github.com/gruntwork-io/cloud-nuke/util"
-	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/stretchr/testify/assert"
 )
 
-func createTestAutoScalingGroup(t *testing.T, session *session.Session, name string) {
-	svc := autoscaling.New(session)
-	instance := createTestEC2Instance(t, session, name, false)
-
-	param := &autoscaling.CreateAutoScalingGroupInput{
-		AutoScalingGroupName: &name,
-		InstanceId:           instance.InstanceId,
-		MinSize:              awsgo.Int64(1),
-		MaxSize:              awsgo.Int64(2),
-	}
-
-	_, err := svc.CreateAutoScalingGroup(param)
-	if err != nil {
-		assert.Failf(t, "Could not create test ASG", errors.WithStackTrace(err).Error())
-	}
-
-	err = svc.WaitUntilGroupExists(&autoscaling.DescribeAutoScalingGroupsInput{
-		AutoScalingGroupNames: []*string{&name},
-	})
-
-	if err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
+type mockedASGroups struct {
+	autoscalingiface.AutoScalingAPI
+	DescribeAutoScalingGroupsResp autoscaling.DescribeAutoScalingGroupsOutput
+	DeleteAutoScalingGroupResp    autoscaling.DeleteAutoScalingGroupOutput
 }
 
-func TestListAutoScalingGroups(t *testing.T) {
+func (m mockedASGroups) DescribeAutoScalingGroups(input *autoscaling.DescribeAutoScalingGroupsInput) (*autoscaling.DescribeAutoScalingGroupsOutput, error) {
+	return &m.DescribeAutoScalingGroupsResp, nil
+}
+
+func (m mockedASGroups) DeleteAutoScalingGroup(input *autoscaling.DeleteAutoScalingGroupInput) (*autoscaling.DeleteAutoScalingGroupOutput, error) {
+	return &m.DeleteAutoScalingGroupResp, nil
+}
+
+func (m mockedASGroups) WaitUntilGroupNotExists(input *autoscaling.DescribeAutoScalingGroupsInput) error {
+	return nil
+}
+
+func TestAutoScalingGroupGetAll(t *testing.T) {
 	telemetry.InitTelemetry("cloud-nuke", "")
 	t.Parallel()
 
-	region, err := getRandomRegion()
-	if err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
-	session, err := session.NewSession(&awsgo.Config{
-		Region: awsgo.String(region)},
-	)
+	testName := "cloud-nuke-test"
+	now := time.Now()
+	ag := ASGroups{
+		Client: mockedASGroups{
+			DescribeAutoScalingGroupsResp: autoscaling.DescribeAutoScalingGroupsOutput{
+				AutoScalingGroups: []*autoscaling.Group{{
+					AutoScalingGroupName: awsgo.String(testName),
+					CreatedTime:          awsgo.Time(now),
+				}}}}}
 
-	if err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
+	// empty filter
+	groups, err := ag.getAll(config.Config{})
+	assert.NoError(t, err)
+	assert.Contains(t, awsgo.StringValueSlice(groups), testName)
 
-	uniqueTestID := "cloud-nuke-test-" + util.UniqueID()
-	createTestAutoScalingGroup(t, session, uniqueTestID)
-	// clean up after this test
-	defer nukeAllAutoScalingGroups(session, []*string{&uniqueTestID})
-	defer nukeAllEc2Instances(session, findEC2InstancesByNameTag(t, session, uniqueTestID))
-
-	groupNames, err := getAllAutoScalingGroups(session, region, time.Now().Add(1*time.Hour*-1), config.Config{})
-	if err != nil {
-		assert.Fail(t, "Unable to fetch list of Auto Scaling Groups")
-	}
-
-	assert.NotContains(t, awsgo.StringValueSlice(groupNames), uniqueTestID)
-
-	groupNames, err = getAllAutoScalingGroups(session, region, time.Now().Add(1*time.Hour), config.Config{})
-	if err != nil {
-		assert.Fail(t, "Unable to fetch list of Auto Scaling Groups")
-	}
-
-	assert.Contains(t, awsgo.StringValueSlice(groupNames), uniqueTestID)
-}
-
-func TestNukeAutoScalingGroups(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
-	t.Parallel()
-
-	region, err := getRandomRegion()
-	if err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
-	session, err := session.NewSession(&awsgo.Config{
-		Region: awsgo.String(region)},
-	)
-	svc := autoscaling.New(session)
-
-	if err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
-
-	uniqueTestID := "cloud-nuke-test-" + util.UniqueID()
-	createTestAutoScalingGroup(t, session, uniqueTestID)
-
-	// clean up ec2 instance created by the above call
-	defer nukeAllEc2Instances(session, findEC2InstancesByNameTag(t, session, uniqueTestID))
-
-	_, err = svc.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
-		AutoScalingGroupNames: []*string{&uniqueTestID},
-	})
-
-	if err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
-
-	if err := nukeAllAutoScalingGroups(session, []*string{&uniqueTestID}); err != nil {
-		assert.Fail(t, errors.WithStackTrace(err).Error())
-	}
-
-	groupNames, err := getAllAutoScalingGroups(session, region, time.Now().Add(1*time.Hour), config.Config{})
-	if err != nil {
-		assert.Fail(t, "Unable to fetch list of Auto Scaling Groups")
-	}
-
-	assert.NotContains(t, awsgo.StringValueSlice(groupNames), uniqueTestID)
-}
-
-// Test config file filtering works as expected
-func TestShouldIncludeAutoScalingGroup(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
-	mockAutoScalingGroup := &autoscaling.Group{
-		AutoScalingGroupName: awsgo.String("cloud-nuke-test"),
-		CreatedTime:          awsgo.Time(time.Now()),
-	}
-
-	mockExpression, err := regexp.Compile("^cloud-nuke-*")
-	if err != nil {
-		logging.Logger.Fatalf("There was an error compiling regex expression %v", err)
-	}
-
-	mockExcludeConfig := config.Config{
+	// name filter
+	groups, err = ag.getAll(config.Config{
 		AutoScalingGroup: config.ResourceType{
 			ExcludeRule: config.FilterRule{
-				NamesRegExp: []config.Expression{
-					{
-						RE: *mockExpression,
-					},
-				},
-			},
-		},
-	}
+				NamesRegExp: []config.Expression{{
+					RE: *regexp.MustCompile("^cloud-nuke-*"),
+				}}}}})
+	assert.NoError(t, err)
+	assert.NotContains(t, awsgo.StringValueSlice(groups), testName)
 
-	mockIncludeConfig := config.Config{
+	// time filter
+	groups, err = ag.getAll(config.Config{
 		AutoScalingGroup: config.ResourceType{
-			IncludeRule: config.FilterRule{
-				NamesRegExp: []config.Expression{
-					{
-						RE: *mockExpression,
-					},
-				},
-			},
-		},
-	}
+			ExcludeRule: config.FilterRule{
+				TimeAfter: awsgo.Time(now.Add(-1)),
+			}}})
+	assert.NoError(t, err)
+	assert.NotContains(t, awsgo.StringValueSlice(groups), testName)
+}
 
-	cases := []struct {
-		Name             string
-		AutoScalingGroup *autoscaling.Group
-		Config           config.Config
-		ExcludeAfter     time.Time
-		Expected         bool
-	}{
-		{
-			Name:             "ConfigExclude",
-			AutoScalingGroup: mockAutoScalingGroup,
-			Config:           mockExcludeConfig,
-			ExcludeAfter:     time.Now().Add(1 * time.Hour),
-			Expected:         false,
-		},
-		{
-			Name:             "ConfigInclude",
-			AutoScalingGroup: mockAutoScalingGroup,
-			Config:           mockIncludeConfig,
-			ExcludeAfter:     time.Now().Add(1 * time.Hour),
-			Expected:         true,
-		},
-		{
-			Name:             "NotOlderThan",
-			AutoScalingGroup: mockAutoScalingGroup,
-			Config:           config.Config{},
-			ExcludeAfter:     time.Now().Add(1 * time.Hour * -1),
-			Expected:         false,
-		},
-	}
+func TestAutoScalingGroupNukeAll(t *testing.T) {
+	telemetry.InitTelemetry("cloud-nuke", "")
+	t.Parallel()
 
-	for _, c := range cases {
-		t.Run(c.Name, func(t *testing.T) {
-			result := shouldIncludeAutoScalingGroup(c.AutoScalingGroup, c.ExcludeAfter, c.Config)
-			assert.Equal(t, c.Expected, result)
-		})
-	}
+	ag := ASGroups{
+		Client: mockedASGroups{
+			DeleteAutoScalingGroupResp: autoscaling.DeleteAutoScalingGroupOutput{},
+		}}
+
+	err := ag.nukeAll([]*string{awsgo.String("cloud-nuke-test")})
+	assert.NoError(t, err)
 }

--- a/aws/asg_types.go
+++ b/aws/asg_types.go
@@ -15,23 +15,23 @@ type ASGroups struct {
 }
 
 // ResourceName - the simple name of the aws resource
-func (group ASGroups) ResourceName() string {
+func (ag ASGroups) ResourceName() string {
 	return "asg"
 }
 
-func (group ASGroups) MaxBatchSize() int {
+func (ag ASGroups) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
 	return 49
 }
 
 // ResourceIdentifiers - The group names of the auto scaling groups
-func (group ASGroups) ResourceIdentifiers() []string {
-	return group.GroupNames
+func (ag ASGroups) ResourceIdentifiers() []string {
+	return ag.GroupNames
 }
 
 // Nuke - nuke 'em all!!!
-func (group ASGroups) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllAutoScalingGroups(session, awsgo.StringSlice(identifiers)); err != nil {
+func (ag ASGroups) Nuke(session *session.Session, identifiers []string) error {
+	if err := ag.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -306,7 +306,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		if IsNukeable(asGroups.ResourceName(), resourceTypes) {
 			start := time.Now()
-			groupNames, err := getAllAutoScalingGroups(cloudNukeSession, region, excludeAfter, configObj)
+			groupNames, err := asGroups.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Part of https://github.com/gruntwork-io/cloud-nuke/issues/494. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated [Refactor auto scaling group resource type]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

