### PR TITLE
SQS: Fix timestamp parsing

### DIFF
--- a/aws/resources/sqs_test.go
+++ b/aws/resources/sqs_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -55,12 +56,12 @@ func TestSqsQueue_GetAll(t *testing.T) {
 			GetQueueAttributesOutput: map[string]sqs.GetQueueAttributesOutput{
 				queue1: {
 					Attributes: map[string]*string{
-						"CreatedTimestamp": awsgo.String(now.Format(time.RFC3339)),
+						"CreatedTimestamp": awsgo.String(strconv.FormatInt(now.Unix(), 10)),
 					},
 				},
 				queue2: {
 					Attributes: map[string]*string{
-						"CreatedTimestamp": awsgo.String(now.Add(1).Format(time.RFC3339)),
+						"CreatedTimestamp": awsgo.String(strconv.FormatInt(now.Add(1).Unix(), 10)),
 					},
 				},
 			},


### PR DESCRIPTION
This was broken by PR #517. SQS uses Unix timestamps, so we need to make sure to treat them as such.

## Description

Fixes #618.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [N/A] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [N/A] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [N/A] Include release notes. If this PR is backward incompatible, include a migration guide.
- [N/A] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

N/A Bugfix only for master

### Migration Guide

N/A