### PR TITLE
Filter out default subnet group due to error

### DIFF
--- a/aws/resources/elasticache.go
+++ b/aws/resources/elasticache.go
@@ -282,9 +282,10 @@ func (sg *ElasticacheSubnetGroups) getAll(configObj config.Config) ([]*string, e
 		&elasticache.DescribeCacheSubnetGroupsInput{},
 		func(page *elasticache.DescribeCacheSubnetGroupsOutput, lastPage bool) bool {
 			for _, subnetGroup := range page.CacheSubnetGroups {
-				if configObj.ElasticacheSubnetGroups.ShouldInclude(config.ResourceValue{
-					Name: subnetGroup.CacheSubnetGroupName,
-				}) {
+				if !strings.Contains(*subnetGroup.CacheSubnetGroupName, "default") &&
+					configObj.ElasticacheSubnetGroups.ShouldInclude(config.ResourceValue{
+						Name: subnetGroup.CacheSubnetGroupName,
+					}) {
 					subnetGroupNames = append(subnetGroupNames, subnetGroup.CacheSubnetGroupName)
 				}
 			}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/486.

Testing: verified it doesn't retrieve default elasticcache group
<img width="912" alt="image" src="https://github.com/gruntwork-io/cloud-nuke/assets/96548424/abf71513-d951-49bd-8870-0f49b595c500">


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

