### PR TITLE
refactor cloudwatch resource types

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1137,7 +1137,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		if IsNukeable(cloudwatchDashboards.ResourceName(), resourceTypes) {
 			start := time.Now()
-			cwdbNames, err := getAllCloudWatchDashboards(cloudNukeSession, excludeAfter, configObj)
+			cwdbNames, err := cloudwatchDashboards.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,
@@ -1168,7 +1168,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		if IsNukeable(cloudwatchLogGroups.ResourceName(), resourceTypes) {
 			start := time.Now()
-			lgNames, err := getAllCloudWatchLogGroups(cloudNukeSession, excludeAfter, configObj)
+			lgNames, err := cloudwatchLogGroups.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,
@@ -1863,7 +1863,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		if IsNukeable(cloudwatchAlarms.ResourceName(), resourceTypes) {
 			start := time.Now()
-			cwalNames, err := getAllCloudWatchAlarms(cloudNukeSession, excludeAfter, configObj)
+			cwalNames, err := cloudwatchAlarms.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/cloudwatch_alarm_test.go
+++ b/aws/cloudwatch_alarm_test.go
@@ -1,179 +1,114 @@
 package aws
 
 import (
-	"fmt"
+	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	"strings"
+	"regexp"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/util"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestListCloudWatchAlarms(t *testing.T) {
+type mockedCloudWatchAlarms struct {
+	cloudwatchiface.CloudWatchAPI
+	DescribeAlarmsOutput    cloudwatch.DescribeAlarmsOutput
+	DeleteAlarmsOutput      cloudwatch.DeleteAlarmsOutput
+	PutCompositeAlarmOutput cloudwatch.PutCompositeAlarmOutput
+}
+
+func (m mockedCloudWatchAlarms) DescribeAlarmsPages(input *cloudwatch.DescribeAlarmsInput, fn func(*cloudwatch.DescribeAlarmsOutput, bool) bool) error {
+	fn(&m.DescribeAlarmsOutput, true)
+	return nil
+}
+
+func (m mockedCloudWatchAlarms) PutCompositeAlarm(input *cloudwatch.PutCompositeAlarmInput) (*cloudwatch.PutCompositeAlarmOutput, error) {
+	return &m.PutCompositeAlarmOutput, nil
+}
+
+func (m mockedCloudWatchAlarms) DescribeAlarms(input *cloudwatch.DescribeAlarmsInput) (*cloudwatch.DescribeAlarmsOutput, error) {
+	return &m.DescribeAlarmsOutput, nil
+}
+
+func (m mockedCloudWatchAlarms) DeleteAlarms(input *cloudwatch.DeleteAlarmsInput) (*cloudwatch.DeleteAlarmsOutput, error) {
+	return &m.DeleteAlarmsOutput, nil
+}
+
+func TestCloudWatchAlarm_GetAll(t *testing.T) {
 	telemetry.InitTelemetry("cloud-nuke", "")
 	t.Parallel()
 
-	region, err := getRandomRegion()
-	require.NoError(t, err)
+	testName1 := "test-name1"
+	testName2 := "test-name2"
+	now := time.Now()
+	cw := CloudWatchAlarms{
+		Client: mockedCloudWatchAlarms{
+			DescribeAlarmsOutput: cloudwatch.DescribeAlarmsOutput{
+				MetricAlarms: []*cloudwatch.MetricAlarm{
+					{AlarmName: aws.String(testName1), AlarmConfigurationUpdatedTimestamp: &now},
+					{AlarmName: aws.String(testName2), AlarmConfigurationUpdatedTimestamp: aws.Time(now.Add(1))},
+				}},
+		}}
 
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-	svc := cloudwatch.New(session)
-
-	// cwal : CloudWatch ALarms (recommended by ChatGPT)
-	cwalName := createCloudWatchAlarm(t, svc, region)
-	defer deleteCloudWatchAlarm(t, svc, cwalName, true)
-
-	cwalNames, err := getAllCloudWatchAlarms(session, time.Now(), config.Config{})
-	require.NoError(t, err)
-	assert.Contains(t, aws.StringValueSlice(cwalNames), aws.StringValue(cwalName))
-}
-
-func TestTimeFilterExclusionNewlyCreatedCloudWatchAlarm(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
-	t.Parallel()
-
-	region, err := getRandomRegion()
-	require.NoError(t, err)
-
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-	svc := cloudwatch.New(session)
-
-	cwalName := createCloudWatchAlarm(t, svc, region)
-	defer deleteCloudWatchAlarm(t, svc, cwalName, true)
-
-	// Assert CloudWatch Alarm is picked up without filters
-	cwalNamesNewer, err := getAllCloudWatchAlarms(session, time.Now(), config.Config{})
-	require.NoError(t, err)
-	assert.Contains(t, aws.StringValueSlice(cwalNamesNewer), aws.StringValue(cwalName))
-
-	// Assert user doesn't appear when we look at users older than 1 Hour
-	olderThan := time.Now().Add(-1 * time.Hour)
-	cwalNamesOlder, err := getAllCloudWatchAlarms(session, olderThan, config.Config{})
-	require.NoError(t, err)
-	assert.NotContains(t, aws.StringValueSlice(cwalNamesOlder), aws.StringValue(cwalName))
-}
-
-func TestNukeCloudWatchAlarmOne(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
-	t.Parallel()
-
-	region, err := getRandomRegion()
-	require.NoError(t, err)
-
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-	svc := cloudwatch.New(session)
-
-	// We ignore errors in the delete call here, because it is intended to be a stop gap in case there is a bug in nuke.
-	cwalName := createCloudWatchAlarm(t, svc, region)
-	defer deleteCloudWatchAlarm(t, svc, cwalName, false)
-	identifiers := []*string{cwalName}
-
-	require.NoError(
-		t,
-		nukeAllCloudWatchAlarms(session, identifiers),
-	)
-
-	// Make sure the CloudWatch Alar m is deleted.
-	assertCloudWatchAlarmsDeleted(t, svc, identifiers)
-}
-
-func TestNukeCloudWatchAlarmsMoreThanOne(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
-	t.Parallel()
-
-	region, err := getRandomRegion()
-	require.NoError(t, err)
-
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-	svc := cloudwatch.New(session)
-
-	cwalNames := []*string{}
-	for i := 0; i < 3; i++ {
-		// We ignore errors in the delete call here, because it is intended to be a stop gap in case there is a bug in nuke.
-		cwalName := createCloudWatchAlarm(t, svc, region)
-		defer deleteCloudWatchAlarm(t, svc, cwalName, false)
-		cwalNames = append(cwalNames, cwalName)
-	}
-
-	require.NoError(
-		t,
-		nukeAllCloudWatchAlarms(session, cwalNames),
-	)
-
-	// Make sure the CloudWatch Alarm is deleted.
-	assertCloudWatchAlarmsDeleted(t, svc, cwalNames)
-}
-
-// Helper functions for driving the CloudWatch Alarm tests
-
-// createCloudWatchAlarm will create a new CloudWatch Alarm with a simple metric.
-func createCloudWatchAlarm(t *testing.T, svc *cloudwatch.CloudWatch, region string) *string {
-	uniqueID := util.UniqueID()
-	name := fmt.Sprintf("cloud-nuke-testing-%s", strings.ToLower(uniqueID))
-	metric := []*cloudwatch.MetricDataQuery{}
-	metric = append(metric, &cloudwatch.MetricDataQuery{})
-
-	_, err := svc.PutMetricAlarm(&cloudwatch.PutMetricAlarmInput{
-		ActionsEnabled:     aws.Bool(true),
-		AlarmActions:       aws.StringSlice([]string{}),
-		AlarmDescription:   aws.String(`Test alarm for cloud-nuke.`),
-		AlarmName:          aws.String(name),
-		ComparisonOperator: aws.String(`GreaterThanThreshold`),
-		DatapointsToAlarm:  aws.Int64(1),
-		Dimensions: []*cloudwatch.Dimension{
-			{Name: aws.String(`InstanceId`), Value: aws.String(`i-0123456789abcdefg`)},
+	tests := map[string]struct {
+		configObj config.ResourceType
+		expected  []string
+	}{
+		"emptyFilter": {
+			configObj: config.ResourceType{},
+			expected:  []string{testName1, testName2},
 		},
-		EvaluationPeriods:       aws.Int64(60),
-		InsufficientDataActions: aws.StringSlice([]string{}),
-		MetricName:              aws.String(`CPUUtilization`),
-		Namespace:               aws.String(`AWS/EC2`),
-		OKActions:               aws.StringSlice([]string{}),
-		Period:                  aws.Int64(60),
-		Statistic:               aws.String(cloudwatch.StatisticAverage),
-		Threshold:               aws.Float64(0.0),
-		TreatMissingData:        aws.String(`missing`),
-	})
-	require.NoError(t, err)
-
-	// Verify that the alarm is generated well
-	resp, err := svc.DescribeAlarms(&cloudwatch.DescribeAlarmsInput{
-		AlarmNames: []*string{&name},
-	})
-	require.NoError(t, err)
-	if len(resp.MetricAlarms) <= 0 {
-		t.Fatalf("Error creating Alarm %s", name)
+		"nameExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					NamesRegExp: []config.Expression{{
+						RE: *regexp.MustCompile(testName1),
+					}}},
+			},
+			expected: []string{testName2},
+		},
+		"timeAfterExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					TimeAfter: aws.Time(now.Add(-1)),
+				}},
+			expected: []string{},
+		},
 	}
