### PR TITLE
Implement Elastic Bean Stalk to cloud-nuke

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Cloud-nuke suppports 🔎 inspecting and 🔥💀 deleting the following AWS res
 | Elasticache             | Clusters                                                 |
 | Elasticache             | Parameter Groups                                         |
 | Elasticache             | Subnet Groups                                            |
+| Elastic Beanstalk       | Applications                                             |
 | ECS                     | Services                                                 |
 | ECS                     | Clusters                                                 |
 | EKS                     | Clusters                                                 |
@@ -509,6 +510,7 @@ of the file that are supported are listed here.
 | rds-subnet-group            | DBSubnetGroups               | ✅ (DB Subnet Group Name)              | ❌                                   | ❌    |
 | dynamodb                    | DynamoDB                     | ✅ (Table Name)                        | ✅ (Creation Time)                   | ❌    |
 | ebs                         | EBSVolume                    | ✅ (Volume Name)                       | ✅ (Creation Time)                   | ✅    |
+| elastic-beanstalk           | ElasticBeanstalk             | ✅ (Application Name)                  | ✅ (Creation Time)                   | ❌    |
 | ec2                         | EC2                          | ✅ (Instance Name)                     | ✅ (Launch Time)                     | ✅    |
 | ec2-dedicated-hosts         | EC2DedicatedHosts            | ✅ (EC2 Name Tag)                      | ✅ (Allocation Time)                 | ❌    |
 | ec2-dhcp-option             | EC2DhcpOption                | ❌                                     | ❌                                   | ❌    |

--- a/aws/resource_registry.go
+++ b/aws/resource_registry.go
@@ -64,6 +64,7 @@ func getRegisteredRegionalResources() []AwsResource {
 		&resources.ConfigServiceRule{},
 		&resources.DynamoDB{},
 		&resources.EBSVolumes{},
+		&resources.EBApplications{},
 		&resources.EC2Instances{},
 		&resources.EC2DedicatedHosts{},
 		&resources.EC2KeyPairs{},

--- a/aws/resources/elastic_beanstalk.go
+++ b/aws/resources/elastic_beanstalk.go
@@ -1,0 +1,71 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+func shouldIncludeEBApplication(app *elasticbeanstalk.ApplicationDescription, configObj config.Config) bool {
+	return configObj.ElasticBeanstalk.ShouldInclude(config.ResourceValue{
+		Name: app.ApplicationName,
+		Time: app.DateCreated,
+	})
+}
+
+// Returns a formatted string of EB application ids
+func (eb *EBApplications) getAll(c context.Context, configObj config.Config) ([]*string, error) {
+	output, err := eb.Client.DescribeApplications(&elasticbeanstalk.DescribeApplicationsInput{})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+	var appIds []*string
+	for _, app := range output.Applications {
+		if shouldIncludeEBApplication(app, configObj) {
+			appIds = append(appIds, app.ApplicationName)
+		}
+	}
+	return appIds, nil
+}
+
+// Deletes all EB Applications
+func (eb *EBApplications) nukeAll(appIds []*string) error {
+	if len(appIds) == 0 {
+		logging.Debugf("No Elastic Beanstalk to nuke in region %s", eb.Region)
+		return nil
+	}
+
+	logging.Debugf("Deleting all Elastic Beanstalk applications in region %s", eb.Region)
+	var deletedApps []*string
+
+	for _, id := range appIds {
+		_, err := eb.Client.DeleteApplication(&elasticbeanstalk.DeleteApplicationInput{
+			ApplicationName:     id,
+			TerminateEnvByForce: aws.Bool(true),
+		})
+		// Record status of this resource
+		e := report.Entry{
+			Identifier:   aws.StringValue(id),
+			ResourceType: "Elastic Beanstalk Application",
+			Error:        err,
+		}
+		report.Record(e)
+
+		if err != nil {
+			logging.Debugf("[Failed] %s", err)
+			continue
+		}
+
+		// get the deleted ids
+		deletedApps = append(deletedApps, id)
+		logging.Debugf("Deleted Elastic Beanstalk application: %s", *id)
+
+	}
+	logging.Debugf("[OK] %d Elastic Beanstalk application(s) deleted in %s", len(deletedApps), eb.Region)
+	return nil
+}

--- a/aws/resources/elastic_beanstalk_test.go
+++ b/aws/resources/elastic_beanstalk_test.go
@@ -1,0 +1,99 @@
+package resources
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
+	"github.com/aws/aws-sdk-go/service/elasticbeanstalk/elasticbeanstalkiface"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/stretchr/testify/require"
+)
+
+type mockedEBApplication struct {
+	elasticbeanstalkiface.ElasticBeanstalkAPI
+	DescribeApplicationsOutput elasticbeanstalk.DescribeApplicationsOutput
+}
+
+func (mock *mockedEBApplication) DescribeApplications(req *elasticbeanstalk.DescribeApplicationsInput) (*elasticbeanstalk.DescribeApplicationsOutput, error) {
+	return &mock.DescribeApplicationsOutput, nil
+}
+
+func (mock *mockedEBApplication) DeleteApplication(*elasticbeanstalk.DeleteApplicationInput) (*elasticbeanstalk.DeleteApplicationOutput, error) {
+	return nil, nil
+}
+
+func TestEBApplication_GetAll(t *testing.T) {
+	t.Parallel()
+
+	app1 := "demo-app-golang-backend"
+	app2 := "demo-app-golang-frontend"
+
+	now := time.Now()
+	eb := EBApplications{
+		Client: &mockedEBApplication{
+			DescribeApplicationsOutput: elasticbeanstalk.DescribeApplicationsOutput{
+				Applications: []*elasticbeanstalk.ApplicationDescription{
+					{
+						ApplicationArn:  aws.String("app-arn-01"),
+						ApplicationName: &app1,
+						DateCreated:     aws.Time(now),
+					},
+					{
+						ApplicationArn:  aws.String("app-arn-02"),
+						ApplicationName: &app2,
+						DateCreated:     aws.Time(now.Add(1)),
+					},
+				},
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		configObj config.ResourceType
+		expected  []string
+	}{
+		"emptyFilter": {
+			configObj: config.ResourceType{},
+			expected: []string{
+				app1, app2,
+			},
+		},
+		"nameExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					NamesRegExp: []config.Expression{{
+						RE: *regexp.MustCompile(app1),
+					}}},
+			},
+			expected: []string{app2},
+		},
+		"timeAfterExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					TimeAfter: aws.Time(now),
+				}},
+			expected: []string{app1},
+		},
+		"timeBeforeExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					TimeBefore: aws.Time(now.Add(1)),
+				}},
+			expected: []string{app2},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			names, err := eb.getAll(context.Background(), config.Config{
+				ElasticBeanstalk: tc.configObj,
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, aws.StringValueSlice(names))
+		})
+	}
+}

