### PR TITLE
Implement wait logic in transite gateway attachment

### DIFF
--- a/aws/resource_registry.go
+++ b/aws/resource_registry.go
@@ -67,6 +67,10 @@ func getRegisteredRegionalResources() []AwsResource {
 		&resources.EC2Instances{},
 		&resources.EC2DedicatedHosts{},
 		&resources.EC2KeyPairs{},
+		&resources.TransitGateways{},
+		&resources.TransitGatewaysRouteTables{},
+		// Note: nuking transitgateway vpc attachement before nuking the vpc since vpc could be associated with it.
+		&resources.TransitGatewaysVpcAttachment{},
 		&resources.EC2VPCs{},
 		// Note: nuking EC2 DHCP options after nuking EC2 VPC because DHCP options could be associated with VPCs.
 		&resources.EC2DhcpOption{},
@@ -103,9 +107,6 @@ func getRegisteredRegionalResources() []AwsResource {
 		&resources.Snapshots{},
 		&resources.SNSTopic{},
 		&resources.SqsQueue{},
-		&resources.TransitGatewaysVpcAttachment{},
-		&resources.TransitGatewaysRouteTables{},
-		&resources.TransitGateways{},
 		&resources.EC2IPAMs{},
 		&resources.EC2IpamScopes{},
 		&resources.EC2IPAMResourceDiscovery{},


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/624.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

