### PR TITLE
refactor kinesis streams

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1558,7 +1558,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		if IsNukeable(kinesisStreams.ResourceName(), resourceTypes) {
 			start := time.Now()
-			streams, err := getAllKinesisStreams(cloudNukeSession, configObj)
+			streams, err := kinesisStreams.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,

--- a/aws/kinesis_stream_types.go
+++ b/aws/kinesis_stream_types.go
@@ -15,16 +15,16 @@ type KinesisStreams struct {
 }
 
 // ResourceName - The simple name of the AWS resource
-func (k KinesisStreams) ResourceName() string {
+func (ks KinesisStreams) ResourceName() string {
 	return "kinesis-stream"
 }
 
 // ResourceIdentifiers - The names of the Kinesis Streams
-func (k KinesisStreams) ResourceIdentifiers() []string {
-	return k.Names
+func (ks KinesisStreams) ResourceIdentifiers() []string {
+	return ks.Names
 }
 
-func (k KinesisStreams) MaxBatchSize() int {
+func (ks KinesisStreams) MaxBatchSize() int {
 	// Tentative batch size to ensure AWS doesn't throttle. Note that Kinesis Streams does not support bulk delete, so
 	// we will be deleting this many in parallel using go routines. We pick 35 here, which is half of what the AWS web
 	// console will do. We pick a conservative number here to avoid hitting AWS API rate limits.
@@ -32,8 +32,8 @@ func (k KinesisStreams) MaxBatchSize() int {
 }
 
 // Nuke - nuke 'em all!!!
-func (k KinesisStreams) Nuke(session *session.Session, identifiers []string) error {
-	if err := nukeAllKinesisStreams(session, aws.StringSlice(identifiers)); err != nil {
+func (ks KinesisStreams) Nuke(session *session.Session, identifiers []string) error {
+	if err := ks.nukeAll(aws.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Part of https://github.com/gruntwork-io/cloud-nuke/issues/494. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated [refactor kinesis streams]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

