### PR TITLE
Add IGW exclusion to not delete in phxdevops

### DIFF
--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -276,4 +276,5 @@ MSKCluster:
 InternetGateway:
   exclude:
     names_regex:
+      # Exclude the IGW for default VPCs in phxdevops
       - "gw-new-default-igw"

--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -272,3 +272,8 @@ MSKCluster:
       - "^msk-cluster-[a-zA-Z0-9]{6}$"
       - "^msk-cluster-[a-zA-Z0-9]{6}-.*"
       - "^msk-tiered-storage-test.*"
+  
+InternetGateway:
+  exclude:
+    names_regex:
+      - "gw-new-default-igw"

--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -276,5 +276,7 @@ MSKCluster:
 InternetGateway:
   exclude:
     names_regex:
-      # Exclude the IGW for default VPCs in phxdevops
+      # Exclude the IGW for default VPCs in phxdevops. This IGW is attached to the default VPC
+      # and is used by tests that require internet access from within the VPC. Without it, any
+      # VPC-based test that requires internet will fail.
       - "gw-new-default-igw"


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* Add name exclusion for IGW in phxdevops

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes

<!-- One-line description of the PR that can be included in the final release notes. -->
Added name exclusion for IGW in phxdevops