### PR TITLE
Fix excludeTimeAfter configuration reflecting on all resource types

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -241,6 +241,7 @@ func GetTargetRegions(enabledRegions []string, selectedRegions []string, exclude
 
 // GetAllResources - Lists all aws resources
 func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTypes []string, configObj config.Config, allowDeleteUnaliasedKeys bool) (*AwsAccountResources, error) {
+	configObj.AddExcludeAfterTime(&excludeAfter)
 	account := AwsAccountResources{
 		Resources: make(map[string]AwsRegionResource),
 	}

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"fmt"
 	"os"
-	"reflect"
 	"strings"
 	"time"
 
@@ -287,17 +286,6 @@ func awsNuke(c *cli.Context) error {
 			EventName: "Error parsing duration",
 		}, map[string]interface{}{})
 		return errors.WithStackTrace(err)
-	}
-
-	// exclude after filter has been applied to all resources via `older-than` flag, we are
-	// setting this rule across all resource types.
-	//
-	// TODO: after refactoring all the code, we can remove having excludeAfter in config and
-	//  passing in as additional argument to GetAllResources.
-	v := reflect.ValueOf(configObj)
-	for i := 0; i < v.NumField(); i++ {
-		excludeRule := v.Field(i).FieldByName("ExcludeRule").Interface().(config.FilterRule)
-		excludeRule.TimeAfter = excludeAfter
 	}
 
 	deleteUnaliasedKmsKeys := c.Bool("delete-unaliased-kms-keys")


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

ExcludeTimeAfter was not being set properly in configuration objects. 
This should fix the issue. 

Tested locally running the command using `--older-than` flag. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated [Fix excludeTimeAfter configuration reflecting on all resource types]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

