### PR TITLE
refactor KMS resource type

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1433,7 +1433,7 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 		}
 		if IsNukeable(customerKeys.ResourceName(), resourceTypes) {
 			start := time.Now()
-			keys, aliases, err := getAllKmsUserKeys(cloudNukeSession, customerKeys.MaxBatchSize(), excludeAfter, configObj, allowDeleteUnaliasedKeys)
+			keys, err := customerKeys.getAll(configObj)
 			if err != nil {
 				ge := report.GeneralError{
 					Error:        err,
@@ -1450,7 +1450,6 @@ func GetAllResources(targetRegions []string, excludeAfter time.Time, resourceTyp
 				"actionTime":  time.Since(start).Seconds(),
 			})
 			if len(keys) > 0 {
-				customerKeys.KeyAliases = aliases
 				customerKeys.KeyIds = awsgo.StringValueSlice(keys)
 				resourcesInRegion.Resources = append(resourcesInRegion.Resources, customerKeys)
 			}

--- a/aws/kms_customer_key.go
+++ b/aws/kms_customer_key.go
@@ -1,36 +1,56 @@
 package aws
 
 import (
-	"sync"
-	"time"
-
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
+	"sync"
 
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/report"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/hashicorp/go-multierror"
 )
 
-func getAllKmsUserKeys(session *session.Session, batchSize int, excludeAfter time.Time, configObj config.Config, allowDeleteUnaliasedKeys bool) ([]*string, map[string][]string, error) {
-	svc := kms.New(session)
+func (kck KmsCustomerKeys) getAll(configObj config.Config) ([]*string, error) {
 	// Collect all keys in the account
-	// AWS managed keys are filtered out in shouldIncludeKmsUserKey
-	keys, err := listKeys(svc, batchSize)
+	var keys []string
+	err := kck.Client.ListKeysPages(&kms.ListKeysInput{}, func(page *kms.ListKeysOutput, lastPage bool) bool {
+		for _, key := range page.Keys {
+			keys = append(keys, *key.KeyId)
+		}
+
+		return !lastPage
+	})
 	if err != nil {
-		return nil, nil, errors.WithStackTrace(err)
+		return nil, errors.WithStackTrace(err)
 	}
 
-	// Create an empty map for storing the mapping between aliases and keys
-	keyAliases, err := listKeyAliases(svc, batchSize)
+	// Collect key to alias mapping
+	keyAliases := map[string][]string{}
+	err = kck.Client.ListAliasesPages(&kms.ListAliasesInput{}, func(page *kms.ListAliasesOutput, lastPage bool) bool {
+		for _, alias := range page.Aliases {
+			key := alias.TargetKeyId
+			if key == nil {
+				continue
+			}
+
+			list, found := keyAliases[*key]
+			if !found {
+				list = make([]string, 0)
+			}
+
+			list = append(list, *alias.AliasName)
+			keyAliases[*key] = list
+		}
+
+		return !lastPage
+	})
 	if err != nil {
-		return nil, nil, errors.WithStackTrace(err)
+		return nil, errors.WithStackTrace(err)
 	}
 
 	// checking in parallel if keys can be considered for removal
@@ -50,7 +70,7 @@ func getAllKmsUserKeys(session *session.Session, batchSize int, excludeAfter tim
 		// If the keyId isn't found in the map, this returns an empty array
 		aliasesForKey := keyAliases[keyId]
 
-		go shouldIncludeKmsUserKey(&wg, resultsChan[id], svc, keyId, aliasesForKey, excludeAfter, configObj, allowDeleteUnaliasedKeys)
+		go kck.shouldInclude(&wg, resultsChan[id], keyId, aliasesForKey, configObj)
 		id++
 	}
 	wg.Wait()
@@ -70,7 +90,9 @@ func getAllKmsUserKeys(session *session.Session, batchSize int, excludeAfter tim
 			kmsIds = append(kmsIds, &result.KeyId)
 		}
 	}
-	return kmsIds, aliases, nil
+
+	kck.KeyAliases = aliases
+	return kmsIds, nil
 }
 
 // KmsCheckIncludeResult - structure used results of evaluation: not null KeyId - key should be included
@@ -79,25 +101,26 @@ type KmsCheckIncludeResult struct {
 	Error error
 }
 
-func shouldIncludeKmsUserKey(wg *sync.WaitGroup, resultsChan chan *KmsCheckIncludeResult, svc *kms.KMS, key string,
-	aliases []string, excludeAfter time.Time, configObj config.Config, allowDeleteUnaliasedKeys bool,
-) {
+func (kck KmsCustomerKeys) shouldInclude(
+	wg *sync.WaitGroup,
+	resultsChan chan *KmsCheckIncludeResult,
+	key string,
+	aliases []string,
+	configObj config.Config) {
 	defer wg.Done()
+
 	includedByName := false
 	// verify if key aliases matches configurations
 	for _, alias := range aliases {
-		v := config.ShouldInclude(alias, configObj.KMSCustomerKeys.IncludeRule.NamesRegExp,
-			configObj.KMSCustomerKeys.ExcludeRule.NamesRegExp)
-		if v {
+		if config.ShouldInclude(alias, configObj.KMSCustomerKeys.IncludeRule.NamesRegExp,
+			configObj.KMSCustomerKeys.ExcludeRule.NamesRegExp) {
 			includedByName = true
-
-			break
 		}
 	}
 
 	// Only delete keys without aliases if the user explicitly says so
 	if len(aliases) == 0 {
-		if !allowDeleteUnaliasedKeys {
+		if !configObj.KMSCustomerKeys.DeleteUnaliasedKeys {
 			resultsChan <- &KmsCheckIncludeResult{KeyId: ""}
 			return
 		} else {
@@ -112,7 +135,7 @@ func shouldIncludeKmsUserKey(wg *sync.WaitGroup, resultsChan chan *KmsCheckInclu
 		return
 	}
 	// additional request to describe key and get information about creation date, removal status
-	details, err := svc.DescribeKey(&kms.DescribeKeyInput{KeyId: &key})
+	details, err := kck.Client.DescribeKey(&kms.DescribeKeyInput{KeyId: &key})
 	if err != nil {
 		resultsChan <- &KmsCheckIncludeResult{Error: err}
 		return
@@ -132,8 +155,8 @@ func shouldIncludeKmsUserKey(wg *sync.WaitGroup, resultsChan chan *KmsCheckInclu
 		resultsChan <- &KmsCheckIncludeResult{KeyId: ""}
 		return
 	}
-	referenceTime := *metadata.CreationDate
-	if referenceTime.After(excludeAfter) {
+	referenceTime := metadata.CreationDate
+	if !configObj.KMSCustomerKeys.ShouldInclude(config.ResourceValue{Time: referenceTime}) {
 		resultsChan <- &KmsCheckIncludeResult{KeyId: ""}
 		return
 	}
@@ -141,93 +164,28 @@ func shouldIncludeKmsUserKey(wg *sync.WaitGroup, resultsChan chan *KmsCheckInclu
 	resultsChan <- &KmsCheckIncludeResult{KeyId: key}
 }
 
-func listKeyAliases(svc *kms.KMS, batchSize int) (map[string][]string, error) {
-	// map key - KMS key id, value list of aliases
-	aliases := map[string][]string{}
-	var next *string
-
-	for {
-		list, err := svc.ListAliases(&kms.ListAliasesInput{
-			Marker: next,
-			Limit:  aws.Int64(int64(batchSize)),
-		})
-		if err != nil {
-			return nil, errors.WithStackTrace(err)
-		}
-
-		// collect key aliases to map
-		for _, alias := range list.Aliases {
-			key := alias.TargetKeyId
-			if key == nil {
-				continue
-			}
-			list, found := aliases[*key]
-			if !found {
-				list = make([]string, 0)
-			}
-			list = append(list, *alias.AliasName)
-			aliases[*key] = list
-		}
-
-		if list.NextMarker == nil || len(*list.NextMarker) == 0 {
-			break
-		}
-		next = list.NextMarker
-	}
-	return aliases, nil
-}
-
-func listKeys(svc *kms.KMS, batchSize int) ([]string, error) {
-	var keyIds []string
-	var next *string
-
-	for {
-		list, err := svc.ListKeys(&kms.ListKeysInput{
-			Marker: next,
-			Limit:  aws.Int64(int64(batchSize)),
-		})
-
-		if err != nil {
-			return nil, errors.WithStackTrace(err)
-		}
-
-		for _, key := range list.Keys {
-			keyIds = append(keyIds, *key.KeyId)
-		}
-
-		if list.NextMarker == nil || len(*list.NextMarker) == 0 {
-			break
-		}
-		next = list.NextMarker
-	}
-
-	return keyIds, nil
-}
-
-func nukeAllCustomerManagedKmsKeys(session *session.Session, keyIds []*string, keyAliases map[string][]string) error {
-	region := aws.StringValue(session.Config.Region)
+func (kck KmsCustomerKeys) nukeAll(keyIds []*string) error {
 	if len(keyIds) == 0 {
-		logging.Logger.Debugf("No Customer Keys to nuke in region %s", region)
+		logging.Logger.Debugf("No Customer Keys to nuke in region %s", kck.Region)
 		return nil
 	}
 
 	// usage of go routines for parallel keys removal
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/kms/#KMS.ScheduleKeyDeletion
-	logging.Logger.Debugf("Deleting Keys secrets in region %s", region)
-	svc := kms.New(session)
+	logging.Logger.Debugf("Deleting Keys secrets in region %s", kck.Region)
 	wg := new(sync.WaitGroup)
 	wg.Add(len(keyIds))
 	errChans := make([]chan error, len(keyIds))
 	for i, secretID := range keyIds {
 		errChans[i] = make(chan error, 1)
-		go requestKeyDeletion(wg, errChans[i], svc, secretID)
+		go kck.requestKeyDeletion(wg, errChans[i], secretID)
 	}
 	wg.Wait()
 
 	wgAlias := new(sync.WaitGroup)
-	wgAlias.Add(len(keyAliases))
-	for _, aliases := range keyAliases {
-		go deleteAliases(wgAlias, svc, aliases)
+	wgAlias.Add(len(kck.KeyAliases))
+	for _, aliases := range kck.KeyAliases {
+		go kck.deleteAliases(wgAlias, aliases)
 	}
 	wgAlias.Wait()
 
@@ -240,19 +198,19 @@ func nukeAllCustomerManagedKmsKeys(session *session.Session, keyIds []*string, k
 			telemetry.TrackEvent(commonTelemetry.EventContext{
 				EventName: "Error Nuking KMS Key",
 			}, map[string]interface{}{
-				"region": *session.Config.Region,
+				"region": kck.Region,
 			})
 		}
 	}
 	return errors.WithStackTrace(allErrs.ErrorOrNil())
 }
 
-func deleteAliases(wg *sync.WaitGroup, svc *kms.KMS, aliases []string) {
+func (kck KmsCustomerKeys) deleteAliases(wg *sync.WaitGroup, aliases []string) {
 	defer wg.Done()
 
 	for _, aliasName := range aliases {
 		input := &kms.DeleteAliasInput{AliasName: &aliasName}
-		_, err := svc.DeleteAlias(input)
+		_, err := kck.Client.DeleteAlias(input)
 
 		if err != nil {
 			logging.Logger.Errorf("[Failed] Failed deleting alias: %s", aliasName)
@@ -262,10 +220,10 @@ func deleteAliases(wg *sync.WaitGroup, svc *kms.KMS, aliases []string) {
 	}
 }
 
-func requestKeyDeletion(wg *sync.WaitGroup, errChan chan error, svc *kms.KMS, key *string) {
+func (kck KmsCustomerKeys) requestKeyDeletion(wg *sync.WaitGroup, errChan chan error, key *string) {
 	defer wg.Done()
 	input := &kms.ScheduleKeyDeletionInput{KeyId: key, PendingWindowInDays: aws.Int64(int64(kmsRemovalWindow))}
-	_, err := svc.ScheduleKeyDeletion(input)
+	_, err := kck.Client.ScheduleKeyDeletion(input)
 
 	// Record status of this resource
 	e := report.Entry{

--- a/aws/kms_customer_key_types.go
+++ b/aws/kms_customer_key_types.go
@@ -19,23 +19,23 @@ type KmsCustomerKeys struct {
 }
 
 // ResourceName - the simple name of the aws resource
-func (c KmsCustomerKeys) ResourceName() string {
+func (kck KmsCustomerKeys) ResourceName() string {
 	return "kmscustomerkeys"
 }
 
 // ResourceIdentifiers - The KMS Key IDs
-func (c KmsCustomerKeys) ResourceIdentifiers() []string {
-	return c.KeyIds
+func (kck KmsCustomerKeys) ResourceIdentifiers() []string {
+	return kck.KeyIds
 }
 
 // MaxBatchSize - Requests batch size
-func (r KmsCustomerKeys) MaxBatchSize() int {
+func (kck KmsCustomerKeys) MaxBatchSize() int {
 	return 49
 }
 
 // Nuke - remove all customer managed keys
-func (c KmsCustomerKeys) Nuke(session *session.Session, keyIds []string) error {
-	if err := nukeAllCustomerManagedKmsKeys(session, awsgo.StringSlice(keyIds), c.KeyAliases); err != nil {
+func (kck KmsCustomerKeys) Nuke(session *session.Session, keyIds []string) error {
+	if err := kck.nukeAll(awsgo.StringSlice(keyIds)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Part of https://github.com/gruntwork-io/cloud-nuke/issues/494. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated [refactor KMS resource type]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

