### PR TITLE
Remove RemediationConfiguration before deleting config rules

### DIFF
--- a/aws/resources/config_service_test.go
+++ b/aws/resources/config_service_test.go
@@ -14,8 +14,9 @@ import (
 
 type mockedConfigServiceRule struct {
 	configserviceiface.ConfigServiceAPI
-	DescribeConfigRulesOutput configservice.DescribeConfigRulesOutput
-	DeleteConfigRuleOutput    configservice.DeleteConfigRuleOutput
+	DescribeConfigRulesOutput            configservice.DescribeConfigRulesOutput
+	DeleteConfigRuleOutput               configservice.DeleteConfigRuleOutput
+	DeleteRemediationConfigurationOutput configservice.DeleteRemediationConfigurationOutput
 }
 
 func (m mockedConfigServiceRule) DescribeConfigRulesPages(input *configservice.DescribeConfigRulesInput, fn func(*configservice.DescribeConfigRulesOutput, bool) bool) error {
@@ -25,6 +26,10 @@ func (m mockedConfigServiceRule) DescribeConfigRulesPages(input *configservice.D
 
 func (m mockedConfigServiceRule) DeleteConfigRule(input *configservice.DeleteConfigRuleInput) (*configservice.DeleteConfigRuleOutput, error) {
 	return &m.DeleteConfigRuleOutput, nil
+}
+
+func (m mockedConfigServiceRule) DeleteRemediationConfiguration(input *configservice.DeleteRemediationConfigurationInput) (*configservice.DeleteRemediationConfigurationOutput, error) {
+	return &m.DeleteRemediationConfigurationOutput, nil
 }
 
 func TestConfigServiceRule_GetAll(t *testing.T) {
@@ -37,8 +42,8 @@ func TestConfigServiceRule_GetAll(t *testing.T) {
 		Client: mockedConfigServiceRule{
 			DescribeConfigRulesOutput: configservice.DescribeConfigRulesOutput{
 				ConfigRules: []*configservice.ConfigRule{
-					{ConfigRuleName: aws.String(testName1)},
-					{ConfigRuleName: aws.String(testName2)},
+					{ConfigRuleName: aws.String(testName1), ConfigRuleState: aws.String("ACTIVE")},
+					{ConfigRuleName: aws.String(testName2), ConfigRuleState: aws.String("ACTIVE")},
 				},
 			},
 		},
@@ -80,7 +85,8 @@ func TestConfigServiceRule_NukeAll(t *testing.T) {
 
 	csr := ConfigServiceRule{
 		Client: mockedConfigServiceRule{
-			DeleteConfigRuleOutput: configservice.DeleteConfigRuleOutput{},
+			DeleteConfigRuleOutput:               configservice.DeleteConfigRuleOutput{},
+			DeleteRemediationConfigurationOutput: configservice.DeleteRemediationConfigurationOutput{},
 		},
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Partially address https://github.com/gruntwork-io/cloud-nuke/issues/410. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

