### PR TITLE
Update CircleCI config to sign MacOS binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,12 @@
+orbs:
+  go: circleci/go@1.7.3
+
+# The "sign binary" runs in a MacOS environment, so it's necessary to download GW's binaries
+env: &env
+  environment:
+    GRUNTWORK_INSTALLER_VERSION: v0.0.39
+    MODULE_CI_VERSION: v0.52.6
+
 defaults: &defaults
   resource_class: medium+
   docker:
@@ -78,11 +87,40 @@ jobs:
               --delete-unaliased-kms-keys
           no_output_timeout: 1h
   deploy:
-    <<: *defaults
+    <<: *env
+    macos:
+      xcode: 14.2.0
+    resource_class: macos.x86.medium.gen2
     steps:
+      - checkout
       - attach_workspace:
           at: .
-      - run: cd bin && sha256sum * > SHA256SUMS
+      - go/install:
+          version: "1.20.5"
+      - run:
+          name: Install sign-binary-helpers
+          command: |
+            curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
+            gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
+            gruntwork-install --module-name "sign-binary-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
+      - run:
+          name: Compile and sign the binaries
+          command: |
+            sign-binary --install-macos-sign-dependencies --os mac .gon_amd64.hcl
+            sign-binary --os mac .gon_arm64.hcl
+            echo "Done signing the binary"
+
+            # Replace the files in bin. These are the same file names generated from .gon_amd64.hcl and .gon_arm64.hcl
+            unzip cloud-nuke_darwin_amd64.zip
+            mv cloud-nuke_darwin_amd64 bin/
+
+            unzip cloud-nuke_darwin_arm64.zip
+            mv cloud-nuke_darwin_arm64 bin/
+      - run:
+          name: Run SHA256SUM
+          command: |
+            brew install coreutils
+            cd bin && sha256sum * > SHA256SUMS
       - run: upload-github-release-assets bin/*
 workflows:
   version: 2
@@ -117,6 +155,7 @@ workflows:
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
+            - APPLE__OSX__code-signing
   nuke_phxdevops:
     when:
       and:

--- a/.gon_amd64.hcl
+++ b/.gon_amd64.hcl
@@ -1,0 +1,19 @@
+# See https://github.com/gruntwork-io/terraform-aws-ci/blob/main/modules/sign-binary-helpers/
+# for further instructions on how to sign the binary + submitting for notarization.
+
+source = ["./bin/cloud-nuke_darwin_amd64"]
+
+bundle_id = "io.gruntwork.app.terragrunt"
+
+apple_id {
+  username = "machine.apple@gruntwork.io"
+  password = "@env:MACOS_AC_PASSWORD"
+}
+
+sign {
+  application_identity = "Developer ID Application: Gruntwork, Inc."
+}
+
+zip {
+  output_path = "cloud-nuke_darwin_amd64.zip"
+}

--- a/.gon_arm64.hcl
+++ b/.gon_arm64.hcl
@@ -1,0 +1,19 @@
+# See https://github.com/gruntwork-io/terraform-aws-ci/blob/main/modules/sign-binary-helpers/
+# for further instructions on how to sign the binary + submitting for notarization.
+
+source = ["./bin/cloud-nuke_darwin_arm64"]
+
+bundle_id = "io.gruntwork.app.terragrunt"
+
+apple_id {
+  username = "machine.apple@gruntwork.io"
+  password = "@env:MACOS_AC_PASSWORD"
+}
+
+sign {
+  application_identity = "Developer ID Application: Gruntwork, Inc."
+}
+
+zip {
+  output_path = "cloud-nuke_darwin_arm64.zip"
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

We are already able to sign the binaries of internal projects, like [patcher-cli](https://github.com/gruntwork-io/patcher-cli/releases) and [terrapatch-cli](https://github.com/gruntwork-io/terrapatch-cli).

I am replicating the same process in cloud-nuke, the MacOS binaries will be signed and notarized before generating the `sha256sum`. 

Related to https://github.com/gruntwork-io/terragrunt/pull/2661 and https://github.com/gruntwork-io/git-xargs/pull/137.

Test release: https://github.com/gruntwork-io/cloud-nuke/releases/tag/v0.32.1-test-signing-binaries


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [X] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

Signing MacOS binaries from now on! 🎉

