### PR TITLE
Prototype RDS cluster removal in order for global RDS clusters

### DIFF
--- a/aws/resources/rds_cluster_types.go
+++ b/aws/resources/rds_cluster_types.go
@@ -11,9 +11,10 @@ import (
 )
 
 type DBClusters struct {
-	Client        rdsiface.RDSAPI
-	Region        string
-	InstanceNames []string
+	Client             rdsiface.RDSAPI
+	Region             string
+	Identifiers        []string
+	IdentifierToArnMap map[string]*string
 }
 
 func (instance *DBClusters) Init(session *session.Session) {
@@ -26,7 +27,7 @@ func (instance *DBClusters) ResourceName() string {
 
 // ResourceIdentifiers - The instance names of the rds db instances
 func (instance *DBClusters) ResourceIdentifiers() []string {
-	return instance.InstanceNames
+	return instance.Identifiers
 }
 
 func (instance *DBClusters) MaxBatchSize() int {
@@ -40,8 +41,8 @@ func (instance *DBClusters) GetAndSetIdentifiers(c context.Context, configObj co
 		return nil, err
 	}
 
-	instance.InstanceNames = awsgo.StringValueSlice(identifiers)
-	return instance.InstanceNames, nil
+	instance.Identifiers = awsgo.StringValueSlice(identifiers)
+	return instance.Identifiers, nil
 }
 
 // Nuke - nuke 'em all!!!


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Prototype for https://github.com/gruntwork-io/cloud-nuke/issues/597. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

