### PR TITLE
Revert exclude-resource type for ACM + temporary log

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ jobs:
               --exclude-resource-type config-rules \
               --exclude-resource-type eip \
               --exclude-resource-type nat-gateway \
-              --exclude-resource-type acm \
               --delete-unaliased-kms-keys \
               --log-level debug
           no_output_timeout: 1h
@@ -86,7 +85,6 @@ jobs:
               --exclude-resource-type config-rules \
               --exclude-resource-type eip \
               --exclude-resource-type nat-gateway \
-              --exclude-resource-type acm \
               --delete-unaliased-kms-keys \
               --log-level debug
           no_output_timeout: 1h

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -245,9 +245,6 @@ func awsNuke(c *cli.Context) error {
 		configObj = *configObjPtr
 	}
 
-	// Temporarily printing the entire config object to validate things
-	pterm.Debug.Println(fmt.Sprintf("Config object: %+v", configObj))
-
 	query, account, err := handleGetResources(c, configObj, c.Bool("delete-unaliased-kms-keys"))
 	if err != nil {
 		telemetry.TrackEvent(commonTelemetry.EventContext{


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/579. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

