### PR TITLE
Add report to ec2 DHCP option resource nuking operation

### DIFF
--- a/aws/resources/ec2_dhcp_option.go
+++ b/aws/resources/ec2_dhcp_option.go
@@ -2,9 +2,11 @@ package resources
 
 import (
 	"context"
-	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/report"
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/pterm/pterm"
 )
@@ -35,9 +37,18 @@ func (v *EC2DhcpOption) nukeAll(identifiers []*string) error {
 			DhcpOptionsId: identifier,
 		})
 		if err != nil {
-			pterm.Debug.Println(fmt.Sprintf("Failed to delete DHCP option w/ err: %s.", err))
-			return errors.WithStackTrace(err)
+			logging.Debugf("Failed to delete DHCP option w/ err: %s.", err)
+		} else {
+			logging.Infof("Successfully deleted DHCP option %s.", pterm.Green(*identifier))
 		}
+
+		// Record status of this resource
+		e := report.Entry{
+			Identifier:   aws.StringValue(identifier),
+			ResourceType: v.ResourceName(),
+			Error:        err,
+		}
+		report.Record(e)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

In a previous PR, forgot to add logic to report the result. 
Without this, we won't see final result. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

