### PR TITLE
Refactor cloudTrail resourceType

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1743,7 +1743,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		if IsNukeable(cloudtrailTrails.ResourceName(), resourceTypes) {
 			start := time.Now()
-			cloudtrailArns, err := getAllCloudtrailTrails(cloudNukeSession, excludeAfter, configObj)
+			cloudtrailArns, err := cloudtrailTrails.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/cloudtrail.go
+++ b/aws/cloudtrail.go
@@ -1,36 +1,33 @@
 package aws
 
 import (
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-	"time"
-
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudtrail"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
-func getAllCloudtrailTrails(session *session.Session, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
-	svc := cloudtrail.New(session)
-
+func (ct CloudtrailTrail) getAll(configObj config.Config) ([]*string, error) {
 	param := &cloudtrail.ListTrailsInput{}
 
 	trailIds := []*string{}
-
 	paginator := func(output *cloudtrail.ListTrailsOutput, lastPage bool) bool {
 		for _, trailInfo := range output.Trails {
-			if shouldIncludeCloudtrailTrail(trailInfo, configObj) {
+			if configObj.CloudtrailTrail.ShouldInclude(config.ResourceValue{
+				Name: trailInfo.Name,
+			}) {
 				trailIds = append(trailIds, trailInfo.TrailARN)
 			}
 		}
+
 		return !lastPage
 	}
 
-	err := svc.ListTrailsPages(param, paginator)
+	err := ct.Client.ListTrailsPages(param, paginator)
 	if err != nil {
 		return trailIds, errors.WithStackTrace(err)
 	}
@@ -38,27 +35,13 @@ func getAllCloudtrailTrails(session *session.Session, excludeAfter time.Time, co
 	return trailIds, nil
 }
 
-func shouldIncludeCloudtrailTrail(trail *cloudtrail.TrailInfo, configObj config.Config) bool {
-	if trail == nil {
-		return false
-	}
-
-	return config.ShouldInclude(
-		aws.StringValue(trail.Name),
-		configObj.CloudtrailTrail.IncludeRule.NamesRegExp,
-		configObj.CloudtrailTrail.ExcludeRule.NamesRegExp,
-	)
-}
-
-func nukeAllCloudTrailTrails(session *session.Session, arns []*string) error {
-	svc := cloudtrail.New(session)
-
+func (ct CloudtrailTrail) nukeAll(arns []*string) error {
 	if len(arns) == 0 {
-		logging.Logger.Debugf("No Cloudtrail Trails to nuke in region %s", *session.Config.Region)
+		logging.Logger.Debugf("No Cloudtrail Trails to nuke in region %s", ct.Region)
 		return nil
 	}
 
-	logging.Logger.Debugf("Deleting all Cloudtrail Trails in region %s", *session.Config.Region)
+	logging.Logger.Debugf("Deleting all Cloudtrail Trails in region %s", ct.Region)
 	var deletedArns []*string
 
 	for _, arn := range arns {
@@ -66,7 +49,7 @@ func nukeAllCloudTrailTrails(session *session.Session, arns []*string) error {
 			Name: arn,
 		}
 
-		_, err := svc.DeleteTrail(params)
+		_, err := ct.Client.DeleteTrail(params)
 
 		// Record status of this resource
 		e := report.Entry{
@@ -81,7 +64,7 @@ func nukeAllCloudTrailTrails(session *session.Session, arns []*string) error {
 			telemetry.TrackEvent(commonTelemetry.EventContext{
 				EventName: "Error Nuking Cloudtrail",
 			}, map[string]interface{}{
-				"region": *session.Config.Region,
+				"region": ct.Region,
 			})
 		} else {
 			deletedArns = append(deletedArns, arn)
@@ -89,7 +72,7 @@ func nukeAllCloudTrailTrails(session *session.Session, arns []*string) error {
 		}
 	}
 
-	logging.Logger.Debugf("[OK] %d Cloudtrail Trail deleted in %s", len(deletedArns), *session.Config.Region)
+	logging.Logger.Debugf("[OK] %d Cloudtrail Trail deleted in %s", len(deletedArns), ct.Region)
 
 	return nil
 }

--- a/aws/cloudtrail_types.go
+++ b/aws/cloudtrail_types.go
@@ -30,7 +30,7 @@ func (ct CloudtrailTrail) MaxBatchSize() int {
 
 // Nuke - nuke 'em all!!!
 func (ct CloudtrailTrail) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllCloudTrailTrails(session, awsgo.StringSlice(identifiers)); err != nil {
+	if err := ct.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Part of https://github.com/gruntwork-io/cloud-nuke/issues/494. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated [Refactor cloudTrail resourceType]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

