### PR TITLE
Refactor backupVault resourceType

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1015,7 +1015,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		if IsNukeable(backupVault.ResourceName(), resourceTypes) {
 			start := time.Now()
-			backupVaultNames, err := getAllBackupVault(cloudNukeSession, configObj)
+			backupVaultNames, err := backupVault.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/backup_vault_test.go
+++ b/aws/backup_vault_test.go
@@ -1,45 +1,104 @@
 package aws
 
 import (
-	"fmt"
+	"github.com/aws/aws-sdk-go/service/backup/backupiface"
+	"regexp"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/backup"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	"github.com/gruntwork-io/cloud-nuke/util"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type mockedBackupVault struct {
+	backupiface.BackupAPI
+	ListBackupVaultsOutput  backup.ListBackupVaultsOutput
+	DeleteBackupVaultOutput backup.DeleteBackupVaultOutput
+}
+
+func (m mockedBackupVault) ListBackupVaultsPages(
+	input *backup.ListBackupVaultsInput, fn func(*backup.ListBackupVaultsOutput, bool) bool) error {
+	fn(&m.ListBackupVaultsOutput, true)
+	return nil
+}
+
+func (m mockedBackupVault) DeleteBackupVault(*backup.DeleteBackupVaultInput) (*backup.DeleteBackupVaultOutput, error) {
+	return &m.DeleteBackupVaultOutput, nil
+}
+
+func TestBackupVaultGetAll(t *testing.T) {
+	telemetry.InitTelemetry("cloud-nuke", "")
+	t.Parallel()
+
+	testName1 := "test-backup-vault-1"
+	testName2 := "test-backup-vault-2"
+	now := time.Now()
+	bv := BackupVault{
+		Client: mockedBackupVault{
+			ListBackupVaultsOutput: backup.ListBackupVaultsOutput{
+				BackupVaultList: []*backup.VaultListMember{
+					{
+						BackupVaultName: aws.String(testName1),
+						CreationDate:    aws.Time(now),
+					},
+					{
+						BackupVaultName: aws.String(testName2),
+						CreationDate:    aws.Time(now.Add(1)),
+					},
+				}}},
+	}
+
+	tests := map[string]struct {
+		configObj config.ResourceType
+		expected  []string
+	}{
+		"emptyFilter": {
+			configObj: config.ResourceType{},
+			expected:  []string{testName1, testName2},
+		},
+		"nameExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					NamesRegExp: []config.Expression{{
+						RE: *regexp.MustCompile(testName1),
+					}}},
+			},
+			expected: []string{testName2},
+		},
+		"timeAfterExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					TimeAfter: aws.Time(now.Add(-1)),
+				}},
+			expected: []string{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			names, err := bv.getAll(config.Config{
+				BackupVault: tc.configObj,
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, aws.StringValueSlice(names), tc.expected)
+		})
+	}
+}
 
 func TestBackupVaultNuke(t *testing.T) {
 	telemetry.InitTelemetry("cloud-nuke", "")
 	t.Parallel()
 
-	region, err := getRandomRegion()
+	bv := BackupVault{
+		Client: mockedBackupVault{
+			DeleteBackupVaultOutput: backup.DeleteBackupVaultOutput{},
+		},
+	}
+
+	err := bv.nukeAll([]*string{aws.String("test-backup-vault")})
 	require.NoError(t, err)
-
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-
-	backupVaultName := createBackupVault(t, session)
-	err = nukeAllBackupVaults(session, []*string{backupVaultName})
-	require.NoError(t, err)
-
-	backupVaultNames, err := getAllBackupVault(session, config.Config{})
-	require.NoError(t, err)
-
-	assert.NotContains(t, aws.StringValueSlice(backupVaultNames), aws.StringValue(backupVaultName))
-}
-
-func createBackupVault(t *testing.T, session *session.Session) *string {
-	svc := backup.New(session)
-	output, err := svc.CreateBackupVault(&backup.CreateBackupVaultInput{
-		BackupVaultName: aws.String(fmt.Sprintf("test-backup-vault-%s", util.UniqueID())),
-	})
-	require.NoError(t, err)
-
-	return output.BackupVaultName
 }

--- a/aws/backup_vault_types.go
+++ b/aws/backup_vault_types.go
@@ -14,22 +14,22 @@ type BackupVault struct {
 }
 
 // ResourceName - the simple name of the aws resource
-func (ct BackupVault) ResourceName() string {
+func (bv BackupVault) ResourceName() string {
 	return "backup-vault"
 }
 
 // ResourceIdentifiers - The instance ids of the ec2 instances
-func (ct BackupVault) ResourceIdentifiers() []string {
-	return ct.Names
+func (bv BackupVault) ResourceIdentifiers() []string {
+	return bv.Names
 }
 
-func (ct BackupVault) MaxBatchSize() int {
+func (bv BackupVault) MaxBatchSize() int {
 	return 50
 }
 
 // Nuke - nuke 'em all!!!
-func (ct BackupVault) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllBackupVaults(session, awsgo.StringSlice(identifiers)); err != nil {
+func (bv BackupVault) Nuke(session *session.Session, identifiers []string) error {
+	if err := bv.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Part of https://github.com/gruntwork-io/cloud-nuke/issues/494. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated [Refactor backupVault resourceType]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

