### PR TITLE
Refactor CodeDeploy, ConfigRecorder, ConfigServiceRule resource types

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1803,7 +1803,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		if IsNukeable(configServiceRules.ResourceName(), resourceTypes) {
 			start := time.Now()
-			configServiceRuleNames, err := getAllConfigRules(cloudNukeSession, excludeAfter, configObj)
+			configServiceRuleNames, err := configServiceRules.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,
@@ -1820,7 +1820,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(configServiceRuleNames) > 0 {
-				configServiceRules.RuleNames = configServiceRuleNames
+				configServiceRules.RuleNames = awsgo.StringValueSlice(configServiceRuleNames)
 				resourcesInRegion.Resources = append(resourcesInRegion.Resources, configServiceRules)
 			}
 		}
@@ -1833,7 +1833,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		if IsNukeable(configServiceRecorders.ResourceName(), resourceTypes) {
 			start := time.Now()
-			configServiceRecorderNames, err := getAllConfigRecorders(cloudNukeSession, excludeAfter, configObj)
+			configServiceRecorderNames, err := configServiceRecorders.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,
@@ -1850,7 +1850,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(configServiceRecorderNames) > 0 {
-				configServiceRecorders.RecorderNames = configServiceRecorderNames
+				configServiceRecorders.RecorderNames = awsgo.StringValueSlice(configServiceRecorderNames)
 				resourcesInRegion.Resources = append(resourcesInRegion.Resources, configServiceRecorders)
 			}
 		}
@@ -1923,7 +1923,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		if IsNukeable(codeDeployApplications.ResourceName(), resourceTypes) {
 			start := time.Now()
-			applications, err := getAllCodeDeployApplications(cloudNukeSession, excludeAfter, configObj)
+			applications, err := codeDeployApplications.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,
@@ -1940,7 +1940,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(applications) > 0 {
-				codeDeployApplications.AppNames = applications
+				codeDeployApplications.AppNames = awsgo.StringValueSlice(applications)
 				resourcesInRegion.Resources = append(resourcesInRegion.Resources, codeDeployApplications)
 			}
 		}

