### PR TITLE
Implement newer_than filter for aws nuke command

### DIFF
--- a/aws/types.go
+++ b/aws/types.go
@@ -91,18 +91,20 @@ type Query struct {
 	ExcludeRegions       []string
 	ResourceTypes        []string
 	ExcludeResourceTypes []string
-	ExcludeAfter         time.Time
+	ExcludeAfter         *time.Time
+	IncludeAfter         *time.Time
 	ListUnaliasedKMSKeys bool
 }
 
 // NewQuery configures and returns a Query struct that can be passed into the InspectResources method
-func NewQuery(regions, excludeRegions, resourceTypes, excludeResourceTypes []string, excludeAfter time.Time, listUnaliasedKMSKeys bool) (*Query, error) {
+func NewQuery(regions, excludeRegions, resourceTypes, excludeResourceTypes []string, excludeAfter, includeAfter *time.Time, listUnaliasedKMSKeys bool) (*Query, error) {
 	q := &Query{
 		Regions:              regions,
 		ExcludeRegions:       excludeRegions,
 		ResourceTypes:        resourceTypes,
 		ExcludeResourceTypes: excludeResourceTypes,
 		ExcludeAfter:         excludeAfter,
+		IncludeAfter:         includeAfter,
 		ListUnaliasedKMSKeys: listUnaliasedKMSKeys,
 	}
 

--- a/aws/types_test.go
+++ b/aws/types_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"testing"
 	"time"
 
@@ -17,7 +18,8 @@ func TestNewQueryAcceptsValidExcludeAfterEntries(t *testing.T) {
 		ExcludeRegions       []string
 		ResourceTypes        []string
 		ExcludeResourceTypes []string
-		ExcludeAfter         time.Time
+		ExcludeAfter         *time.Time
+		IncludeAfter         *time.Time
 	}
 
 	testCases := []TestCase{
@@ -26,20 +28,22 @@ func TestNewQueryAcceptsValidExcludeAfterEntries(t *testing.T) {
 			Regions:        []string{"us-east-1"},
 			ExcludeRegions: []string{},
 			ResourceTypes:  []string{"ec2"},
-			ExcludeAfter:   time.Now().Add(time.Hour * 24),
+			ExcludeAfter:   aws.Time(time.Now().Add(time.Hour * 24)),
+			IncludeAfter:   aws.Time(time.Now().Add(time.Hour * 24)),
 		},
 		{
 			Name:           "Can pass time.Now",
 			Regions:        []string{"us-east-1"},
 			ExcludeRegions: []string{},
 			ResourceTypes:  []string{"ec2"},
-			ExcludeAfter:   time.Now(),
+			ExcludeAfter:   aws.Time(time.Now()),
+			IncludeAfter:   aws.Time(time.Now()),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			_, err := NewQuery(tc.Regions, tc.ExcludeRegions, tc.ResourceTypes, tc.ExcludeResourceTypes, tc.ExcludeAfter, false)
+			_, err := NewQuery(tc.Regions, tc.ExcludeRegions, tc.ResourceTypes, tc.ExcludeResourceTypes, tc.ExcludeAfter, tc.IncludeAfter, false)
 			require.NoError(t, err)
 		})
 	}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/485. 

Testing with the newer-than filter (retrieve elements "newer" than 1 hour): 
<img width="855" alt="image" src="https://github.com/gruntwork-io/cloud-nuke/assets/96548424/01e6510c-ecac-4516-8554-c6ce017ba696">

Testing with the newer-than filter (retrieve elements "newer" than 1s):
<img width="886" alt="image" src="https://github.com/gruntwork-io/cloud-nuke/assets/96548424/c4349d54-d7c6-4dd4-bb68-9251bac47cc9">


TODO: we may want to reword these filters to `excludeAfter` and `includeAfter` to be consistent with the naming within the code. Also, it could be quite confusing to understand "older-than" and "newer-than". 



<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

