### PR TITLE
Move telemetry down in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,5 @@
 [![Maintained by Gruntwork.io](https://img.shields.io/badge/maintained%20by-gruntwork.io-%235849a6.svg)](https://gruntwork.io/?ref=repo_cloud_nuke)
 
-## Telemetry
-
-As of version `v0.29.0` cloud-nuke sends telemetry back to Gruntwork to help us better prioritize bug fixes and feature
-improvements. The following metrics are included:
-
-- Command and Arguments
-- Version Number
-- Timestamps
-- Resource Types
-- Resource Counts
-- A randomly generated Run ID
-- AWS Account ID
-
-We never collect
-
-- IP Addresses
-- Resource Names
-
-Telemetry can be disabled entirely by setting the `DISABLE_TELEMETRY` environment variable on the command line.
-
-As an open source tool, you can see the exact statistics being collected by searching the code for
-`telemetry.TrackEvent(...)`
-
 # cloud-nuke
 
 This repo contains a CLI tool to delete all resources . cloud-nuke was created for situations when you might have an
@@ -135,6 +112,29 @@ be used in a production environment!
 
 When executed as `cloud-nuke defaults-aws`, this tool deletes all DEFAULT VPCs and the default ingress/egress rule for
 all default security groups. This should be used in production environments **WITH CAUTION**.
+
+## Telemetry
+
+As of version `v0.29.0` cloud-nuke sends telemetry back to Gruntwork to help us better prioritize bug fixes and feature
+improvements. The following metrics are included:
+
+- Command and Arguments
+- Version Number
+- Timestamps
+- Resource Types
+- Resource Counts
+- A randomly generated Run ID
+- AWS Account ID
+
+We never collect
+
+- IP Addresses
+- Resource Names
+
+Telemetry can be disabled entirely by setting the `DISABLE_TELEMETRY` environment variable on the command line.
+
+As an open source tool, you can see the exact statistics being collected by searching the code for
+`telemetry.TrackEvent(...)`
 
 ## Install
 


### PR DESCRIPTION
I've found it very annoying that the very top of the cloud-nuke README file is a note about telemetry. Being up front about this is important, but it shouldn't appear before the README even introduces what the tool is or does!

This PR moves the telemetry note below that, but still above install, so it should still get high visibility.

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