--- a/aws/codedeploy_application_types.go
+++ b/aws/codedeploy_application_types.go
@@ -30,7 +30,7 @@ func (c CodeDeployApplications) MaxBatchSize() int {
 
 // Nuke - nuke 'em all!!!
 func (c CodeDeployApplications) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllCodeDeployApplications(session, identifiers); err != nil {
+	if err := c.nukeAll(identifiers); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/config_recorder_types.go
+++ b/aws/config_recorder_types.go
@@ -12,20 +12,20 @@ type ConfigServiceRecorders struct {
 	RecorderNames []string
 }
 
-func (u ConfigServiceRecorders) ResourceName() string {
+func (csr ConfigServiceRecorders) ResourceName() string {
 	return "config-recorders"
 }
 
-func (u ConfigServiceRecorders) ResourceIdentifiers() []string {
-	return u.RecorderNames
+func (csr ConfigServiceRecorders) ResourceIdentifiers() []string {
+	return csr.RecorderNames
 }
 
-func (u ConfigServiceRecorders) MaxBatchSize() int {
+func (csr ConfigServiceRecorders) MaxBatchSize() int {
 	return 50
 }
 
-func (u ConfigServiceRecorders) Nuke(session *session.Session, configServiceRecorderNames []string) error {
-	if err := nukeAllConfigRecorders(session, configServiceRecorderNames); err != nil {
+func (csr ConfigServiceRecorders) Nuke(session *session.Session, configServiceRecorderNames []string) error {
+	if err := csr.nukeAll(configServiceRecorderNames); err != nil {
 		return errors.WithStackTrace(err)
 	}
 	return nil

--- a/aws/config_service_test.go
+++ b/aws/config_service_test.go
@@ -1,283 +1,88 @@
 package aws
 
 import (
-	"fmt"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	"strings"
-	"testing"
-	"time"
-
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/configservice"
-	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/configservice/configserviceiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/util"
-	"github.com/stretchr/testify/assert"
+	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
+	"regexp"
+	"testing"
 )
 
-func TestListConfigServiceRules(t *testing.T) {
+type mockedConfigServiceRule struct {
+	configserviceiface.ConfigServiceAPI
+	DescribeConfigRulesOutput configservice.DescribeConfigRulesOutput
+	DeleteConfigRuleOutput    configservice.DeleteConfigRuleOutput
+}
+
+func (m mockedConfigServiceRule) DescribeConfigRulesPages(input *configservice.DescribeConfigRulesInput, fn func(*configservice.DescribeConfigRulesOutput, bool) bool) error {
+	fn(&m.DescribeConfigRulesOutput, true)
+	return nil
+}
+
+func (m mockedConfigServiceRule) DeleteConfigRule(input *configservice.DeleteConfigRuleInput) (*configservice.DeleteConfigRuleOutput, error) {
+	return &m.DeleteConfigRuleOutput, nil
+}
+
+func TestConfigServiceRule_GetAll(t *testing.T) {
 	telemetry.InitTelemetry("cloud-nuke", "")
 	t.Parallel()
 
-	region, err := getRandomRegion()
-	require.NoError(t, err)
-
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-
-	configRuleName := createConfigServiceRule(t, region)
-	defer deleteConfigServiceRule(t, region, configRuleName, false)
-
-	configServiceRuleNames, err := getAllConfigRules(session, time.Now(), config.Config{})
-	require.NoError(t, err)
-	assert.Contains(t, configServiceRuleNames, configRuleName)
-}
-
-func TestNukeConfigServiceRuleOne(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
-	t.Parallel()
-
-	region, err := getRandomRegion()
-	require.NoError(t, err)
-
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-
-	configRuleName := createConfigServiceRule(t, region)
-	defer deleteConfigServiceRule(t, region, configRuleName, false)
-
-	configServiceRuleNames := []string{configRuleName}
-
-	require.NoError(
-		t,
-		nukeAllConfigServiceRules(session, configServiceRuleNames),
-	)
-
-	assertConfigServiceRulesDeleted(t, region, configServiceRuleNames)
-}
-
-func TestNukeConfigServiceRuleMoreThanOne(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
-	t.Parallel()
-
-	region, err := getRandomRegion()
-	require.NoError(t, err)
-
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-
-	configServiceRuleNames := []string{}
-	for i := 0; i < 3; i++ {
-		configServiceRuleName := createConfigServiceRule(t, region)
-		defer deleteConfigServiceRule(t, region, configServiceRuleName, false)
-		configServiceRuleNames = append(configServiceRuleNames, configServiceRuleName)
-	}
-
-	require.NoError(
-		t,
-		nukeAllConfigServiceRules(session, configServiceRuleNames),
-	)
-
-	assertConfigServiceRulesDeleted(t, region, configServiceRuleNames)
-}
-
-// Test helpers
-
-// ensureConfigurationRecorderExistsInRegion is a convenience method to be used during testing
-// since you cannot create a custom configuration rule unless you already have a configuration
-// recorder in the target region
-func ensureConfigurationRecorderExistsInRegion(t *testing.T, region string) string {
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-
-	configService := configservice.New(session)
-
-	param := &configservice.DescribeConfigurationRecordersInput{}
-
-	output, lookupErr := configService.DescribeConfigurationRecorders(param)
-	require.NoError(t, lookupErr)
-
-	// If we have no recorders in the region, create one - otherwise we have no more work to do
-	if len(output.ConfigurationRecorders) == 0 {
-		configRecorderName := createConfigurationRecorder(t, region)
-		require.NotEqual(t, "", configRecorderName)
-		return configRecorderName
-	}
-
-	return aws.StringValue(output.ConfigurationRecorders[0].Name)
-}
-
-// getAccountId contacts STS to retrieve the ID of the AWS account the tests are
-// being run against. This is necessary because we need to "fake" an IAM role,
-// but the fake IAM role must contain the correct account ID to avoid a cross-account
-// validation error
-func getAccountId(t *testing.T, session *session.Session) string {
-	stsService := sts.New(session)
-	stsOutput, stsErr := stsService.GetCallerIdentity(&sts.GetCallerIdentityInput{})
-	require.NoError(t, stsErr)
-
-	return aws.StringValue(stsOutput.Account)
-}
-
-// scaffoldTestConfigRecorder is a convenience method that generates a custom config service rule
-// suitable for use in testing
-func scaffoldTestConfigRecorder(t *testing.T, session *session.Session) *configservice.ConfigurationRecorder {
-	testConfigurationRecorderName := "default"
-
-	accountId := getAccountId(t, session)
-	// Create the test Configuration recorder
-	testConfigurationRecorder := &configservice.ConfigurationRecorder{
-		Name: aws.String(testConfigurationRecorderName),
-		RecordingGroup: &configservice.RecordingGroup{
-			AllSupported:               aws.Bool(false),
-			IncludeGlobalResourceTypes: aws.Bool(false),
-			ResourceTypes: []*string{
-				aws.String("AWS::Lambda::Function"),
+	testName1 := "test-rule-1"
+	testName2 := "test-rule-2"
+	csr := ConfigServiceRule{
+		Client: mockedConfigServiceRule{
+			DescribeConfigRulesOutput: configservice.DescribeConfigRulesOutput{
+				ConfigRules: []*configservice.ConfigRule{
+					{ConfigRuleName: aws.String(testName1)},
+					{ConfigRuleName: aws.String(testName2)},
+				},
 			},
 		},
-		// As the AWS documentation for config service notes, this RoleARN is not required by
-		// the API model, but it IS required by the AWS API, meaning you must pass a value
-		// We can "fake" this IAM role, in the sense that it doesn't actually need to exist,
-		// However, the AWS API will return an error if you don't supply the correct account
-		// number in the role ARN. Therefore, we need to look up the current account's ID dynamically
-		RoleARN: aws.String(fmt.Sprintf("arn:aws:iam::%s:role/S3Access", accountId)),
-	}
-	return testConfigurationRecorder
-}
-
-func createConfigurationRecorder(t *testing.T, region string) string {
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-
-	configService := configservice.New(session)
-
-	testConfigRecorder := scaffoldTestConfigRecorder(t, session)
-
-	param := &configservice.PutConfigurationRecorderInput{
-		ConfigurationRecorder: testConfigRecorder,
 	}
 
-	// The PutConfigurationRecorderOutput is an empty struct
-	_, putErr := configService.PutConfigurationRecorder(param)
-	require.NoError(t, putErr)
-
-	return aws.StringValue(testConfigRecorder.Name)
-}
-
-// scaffoldConfigServiceRule is a convenience method that generates an essentially nonsensical custom config rule
-// It is intended for use during testing
-func scaffoldConfigServiceRule() *configservice.ConfigRule {
-	configServiceRuleName := strings.ToLower(fmt.Sprintf("cloud-nuke-test-%s-%s", util.UniqueID(), util.UniqueID()))
-
-	configRulePolicyText := `
-# This rule checks if point in time recovery (PITR) is enabled on active Amazon DynamoDB tables
-let status = ['ACTIVE']
-
-rule tableisactive when
-    resourceType == "AWS::DynamoDB::Table" {
-    configuration.tableStatus == %status
-}
-
-rule checkcompliance when
-    resourceType == "AWS::DynamoDB::Table"
-    tableisactive {
-        let pitr = supplementaryConfiguration.ContinuousBackupsDescription.pointInTimeRecoveryDescription.pointInTimeRecoveryStatus
-        %pitr == "ENABLED"
-}
-	`
-	sourceDetail := &configservice.SourceDetail{
-		EventSource: aws.String("aws.config"),
-		MessageType: aws.String("ConfigurationItemChangeNotification"),
-	}
-
-	configRuleSource := &configservice.Source{
-		CustomPolicyDetails: &configservice.CustomPolicyDetails{
-			PolicyRuntime: aws.String("guard-2.x.x"),
-			PolicyText:    aws.String(configRulePolicyText),
+	tests := map[string]struct {
+		configObj config.ResourceType
+		expected  []string
+	}{
+		"emptyFilter": {
+			configObj: config.ResourceType{},
+			expected:  []string{testName1, testName2},
 		},
-		Owner: aws.String("CUSTOM_POLICY"),
-		SourceDetails: []*configservice.SourceDetail{
-			sourceDetail,
+		"nameExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					NamesRegExp: []config.Expression{{
+						RE: *regexp.MustCompile(testName1),
+					}}},
+			},
+			expected: []string{testName2},
 		},
-		SourceIdentifier: aws.String("cloud-nuke-test"),
 	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			names, err := csr.getAll(config.Config{
+				ConfigServiceRule: tc.configObj,
+			})
 
-	return &configservice.ConfigRule{
-		ConfigRuleName: aws.String(configServiceRuleName),
-		Source:         configRuleSource,
-	}
-}
-
-// createConfigServiceRule creates a custom AWS config service rule
-func createConfigServiceRule(t *testing.T, region string) string {
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-
-	// We must first ensure there is a configuration recorder in the target region
-	// Otherwise, the attempt to create the custom configuration rule will fail
-	ensureConfigurationRecorderExistsInRegion(t, region)
-
-	configService := configservice.New(session)
-
-	testConfigServiceRule := scaffoldConfigServiceRule()
-
-	param := &configservice.PutConfigRuleInput{
-		ConfigRule: testConfigServiceRule,
-	}
-
-	// PutConfigRuleOutput is an empty struct, so we just check for an error
-	_, createConfigServiceRuleErr := configService.PutConfigRule(param)
-	require.NoError(t, createConfigServiceRuleErr)
-
-	return *testConfigServiceRule.ConfigRuleName
-}
-
-func deleteConfigServiceRule(t *testing.T, region string, configServiceRuleName string, checkErr bool) {
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-
-	configService := configservice.New(session)
-
-	param := &configservice.DeleteConfigRuleInput{
-		ConfigRuleName: aws.String(configServiceRuleName),
-	}
-
-	_, deleteErr := configService.DeleteConfigRule(param)
-	if checkErr {
-		require.NoError(t, deleteErr)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, aws.StringValueSlice(names))
+		})
 	}
 }
 
-func assertConfigServiceRulesDeleted(t *testing.T, region string, configServiceRuleNames []string) {
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+func TestConfigServiceRule_NukeAll(t *testing.T) {
+	telemetry.InitTelemetry("cloud-nuke", "")
+	t.Parallel()
+
+	csr := ConfigServiceRule{
+		Client: mockedConfigServiceRule{
+			DeleteConfigRuleOutput: configservice.DeleteConfigRuleOutput{},
+		},
+	}
+
+	err := csr.nukeAll([]string{"test"})
 	require.NoError(t, err)
-
-	svc := configservice.New(session)
-
-	param := &configservice.DescribeConfigRulesInput{
-		ConfigRuleNames: aws.StringSlice(configServiceRuleNames),
-	}
-
-	resp, err := svc.DescribeConfigRules(param)
-	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case configservice.ErrCodeNoSuchConfigRuleException:
-				t.Log("Ignoring Config service rule not found error in test lookup")
-			default:
-				require.NoError(t, err)
-				if len(resp.ConfigRules) > 0 {
-					configServiceRuleNames := []string{}
-					// Unpack config service rules that failed to delete
-					for _, configRule := range resp.ConfigRules {
-						configServiceRuleNames = append(configServiceRuleNames, aws.StringValue(configRule.ConfigRuleName))
-					}
-					t.Fatalf("At least one of the following Config service rules was not deleted: %+v\n", aws.StringSlice(configServiceRuleNames))
-				}
-			}
-		}
-	}
 }

--- a/aws/config_service_types.go
+++ b/aws/config_service_types.go
@@ -12,20 +12,20 @@ type ConfigServiceRule struct {
 	RuleNames []string
 }
 
-func (c ConfigServiceRule) ResourceName() string {
+func (csr ConfigServiceRule) ResourceName() string {
 	return "config-rules"
 }
 
-func (c ConfigServiceRule) ResourceIdentifiers() []string {
-	return c.RuleNames
+func (csr ConfigServiceRule) ResourceIdentifiers() []string {
+	return csr.RuleNames
 }
 
-func (c ConfigServiceRule) MaxBatchSize() int {
+func (csr ConfigServiceRule) MaxBatchSize() int {
 	return 200
 }
 
-func (c ConfigServiceRule) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllConfigServiceRules(session, identifiers); err != nil {
+func (csr ConfigServiceRule) Nuke(session *session.Session, identifiers []string) error {
+	if err := csr.nukeAll(identifiers); err != nil {
 		return errors.WithStackTrace(err)
 	}
 	return nil


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Part of https://github.com/gruntwork-io/cloud-nuke/issues/494. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated [Refactor CodeDeploy, ConfigRecorder, ConfigServiceRule resource types]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

