### PR TITLE
UI improvement + refactoring work for aws-inspect and aws commands

### DIFF
--- a/aws/inspect.go
+++ b/aws/inspect.go
@@ -1,34 +1,8 @@
 package aws
 
 import (
-	"fmt"
-	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/logging"
-	"github.com/gruntwork-io/cloud-nuke/ui"
 	"github.com/gruntwork-io/go-commons/collections"
 )
-
-// ExtractResourcesForPrinting is a convenience method that converts the nested structure of AwsAccountResources
-// into a flat slice of resource identifiers, well-suited for printing line by line
-func ExtractResourcesForPrinting(account *AwsAccountResources) []string {
-	var resources []string
-
-	if len(account.Resources) == 0 {
-		logging.Logger.Infoln("No resources found!")
-		return resources
-	}
-
-	resources = make([]string, 0)
-	for region, resourcesInRegion := range account.Resources {
-		for _, foundResources := range resourcesInRegion.Resources {
-			for _, identifier := range (*foundResources).ResourceIdentifiers() {
-				resources = append(resources, fmt.Sprintf("%s %s %s\n", ui.ResourceHighlightStyle.Render((*foundResources).ResourceName()), identifier, region))
-			}
-		}
-	}
-
-	return resources
-}
 
 func ensureValidResourceTypes(resourceTypes []string) ([]string, error) {
 	invalidresourceTypes := []string{}
@@ -75,19 +49,4 @@ func HandleResourceTypeSelections(
 		}
 	}
 	return resourceTypes, nil
-}
-
-func InspectResources(q *Query) (*AwsAccountResources, error) {
-	if len(q.ResourceTypes) > 0 {
-		for _, resourceType := range q.ResourceTypes {
-			logging.Logger.Infof("- %s", resourceType)
-		}
-	} else {
-		for _, resourceType := range ListResourceTypes() {
-			logging.Logger.Infof("- %s", resourceType)
-		}
-	}
-
-	// NOTE: The inspect functionality currently does not support config file, so we short circuit the logic with an empty struct.
-	return GetAllResources(q.Regions, q.ExcludeAfter, q.ResourceTypes, config.Config{}, q.ListUnaliasedKMSKeys)
 }

--- a/aws/resources/kms_customer_key.go
+++ b/aws/resources/kms_customer_key.go
@@ -120,7 +120,7 @@ func (kck *KmsCustomerKeys) shouldInclude(
 
 	// Only delete keys without aliases if the user explicitly says so
 	if len(aliases) == 0 {
-		if !configObj.KMSCustomerKeys.DeleteUnaliasedKeys {
+		if !configObj.KMSCustomerKeys.IncludeUnaliasedKeys {
 			resultsChan <- &KmsCheckIncludeResult{KeyId: ""}
 			return
 		} else {

--- a/config/config.go
+++ b/config/config.go
@@ -99,7 +99,7 @@ func (c *Config) AddExcludeAfterTime(excludeAfter *time.Time) {
 }
 
 type KMSCustomerKeyResourceType struct {
-	DeleteUnaliasedKeys bool `yaml:"delete_unaliased_keys"`
+	IncludeUnaliasedKeys bool `yaml:"include_unaliased_keys"`
 
 	ResourceType
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/572.

* Refactoring some common logic between `aws-nuke` and `aws-inspect` to have consistent logic & UI going forward
* made some changes to UI to make things cleaner. 

Here is the screenshot of the `aws-inspect` command: 
![image](https://github.com/gruntwork-io/cloud-nuke/assets/96548424/e6cec1b5-6ce7-4f5f-b9b2-11925ae542f6)

This is the screenshot when searching through aws resources

![image](https://github.com/gruntwork-io/cloud-nuke/assets/96548424/f779d846-8647-49bc-8290-36172034d7ed)


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

