### PR TITLE
Stop tasks before nuking ECS cluster

### DIFF
--- a/aws/resources/ecs_cluster.go
+++ b/aws/resources/ecs_cluster.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"github.com/gruntwork-io/cloud-nuke/util"
 	"time"
+
+	"github.com/gruntwork-io/cloud-nuke/util"
 
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
@@ -124,6 +125,34 @@ func (clusters *ECSClusters) getAll(c context.Context, configObj config.Config) 
 	return filteredEcsClusters, nil
 }
 
+func (clusters *ECSClusters) stopClusterRunningTasks(clusterArn *string) error {
+	logging.Debugf("[TASK] stopping tasks running on cluster %v", *clusterArn)
+	// before deleting the cluster, remove the active tasks on that cluster
+	runningTasks, err := clusters.Client.ListTasks(&ecs.ListTasksInput{
+		Cluster:       clusterArn,
+		DesiredStatus: aws.String("RUNNING"),
+	})
+
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	// stop the listed tasks
+	for _, task := range runningTasks.TaskArns {
+		_, err := clusters.Client.StopTask(&ecs.StopTaskInput{
+			Cluster: clusterArn,
+			Task:    task,
+			Reason:  aws.String("Terminating task due to cluster deletion"),
+		})
+		if err != nil {
+			logging.Debugf("[TASK] Unable to stop the task %s on cluster %s. Reason: %v", *task, *clusterArn, err)
+			return errors.WithStackTrace(err)
+		}
+		logging.Debugf("[TASK] Success, stopped task %v", *task)
+	}
+	return nil
+}
+
 func (clusters *ECSClusters) nukeAll(ecsClusterArns []*string) error {
 	numNuking := len(ecsClusterArns)
 
@@ -136,10 +165,18 @@ func (clusters *ECSClusters) nukeAll(ecsClusterArns []*string) error {
 
 	var nukedEcsClusters []*string
 	for _, clusterArn := range ecsClusterArns {
+
+		// before nuking the clusters, do check active tasks on the cluster and stop all of them
+		err := clusters.stopClusterRunningTasks(clusterArn)
+		if err != nil {
+			logging.Debugf("Error, unable to stop the running stasks on the cluster %s %s", aws.StringValue(clusterArn), err)
+			return errors.WithStackTrace(err)
+		}
+
 		params := &ecs.DeleteClusterInput{
 			Cluster: clusterArn,
 		}
-		_, err := clusters.Client.DeleteCluster(params)
+		_, err = clusters.Client.DeleteCluster(params)
 
 		// Record status of this resource
 		e := report.Entry{
@@ -150,7 +187,7 @@ func (clusters *ECSClusters) nukeAll(ecsClusterArns []*string) error {
 		report.Record(e)
 
 		if err != nil {
-			logging.Debugf("Error, failed to delete cluster with ARN %s", aws.StringValue(clusterArn))
+			logging.Debugf("Error, failed to delete cluster with ARN %s %s", aws.StringValue(clusterArn), err)
 			telemetry.TrackEvent(commonTelemetry.EventContext{
 				EventName: "Error Nuking ECS Cluster",
 			}, map[string]interface{}{


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/368

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

