### PR TITLE
refactor secret manager resource type

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1068,7 +1068,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		if IsNukeable(secretsManagerSecrets.ResourceName(), resourceTypes) {
 			start := time.Now()
-			secrets, err := getAllSecretsManagerSecrets(cloudNukeSession, excludeAfter, configObj)
+			secrets, err := secretsManagerSecrets.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/secrets_manager_test.go
+++ b/aws/secrets_manager_test.go
@@ -1,233 +1,122 @@
 package aws
 
 import (
-	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
+	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	"github.com/stretchr/testify/require"
+	"regexp"
 	"testing"
 	"time"
-
-	"github.com/gruntwork-io/cloud-nuke/logging"
-	"github.com/gruntwork-io/go-commons/collections"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
-	"github.com/gruntwork-io/cloud-nuke/config"
-	terraws "github.com/gruntwork-io/terratest/modules/aws"
-	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/gruntwork-io/go-commons/retry"
 )
 
-func TestListSecretsManagerSecrets(t *testing.T) {
+type mockedSecretsManager struct {
+	secretsmanageriface.SecretsManagerAPI
+	ListSecretsOutput                  secretsmanager.ListSecretsOutput
+	DescribeSecretOutput               secretsmanager.DescribeSecretOutput
+	DeleteSecretOutput                 secretsmanager.DeleteSecretOutput
+	RemoveRegionsFromReplicationOutput secretsmanager.RemoveRegionsFromReplicationOutput
+}
+
+func (m mockedSecretsManager) ListSecretsPages(input *secretsmanager.ListSecretsInput, fn func(*secretsmanager.ListSecretsOutput, bool) bool) error {
+	fn(&m.ListSecretsOutput, true)
+	return nil
+}
+
+func (m mockedSecretsManager) DescribeSecret(input *secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error) {
+	return &m.DescribeSecretOutput, nil
+}
+
+func (m mockedSecretsManager) DeleteSecret(input *secretsmanager.DeleteSecretInput) (*secretsmanager.DeleteSecretOutput, error) {
+	return &m.DeleteSecretOutput, nil
+}
+
+func (m mockedSecretsManager) RemoveRegionsFromReplication(input *secretsmanager.RemoveRegionsFromReplicationInput) (*secretsmanager.RemoveRegionsFromReplicationOutput, error) {
+	return &m.RemoveRegionsFromReplicationOutput, nil
+}
+
+func TestSecretsManagerSecrets_GetAll(t *testing.T) {
 	telemetry.InitTelemetry("cloud-nuke", "")
 	t.Parallel()
 
-	region, err := getRandomRegion()
-	require.NoError(t, err)
-
-	secretName := fmt.Sprintf("test-cloud-nuke-secretsmanager-list-%s", random.UniqueId())
-	defer terraws.DeleteSecret(t, region, secretName, true)
-	arn := createSecretStringWithDefaultKey(t, region, secretName)
-
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-
-	secretARNPtrs, err := getAllSecretsManagerSecrets(session, time.Now(), config.Config{})
-	require.NoError(t, err)
-	assert.Contains(t, aws.StringValueSlice(secretARNPtrs), arn)
-}
-
-func TestTimeFilterExclusionNewlyCreatedSecret(t *testing.T) {
-	t.Parallel()
-
-	region, err := getRandomRegion()
-	require.NoError(t, err)
-
-	secretName := fmt.Sprintf("test-cloud-nuke-secretsmanager-exclusion-%s", random.UniqueId())
-	defer terraws.DeleteSecret(t, region, secretName, true)
-
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-
-	// Assert user didn't exist
-	secretARNPtrs, err := getAllSecretsManagerSecrets(session, time.Now(), config.Config{})
-	require.NoError(t, err)
-	for _, secretARNPtr := range secretARNPtrs {
-		assert.NotContains(t, aws.StringValue(secretARNPtr), secretName)
-	}
-
-	// Creates a secret
-	arn := createSecretStringWithDefaultKey(t, region, secretName)
-
-	// Assert secret is picked up without filters
-	secretARNPtrsNewer, err := getAllSecretsManagerSecrets(session, time.Now(), config.Config{})
-	require.NoError(t, err)
-	assert.Contains(t, aws.StringValueSlice(secretARNPtrsNewer), arn)
-
-	// Assert user doesn't appear when we look at users older than 1 Hour
-	olderThan := time.Now().Add(-1 * time.Hour)
-	secretARNPtrsOlder, err := getAllSecretsManagerSecrets(session, olderThan, config.Config{})
-	require.NoError(t, err)
-	assert.NotContains(t, aws.StringValueSlice(secretARNPtrsOlder), arn)
-}
-
-func TestNukeSecretOne(t *testing.T) {
-	t.Parallel()
-
-	region, err := getRandomRegion()
-	require.NoError(t, err)
-
-	secretName := fmt.Sprintf("test-cloud-nuke-secretsmanager-one-%s", random.UniqueId())
-	// We use the E version and ignore the error, as this is meant to be a stop gap deletion in case nuke has a bug.
-	defer terraws.DeleteSecretE(t, region, secretName, true)
-	arn := createSecretStringWithDefaultKey(t, region, secretName)
-
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-
-	require.NoError(
-		t,
-		nukeAllSecretsManagerSecrets(session, aws.StringSlice([]string{arn})),
-	)
-
-	// Make sure the secret is deleted.
-	_, err = terraws.GetSecretValueE(t, region, arn)
-	assert.Error(t, err)
-}
-
-func TestNukeSecretMoreThanOne(t *testing.T) {
-	t.Parallel()
-
-	region, err := getRandomRegion()
-	require.NoError(t, err)
-
-	secretNameBase := fmt.Sprintf("test-cloud-nuke-secretsmanager-more-than-one-%s", random.UniqueId())
-
-	secretArns := []string{}
-	for i := 0; i < 3; i++ {
-		secretName := fmt.Sprintf("%s-%d", secretNameBase, i)
-		// We use the E version and ignore the error, as this is meant to be a stop gap deletion in case nuke has a bug.
-		defer terraws.DeleteSecretE(t, region, secretName, true)
-		secretArns = append(secretArns, createSecretStringWithDefaultKey(t, region, secretName))
-	}
-
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-
-	require.NoError(
-		t,
-		nukeAllSecretsManagerSecrets(session, aws.StringSlice(secretArns)),
-	)
-
-	// Make sure the secret is deleted.
-	for _, arn := range secretArns {
-		_, err = terraws.GetSecretValueE(t, region, arn)
-		assert.Error(t, err)
-	}
-}
-
-func TestNukeSecretReplica(t *testing.T) {
-	t.Parallel()
-
-	region, err := getRandomRegion()
-	require.NoError(t, err)
-
-	secretName := fmt.Sprintf("test-cloud-nuke-secretsmanager-one-%s", random.UniqueId())
-	// We use the E version and ignore the error, as this is meant to be a stop gap deletion in case nuke has a bug.
-	defer terraws.DeleteSecretE(t, region, secretName, true)
-	arn := createSecretStringReplicaWithDefaultKey(t, region, secretName)
-
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
-	require.NoError(t, err)
-
-	require.NoError(
-		t,
-		nukeAllSecretsManagerSecrets(session, aws.StringSlice([]string{arn})),
-	)
-
-	// Make sure the secret is deleted.
-	_, err = terraws.GetSecretValueE(t, region, arn)
-	assert.Error(t, err)
-}
-
-// Helper functions for driving the secrets manager tests
-
-// createSecretStringWithDefaultKey creates a new secret with a random value in Secrets Manager using the default
-// "aws/secretsmanager" KMS key and returns the secret ARN
-func createSecretStringWithDefaultKey(t *testing.T, awsRegion string, name string) string {
-	description := "Random secret created for cloud-nuke testing."
-	secretVal := random.UniqueId()
-	arn := terraws.CreateSecretStringWithDefaultKey(t, awsRegion, description, name, secretVal)
-	// Check if created secret is available by checking secret ARN in list of all secrets
-	// https://github.com/gruntwork-io/cloud-nuke/issues/227
-	awsSession, err := session.NewSession(&aws.Config{Region: aws.String(awsRegion)})
-	require.NoError(t, err)
-	err = retry.DoWithRetry(
-		logging.Logger,
-		"Check if created secret is available",
-		4,
-		15*time.Second,
-		func() error {
-			secretARNPtrs, err := getAllSecretsManagerSecrets(awsSession, time.Now(), config.Config{})
-			if err != nil {
-				return err
-			}
-			if collections.ListContainsElement(aws.StringValueSlice(secretARNPtrs), arn) {
-				return nil
-			}
-			return fmt.Errorf("not found secret %s", arn)
-		},
-	)
-	require.NoError(t, err)
-	return arn
-}
-
-// createSecretStringReplicaWithDefaultKey creates a new secret and replicate other random region with a random value in
-// Secrets Manager using the default "aws/secretsmanager" KMS key and returns the secret ARN
-func createSecretStringReplicaWithDefaultKey(t *testing.T, awsRegion string, name string) string {
-	description := "Random secret created for cloud-nuke testing."
-	secretVal := random.UniqueId()
-	arn := terraws.CreateSecretStringWithDefaultKey(t, awsRegion, description, name, secretVal)
-	// Check if created secret is available by checking secret ARN in list of all secrets
-	// https://github.com/gruntwork-io/cloud-nuke/issues/227
-	awsSession, err := session.NewSession(&aws.Config{Region: aws.String(awsRegion)})
-	require.NoError(t, err)
-
-	// Replicate other random region
-	svc := secretsmanager.New(awsSession)
-	replicaRegion, err := getRandomRegion()
-	require.NoError(t, err)
-
-	_, err = svc.ReplicateSecretToRegions(&secretsmanager.ReplicateSecretToRegionsInput{
-		AddReplicaRegions: []*secretsmanager.ReplicaRegionType{
-			{
-				Region: aws.String(replicaRegion),
+	testName1 := "test-name-1"
+	testName2 := "test-name-2"
+	testArn1 := "test-arn1"
+	testArn2 := "test-arn2"
+	now := time.Now()
+	sms := SecretsManagerSecrets{
+		Client: mockedSecretsManager{
+			ListSecretsOutput: secretsmanager.ListSecretsOutput{
+				SecretList: []*secretsmanager.SecretListEntry{
+					{
+						Name:        aws.String(testName1),
+						ARN:         aws.String(testArn1),
+						CreatedDate: &now,
+					},
+					{
+						Name:        aws.String(testName2),
+						ARN:         aws.String(testArn2),
+						CreatedDate: aws.Time(now.Add(1)),
+					},
+				},
 			},
 		},
-		SecretId:                    aws.String(arn),
-		ForceOverwriteReplicaSecret: aws.Bool(true),
-	})
-	require.NoError(t, err)
+	}
 
-	err = retry.DoWithRetry(
-		logging.Logger,
-		"Check if created secret is available",
-		4,
-		15*time.Second,
-		func() error {
-			secretARNPtrs, err := getAllSecretsManagerSecrets(awsSession, time.Now(), config.Config{})
-			if err != nil {
-				return err
-			}
-			if collections.ListContainsElement(aws.StringValueSlice(secretARNPtrs), arn) {
-				return nil
-			}
-			return fmt.Errorf("not found secret %s", arn)
+	tests := map[string]struct {
+		configObj config.ResourceType
+		expected  []string
+	}{
+		"emptyFilter": {
+			configObj: config.ResourceType{},
+			expected:  []string{testArn1, testArn2},
 		},
-	)
+		"nameExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					NamesRegExp: []config.Expression{{
+						RE: *regexp.MustCompile(testName1),
+					}}},
+			},
+			expected: []string{testArn2},
+		},
+		"timeAfterExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
+				}},
+			expected: []string{},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			names, err := sms.getAll(config.Config{
+				SecretsManagerSecrets: tc.configObj,
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, aws.StringValueSlice(names))
+		})
+	}
+}
+
+func TestSecretsManagerSecrets_NukeAll(t *testing.T) {
+	telemetry.InitTelemetry("cloud-nuke", "")
+	t.Parallel()
+
+	sms := SecretsManagerSecrets{
+		Client: mockedSecretsManager{
+			DescribeSecretOutput: secretsmanager.DescribeSecretOutput{
+				ARN: aws.String("test-arn"),
+			},
+			DeleteSecretOutput: secretsmanager.DeleteSecretOutput{},
+			RemoveRegionsFromReplicationOutput: secretsmanager.RemoveRegionsFromReplicationOutput{
+				ARN: aws.String("test-arn"),
+			},
+		},
+	}
+
+	err := sms.nukeAll([]*string{aws.String("test-arn")})
 	require.NoError(t, err)
-	return arn
 }

