### PR TITLE
Refactor db subnet groups

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -941,7 +941,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 
 			// Note: the `DescribeDBSubnetGroups` API response does not contain any information
 			// about when the subnet group was created, so we cannot apply the `excludeAfter` filter
-			subnetGroups, err := getAllRdsDbSubnetGroups(cloudNukeSession, configObj)
+			subnetGroups, err := dbSubnetGroups.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/rds_subnet_group_types.go
+++ b/aws/rds_subnet_group_types.go
@@ -13,23 +13,23 @@ type DBSubnetGroups struct {
 	InstanceNames []string
 }
 
-func (instance DBSubnetGroups) ResourceName() string {
+func (dsg DBSubnetGroups) ResourceName() string {
 	return "rds-subnet-group"
 }
 
 // ResourceIdentifiers - The instance names of the rds db instances
-func (instance DBSubnetGroups) ResourceIdentifiers() []string {
-	return instance.InstanceNames
+func (dsg DBSubnetGroups) ResourceIdentifiers() []string {
+	return dsg.InstanceNames
 }
 
-func (instance DBSubnetGroups) MaxBatchSize() int {
+func (dsg DBSubnetGroups) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle
 	return 49
 }
 
 // Nuke - nuke 'em all!!!
-func (instance DBSubnetGroups) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllRdsDbSubnetGroups(session, awsgo.StringSlice(identifiers)); err != nil {
+func (dsg DBSubnetGroups) Nuke(session *session.Session, identifiers []string) error {
+	if err := dsg.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Part of https://github.com/gruntwork-io/cloud-nuke/issues/494. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated [Refactor db subnet groups]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