--- a/aws/resources/elastic_beanstalk_types.go
+++ b/aws/resources/elastic_beanstalk_types.go
@@ -1,0 +1,58 @@
+package resources
+
+import (
+	"context"
+
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
+	"github.com/aws/aws-sdk-go/service/elasticbeanstalk/elasticbeanstalkiface"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+// EBSVolumes - represents all ebs volumes
+type EBApplications struct {
+	BaseAwsResource
+	Client elasticbeanstalkiface.ElasticBeanstalkAPI
+	Region string
+	appIds []string
+}
+
+func (eb *EBApplications) Init(session *session.Session) {
+	eb.Client = elasticbeanstalk.New(session)
+}
+
+// ResourceName - the simple name of the aws resource
+func (eb *EBApplications) ResourceName() string {
+	return "elastic-beanstalk"
+}
+
+// ResourceIdentifiers - The volume ids of the ebs volumes
+func (eb *EBApplications) ResourceIdentifiers() []string {
+	return eb.appIds
+}
+
+func (eb *EBApplications) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 49
+}
+
+func (eb *EBApplications) GetAndSetIdentifiers(c context.Context, configObj config.Config) ([]string, error) {
+	identifiers, err := eb.getAll(c, configObj)
+	if err != nil {
+		return nil, err
+	}
+
+	eb.appIds = awsgo.StringValueSlice(identifiers)
+	return eb.appIds, nil
+}
+
+// Nuke - nuke 'em all!!!
+func (eb *EBApplications) Nuke(identifiers []string) error {
+	if err := eb.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	DBSubnetGroups                  ResourceType               `yaml:"DBSubnetGroups"`
 	DynamoDB                        ResourceType               `yaml:"DynamoDB"`
 	EBSVolume                       ResourceType               `yaml:"EBSVolume"`
+	ElasticBeanstalk                ResourceType               `yaml:"ElasticBeanstalk"`
 	EC2                             ResourceType               `yaml:"EC2"`
 	EC2DedicatedHosts               ResourceType               `yaml:"EC2DedicatedHosts"`
 	EC2DHCPOption                   ResourceType               `yaml:"EC2DhcpOption"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -58,6 +58,7 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},
+		ResourceType{FilterRule{}, FilterRule{}},
 		KMSCustomerKeyResourceType{false, ResourceType{FilterRule{}, FilterRule{}}},
 		ResourceType{FilterRule{}, FilterRule{}},
 		ResourceType{FilterRule{}, FilterRule{}},


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/351.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