-	// Add an arbitrary sleep to account for eventual consistency
-	time.Sleep(15 * time.Second)
-	return &name
-}
 
-// deleteCloudWatchAlarm is a function to delete the given CloudWatch Alarm.
-func deleteCloudWatchAlarm(t *testing.T, svc *cloudwatch.CloudWatch, name *string, checkErr bool) {
-	input := &cloudwatch.DeleteAlarmsInput{AlarmNames: []*string{name}}
-	_, err := svc.DeleteAlarms(input)
-	if checkErr {
-		require.NoError(t, err)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			names, err := cw.getAll(config.Config{
+				CloudWatchAlarm: tc.configObj,
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, aws.StringValueSlice(names))
+		})
 	}
 }
 
-func assertCloudWatchAlarmsDeleted(t *testing.T, svc *cloudwatch.CloudWatch, identifiers []*string) {
-	for _, name := range identifiers {
-		resp, err := svc.DescribeAlarms(&cloudwatch.DescribeAlarmsInput{AlarmNames: []*string{name}})
-		require.NoError(t, err)
-		if len(resp.MetricAlarms) > 0 {
-			t.Fatalf("Alarm %s is not deleted", aws.StringValue(name))
-		}
-	}
+func TestCloudWatchAlarms_NukeAll(t *testing.T) {
+	telemetry.InitTelemetry("cloud-nuke", "")
+	t.Parallel()
+
+	testName1 := "test-name1"
+	testName2 := "test-name2"
+	now := time.Now()
+	cw := CloudWatchAlarms{
+		Client: mockedCloudWatchAlarms{
+			DescribeAlarmsOutput: cloudwatch.DescribeAlarmsOutput{
+				MetricAlarms: []*cloudwatch.MetricAlarm{
+					{AlarmName: aws.String(testName1), AlarmConfigurationUpdatedTimestamp: &now},
+					{AlarmName: aws.String(testName2), AlarmConfigurationUpdatedTimestamp: aws.Time(now.Add(1))},
+				}},
+			PutCompositeAlarmOutput: cloudwatch.PutCompositeAlarmOutput{},
+			DeleteAlarmsOutput:      cloudwatch.DeleteAlarmsOutput{},
+		}}
+
+	err := cw.nukeAll([]*string{aws.String(testName1), aws.String(testName2)})
+	require.NoError(t, err)
 }

--- a/aws/cloudwatch_alarm_types.go
+++ b/aws/cloudwatch_alarm_types.go
@@ -15,22 +15,22 @@ type CloudWatchAlarms struct {
 }
 
 // ResourceName - the simple name of the aws resource
-func (cwal CloudWatchAlarms) ResourceName() string {
+func (cw CloudWatchAlarms) ResourceName() string {
 	return "cloudwatch-alarm"
 }
 
 // ResourceIdentifiers - The name of cloudwatch alarms
-func (cwal CloudWatchAlarms) ResourceIdentifiers() []string {
-	return cwal.AlarmNames
+func (cw CloudWatchAlarms) ResourceIdentifiers() []string {
+	return cw.AlarmNames
 }
 
-func (cwal CloudWatchAlarms) MaxBatchSize() int {
+func (cw CloudWatchAlarms) MaxBatchSize() int {
 	return 99
 }
 
 // Nuke - nuke 'em all!!!
-func (cwal CloudWatchAlarms) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllCloudWatchAlarms(session, awsgo.StringSlice(identifiers)); err != nil {
+func (cw CloudWatchAlarms) Nuke(session *session.Session, identifiers []string) error {
+	if err := cw.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/cloudwatch_dashboard_types.go
+++ b/aws/cloudwatch_dashboard_types.go
@@ -30,7 +30,7 @@ func (cwdb CloudWatchDashboards) MaxBatchSize() int {
 
 // Nuke - nuke 'em all!!!
 func (cwdb CloudWatchDashboards) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllCloudWatchDashboards(session, awsgo.StringSlice(identifiers)); err != nil {
+	if err := cwdb.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/cloudwatch_loggroup_types.go
+++ b/aws/cloudwatch_loggroup_types.go
@@ -15,16 +15,16 @@ type CloudWatchLogGroups struct {
 }
 
 // ResourceName - the simple name of the aws resource
-func (r CloudWatchLogGroups) ResourceName() string {
+func (cwlg CloudWatchLogGroups) ResourceName() string {
 	return "cloudwatch-loggroup"
 }
 
 // ResourceIdentifiers - The instance ids of the ec2 instances
-func (r CloudWatchLogGroups) ResourceIdentifiers() []string {
-	return r.Names
+func (cwlg CloudWatchLogGroups) ResourceIdentifiers() []string {
+	return cwlg.Names
 }
 
-func (r CloudWatchLogGroups) MaxBatchSize() int {
+func (cwlg CloudWatchLogGroups) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle. Note that CloudWatch Logs does not support bulk delete, so
 	// we will be deleting this many in parallel using go routines. We pick 35 here, which is half of what the AWS web
 	// console will do. We pick a conservative number here to avoid hitting AWS API rate limits.
@@ -32,8 +32,8 @@ func (r CloudWatchLogGroups) MaxBatchSize() int {
 }
 
 // Nuke - nuke 'em all!!!
-func (r CloudWatchLogGroups) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllCloudWatchLogGroups(session, awsgo.StringSlice(identifiers)); err != nil {
+func (cwlg CloudWatchLogGroups) Nuke(session *session.Session, identifiers []string) error {
+	if err := cwlg.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Part of https://github.com/gruntwork-io/cloud-nuke/issues/494. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated [Refactor cloudwatch resource types]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

