### PR TITLE
Exclude ec2-subnet resource from phxdevops nuke config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
               --exclude-resource-type config-rules \
               --exclude-resource-type eip \
               --exclude-resource-type nat-gateway \
+              --exclude-resource-type ec2-subnet \
               --delete-unaliased-kms-keys \
               --log-level debug
           no_output_timeout: 1h
@@ -85,6 +86,7 @@ jobs:
               --exclude-resource-type config-rules \
               --exclude-resource-type eip \
               --exclude-resource-type nat-gateway \
+              --exclude-resource-type ec2-subnet \
               --delete-unaliased-kms-keys \
               --log-level debug
           no_output_timeout: 1h


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* Adds `ec2-subnet` resource exclusion for `phxdevops`. We use default subnets for tests and they should not be deleted.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes

<!-- One-line description of the PR that can be included in the final release notes. -->
Added `ec2-subnet` resource exclusion for `phxdevops`
