### PR TITLE
Fix multiple cloudwatch composite alarm nuking

### DIFF
--- a/aws/resources/cloudwatch_alarm_test.go
+++ b/aws/resources/cloudwatch_alarm_test.go
@@ -112,3 +112,26 @@ func TestCloudWatchAlarms_NukeAll(t *testing.T) {
 	err := cw.nukeAll([]*string{aws.String(testName1), aws.String(testName2)})
 	require.NoError(t, err)
 }
+
+func TestCloudWatchCompositeAlarms_NukeAll(t *testing.T) {
+	telemetry.InitTelemetry("cloud-nuke", "")
+	t.Parallel()
+
+	testCompositeAlaram1 := "test-name1"
+	testCompositeAlaram2 := "test-name2"
+	testName3 := "test-name3"
+	now := time.Now()
+	cw := CloudWatchAlarms{
+		Client: mockedCloudWatchAlarms{
+			DescribeAlarmsOutput: cloudwatch.DescribeAlarmsOutput{
+				MetricAlarms: []*cloudwatch.MetricAlarm{
+					{AlarmName: aws.String(testCompositeAlaram1), AlarmConfigurationUpdatedTimestamp: &now},
+					{AlarmName: aws.String(testCompositeAlaram2), AlarmConfigurationUpdatedTimestamp: &now},
+				}},
+			PutCompositeAlarmOutput: cloudwatch.PutCompositeAlarmOutput{},
+			DeleteAlarmsOutput:      cloudwatch.DeleteAlarmsOutput{},
+		}}
+
+	err := cw.nukeAll([]*string{aws.String(testCompositeAlaram1), aws.String(testCompositeAlaram2), aws.String(testName3)})
+	require.NoError(t, err)
+}

--- a/util/string_utils.go
+++ b/util/string_utils.go
@@ -19,3 +19,20 @@ func Split(identifiers []string, limit int) [][]string {
 
 	return chunks
 }
+
+// Difference returns the elements in `a` that aren't in `b`.
+func Difference(a, b []*string) []*string {
+	mb := make(map[string]bool, len(b))
+	for _, x := range b {
+		mb[*x] = true
+	}
+
+	var diff []*string
+	for _, x := range a {
+		if _, found := mb[*x]; !found {
+			diff = append(diff, x)
+		}
+	}
+
+	return diff
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/467. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

