### PR TITLE
refactor redshift resource type

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1584,7 +1584,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		if IsNukeable(redshiftClusters.ResourceName(), resourceTypes) {
 			start := time.Now()
-			clusters, err := getAllRedshiftClusters(cloudNukeSession, region, excludeAfter, configObj)
+			clusters, err := redshiftClusters.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/redshift.go
+++ b/aws/redshift.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
@@ -10,55 +9,46 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
 	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-	"time"
 )
 
-func getAllRedshiftClusters(session *session.Session, region string, excludeAfter time.Time, configObj config.Config) ([]*string, error) {
-	svc := redshift.New(session)
+func (rc RedshiftClusters) getAll(configObj config.Config) ([]*string, error) {
 	var clusterIds []*string
-	err := svc.DescribeClustersPages(
+	err := rc.Client.DescribeClustersPages(
 		&redshift.DescribeClustersInput{},
 		func(page *redshift.DescribeClustersOutput, lastPage bool) bool {
 			for _, cluster := range page.Clusters {
-				if shouldIncludeRedshiftCluster(cluster, excludeAfter, configObj) {
+				if configObj.Redshift.ShouldInclude(config.ResourceValue{
+					Time: cluster.ClusterCreateTime,
+					Name: cluster.ClusterIdentifier,
+				}) {
 					clusterIds = append(clusterIds, cluster.ClusterIdentifier)
 				}
 			}
+
 			return !lastPage
 		},
 	)
+
 	return clusterIds, errors.WithStackTrace(err)
 }
 
-func shouldIncludeRedshiftCluster(cluster *redshift.Cluster, excludeAfter time.Time, configObj config.Config) bool {
-	if cluster == nil {
-		return false
-	}
-	if excludeAfter.Before(*cluster.ClusterCreateTime) {
-		return false
-	}
-	return config.ShouldInclude(
-		aws.StringValue(cluster.ClusterIdentifier),
-		configObj.Redshift.IncludeRule.NamesRegExp,
-		configObj.Redshift.ExcludeRule.NamesRegExp,
-	)
-}
-
-func nukeAllRedshiftClusters(session *session.Session, identifiers []*string) error {
-	svc := redshift.New(session)
+func (rc RedshiftClusters) nukeAll(identifiers []*string) error {
 	if len(identifiers) == 0 {
-		logging.Logger.Debugf("No Redshift Clusters to nuke in region %s", *session.Config.Region)
+		logging.Logger.Debugf("No Redshift Clusters to nuke in region %s", rc.Region)
 		return nil
 	}
-	logging.Logger.Debugf("Deleting all Redshift Clusters in region %s", *session.Config.Region)
+	logging.Logger.Debugf("Deleting all Redshift Clusters in region %s", rc.Region)
 	deletedIds := []*string{}
 	for _, id := range identifiers {
-		_, err := svc.DeleteCluster(&redshift.DeleteClusterInput{ClusterIdentifier: id, SkipFinalClusterSnapshot: aws.Bool(true)})
+		_, err := rc.Client.DeleteCluster(&redshift.DeleteClusterInput{
+			ClusterIdentifier:        id,
+			SkipFinalClusterSnapshot: aws.Bool(true),
+		})
 		if err != nil {
 			telemetry.TrackEvent(commonTelemetry.EventContext{
 				EventName: "Error Nuking RedshiftCluster",
 			}, map[string]interface{}{
-				"region": *session.Config.Region,
+				"region": rc.Region,
 			})
 			logging.Logger.Errorf("[Failed] %s: %s", *id, err)
 		} else {
@@ -69,7 +59,7 @@ func nukeAllRedshiftClusters(session *session.Session, identifiers []*string) er
 
 	if len(deletedIds) > 0 {
 		for _, id := range deletedIds {
-			err := svc.WaitUntilClusterDeleted(&redshift.DescribeClustersInput{ClusterIdentifier: id})
+			err := rc.Client.WaitUntilClusterDeleted(&redshift.DescribeClustersInput{ClusterIdentifier: id})
 			// Record status of this resource
 			e := report.Entry{
 				Identifier:   aws.StringValue(id),
@@ -81,13 +71,13 @@ func nukeAllRedshiftClusters(session *session.Session, identifiers []*string) er
 				telemetry.TrackEvent(commonTelemetry.EventContext{
 					EventName: "Error Nuking Redshift Cluster",
 				}, map[string]interface{}{
-					"region": *session.Config.Region,
+					"region": rc.Region,
 				})
 				logging.Logger.Errorf("[Failed] %s", err)
 				return errors.WithStackTrace(err)
 			}
 		}
 	}
-	logging.Logger.Debugf("[OK] %d Redshift Cluster(s) deleted in %s", len(deletedIds), *session.Config.Region)
+	logging.Logger.Debugf("[OK] %d Redshift Cluster(s) deleted in %s", len(deletedIds), rc.Region)
 	return nil
 }

--- a/aws/redshift_types.go
+++ b/aws/redshift_types.go
@@ -13,23 +13,23 @@ type RedshiftClusters struct {
 	ClusterIdentifiers []string
 }
 
-func (cluster RedshiftClusters) ResourceName() string {
+func (rc RedshiftClusters) ResourceName() string {
 	return "redshift"
 }
 
 // ResourceIdentifiers - The instance names of the rds db instances
-func (cluster RedshiftClusters) ResourceIdentifiers() []string {
-	return cluster.ClusterIdentifiers
+func (rc RedshiftClusters) ResourceIdentifiers() []string {
+	return rc.ClusterIdentifiers
 }
 
-func (cluster RedshiftClusters) MaxBatchSize() int {
+func (rc RedshiftClusters) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
 	return 49
 }
 
 // Nuke - nuke 'em all!!!
-func (cluster RedshiftClusters) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllRedshiftClusters(session, awsgo.StringSlice(identifiers)); err != nil {
+func (rc RedshiftClusters) Nuke(session *session.Session, identifiers []string) error {
+	if err := rc.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Part of https://github.com/gruntwork-io/cloud-nuke/issues/494. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated [refactor redshift resource type]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

