### PR TITLE
Fix nil pointer in Ec2 resource type

### DIFF
--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -88,6 +88,9 @@ func shouldIncludeInstanceId(instance *ec2.Instance, excludeAfter time.Time, pro
 	// If Name is unset, GetEC2ResourceNameTagValue returns error and zero value string
 	// Ignore this error and pass empty string to config.ShouldInclude
 	instanceName := GetEC2ResourceNameTagValue(instance.Tags)
+	if instanceName == nil {
+		instanceName = awsgo.String("")
+	}
 
 	return config.ShouldInclude(
 		*instanceName,


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

<!-- Description of the changes introduced by this PR. -->

Fixing issue

```
runtime error: invalid memory address or nil pointer dereference  binary=cloud-nuke version=exit status 1
```

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

