### PR TITLE
condition to allow multi region list only to us-west-2

### DIFF
--- a/aws/resources/s3_multi_region_access_point_test.go
+++ b/aws/resources/s3_multi_region_access_point_test.go
@@ -42,6 +42,7 @@ func TestS3MultiRegionAccessPoint_GetAll(t *testing.T) {
 	now := time.Now()
 
 	ap := S3MultiRegionAccessPoint{
+		Region: "us-west-2",
 		Client: mockS3MultiRegionAccessPoint{
 			ListMultiRegionAccessPointsOutput: s3control.ListMultiRegionAccessPointsOutput{
 				AccessPoints: []*s3control.MultiRegionAccessPointReport{
@@ -101,6 +102,7 @@ func TestS3MultiRegionAccessPoint_NukeAll(t *testing.T) {
 	t.Parallel()
 
 	rc := S3MultiRegionAccessPoint{
+		Region: "us-west-2",
 		Client: mockS3MultiRegionAccessPoint{
 			DeleteMultiRegionAccessPointOutput: s3control.DeleteMultiRegionAccessPointOutput{},
 		},


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/667.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