--- a/aws/secrets_manager_types.go
+++ b/aws/secrets_manager_types.go
@@ -15,16 +15,16 @@ type SecretsManagerSecrets struct {
 }
 
 // ResourceName - the simple name of the aws resource
-func (secret SecretsManagerSecrets) ResourceName() string {
+func (sms SecretsManagerSecrets) ResourceName() string {
 	return "secretsmanager"
 }
 
 // ResourceIdentifiers - The instance ids of the ec2 instances
-func (secret SecretsManagerSecrets) ResourceIdentifiers() []string {
-	return secret.SecretIDs
+func (sms SecretsManagerSecrets) ResourceIdentifiers() []string {
+	return sms.SecretIDs
 }
 
-func (secret SecretsManagerSecrets) MaxBatchSize() int {
+func (sms SecretsManagerSecrets) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle. Note that secrets manager does not support bulk delete, so
 	// we will be deleting this many in parallel using go routines. We conservatively pick 10 here, both to limit
 	// overloading the runtime and to avoid AWS throttling with many API calls.
@@ -32,8 +32,8 @@ func (secret SecretsManagerSecrets) MaxBatchSize() int {
 }
 
 // Nuke - nuke 'em all!!!
-func (secret SecretsManagerSecrets) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllSecretsManagerSecrets(session, awsgo.StringSlice(identifiers)); err != nil {
+func (sms SecretsManagerSecrets) Nuke(session *session.Session, identifiers []string) error {
+	if err := sms.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Part of https://github.com/gruntwork-io/cloud-nuke/issues/494. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated [refactor secret manager resource type]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

