### PR TITLE
Refactor nuking default resources code.

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -26,6 +26,11 @@ func GetAllResources(c context.Context, query *Query, configObj config.Config) (
 	configObj.AddTimeout(query.Timeout)
 
 	configObj.KMSCustomerKeys.IncludeUnaliasedKeys = query.ListUnaliasedKMSKeys
+
+	// Setting the DefaultOnly field
+	// This function only sets the objects that have the `DefaultOnly` field, currently VPC, Subnet, and Security Group.
+	configObj.AddEC2DefaultOnly(query.DefaultOnly)
+
 	account := AwsAccountResources{
 		Resources: make(map[string]AwsResources),
 	}

--- a/aws/query.go
+++ b/aws/query.go
@@ -14,10 +14,11 @@ type Query struct {
 	IncludeAfter         *time.Time
 	ListUnaliasedKMSKeys bool
 	Timeout              *time.Duration
+	DefaultOnly          bool
 }
 
 // NewQuery configures and returns a Query struct that can be passed into the InspectResources method
-func NewQuery(regions, excludeRegions, resourceTypes, excludeResourceTypes []string, excludeAfter, includeAfter *time.Time, listUnaliasedKMSKeys bool, timeout *time.Duration) (*Query, error) {
+func NewQuery(regions, excludeRegions, resourceTypes, excludeResourceTypes []string, excludeAfter, includeAfter *time.Time, listUnaliasedKMSKeys bool, timeout *time.Duration, defaultOnly bool) (*Query, error) {
 	q := &Query{
 		Regions:              regions,
 		ExcludeRegions:       excludeRegions,
@@ -27,6 +28,7 @@ func NewQuery(regions, excludeRegions, resourceTypes, excludeResourceTypes []str
 		IncludeAfter:         includeAfter,
 		ListUnaliasedKMSKeys: listUnaliasedKMSKeys,
 		Timeout:              timeout,
+		DefaultOnly:          defaultOnly,
 	}
 
 	validationErr := q.Validate()

--- a/aws/resources/ec2_subnet_test.go
+++ b/aws/resources/ec2_subnet_test.go
@@ -76,27 +76,32 @@ func TestEc2Subnets_GetAll(t *testing.T) {
 	ec2subnet.BaseAwsResource.Init(nil)
 
 	tests := map[string]struct {
-		configObj config.ResourceType
+		configObj config.EC2ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			configObj: config.ResourceType{},
+			configObj: config.EC2ResourceType{},
 			expected:  []string{subnet1, subnet2},
 		},
 		"nameExclusionFilter": {
-			configObj: config.ResourceType{
-				ExcludeRule: config.FilterRule{
-					NamesRegExp: []config.Expression{{
-						RE: *regexp.MustCompile(testName1),
-					}}},
+			configObj: config.EC2ResourceType{
+				ResourceType: config.ResourceType{
+					ExcludeRule: config.FilterRule{
+						NamesRegExp: []config.Expression{{
+							RE: *regexp.MustCompile(testName1),
+						}},
+					},
+				},
 			},
 			expected: []string{subnet2},
 		},
 		"timeAfterExclusionFilter": {
-			configObj: config.ResourceType{
-				ExcludeRule: config.FilterRule{
-					TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
-				}},
+			configObj: config.EC2ResourceType{
+				ResourceType: config.ResourceType{
+					ExcludeRule: config.FilterRule{
+						TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
+					}},
+			},
 			expected: []string{},
 		},
 	}

--- a/aws/resources/ec2_vpc.go
+++ b/aws/resources/ec2_vpc.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	cerrors "errors"
 	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"strconv"
 	"strings"
 	"time"
 
@@ -59,19 +61,13 @@ func (v *EC2VPCs) getFirstSeenTag(vpc ec2.Vpc) (*time.Time, error) {
 
 func (v *EC2VPCs) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
 	// Note: This filter initially handles non-default resources and can be overridden by passing the only-default filter to choose default VPCs.
-	var isdefault = "false"
-
-	// check the vpc needs to only include default
-	if configObj.VPC.DefaultOnly {
-		logging.Debugf("[default only] Retrieving the default vpcs")
-		isdefault = "true"
-	}
-
 	result, err := v.Client.DescribeVpcs(&ec2.DescribeVpcsInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   awsgo.String("is-default"),
-				Values: awsgo.StringSlice([]string{isdefault}),
+				Name: awsgo.String("is-default"),
+				Values: []*string{
+					aws.String(strconv.FormatBool(configObj.VPC.DefaultOnly)), // convert the bool status into string
+				},
 			},
 		},
 	})

--- a/aws/resources/ec2_vpc.go
+++ b/aws/resources/ec2_vpc.go
@@ -57,14 +57,21 @@ func (v *EC2VPCs) getFirstSeenTag(vpc ec2.Vpc) (*time.Time, error) {
 	return nil, nil
 }
 
-func (v *EC2VPCs) getAll(c context.Context, configObj config.Config) ([]*string, error) {
+func (v *EC2VPCs) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
+	// Note: This filter initially handles non-default resources and can be overridden by passing the only-default filter to choose default VPCs.
+	var isdefault = "false"
+
+	// check the vpc needs to only include default
+	if configObj.VPC.DefaultOnly {
+		logging.Debugf("[default only] Retrieving the default vpcs")
+		isdefault = "true"
+	}
+
 	result, err := v.Client.DescribeVpcs(&ec2.DescribeVpcsInput{
 		Filters: []*ec2.Filter{
-			// Note: this filter omits the default since there is special
-			// handling for default resources already
 			{
 				Name:   awsgo.String("is-default"),
-				Values: awsgo.StringSlice([]string{"false"}),
+				Values: awsgo.StringSlice([]string{isdefault}),
 			},
 		},
 	})

--- a/aws/resources/ec2_vpc_test.go
+++ b/aws/resources/ec2_vpc_test.go
@@ -2,6 +2,10 @@ package resources
 
 import (
 	"context"
+	"regexp"
+	"testing"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -10,9 +14,6 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
-	"regexp"
-	"testing"
-	"time"
 )
 
 type mockedEC2VPCs struct {
@@ -74,27 +75,32 @@ func TestEC2VPC_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		configObj config.ResourceType
+		configObj config.EC2ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			configObj: config.ResourceType{},
+			configObj: config.EC2ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
-			configObj: config.ResourceType{
-				ExcludeRule: config.FilterRule{
-					NamesRegExp: []config.Expression{{
-						RE: *regexp.MustCompile(testName1),
-					}}},
+			configObj: config.EC2ResourceType{
+				ResourceType: config.ResourceType{
+					ExcludeRule: config.FilterRule{
+						NamesRegExp: []config.Expression{{
+							RE: *regexp.MustCompile(testName1),
+						}},
+					},
+				},
 			},
 			expected: []string{testId2},
 		},
 		"timeAfterExclusionFilter": {
-			configObj: config.ResourceType{
-				ExcludeRule: config.FilterRule{
-					TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
-				}},
+			configObj: config.EC2ResourceType{
+				ResourceType: config.ResourceType{
+					ExcludeRule: config.FilterRule{
+						TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
+					}},
+			},
 			expected: []string{},
 		},
 	}

--- a/aws/resources/security_group_test.go
+++ b/aws/resources/security_group_test.go
@@ -89,27 +89,31 @@ func TestSecurityGroup_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		configObj config.ResourceType
+		configObj config.EC2ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			configObj: config.ResourceType{},
+			configObj: config.EC2ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
-			configObj: config.ResourceType{
-				ExcludeRule: config.FilterRule{
-					NamesRegExp: []config.Expression{{
-						RE: *regexp.MustCompile(testName1),
-					}}},
+			configObj: config.EC2ResourceType{
+				ResourceType: config.ResourceType{
+					ExcludeRule: config.FilterRule{
+						NamesRegExp: []config.Expression{{
+							RE: *regexp.MustCompile(testName1),
+						}}},
+				},
 			},
 			expected: []string{testId2},
 		},
 		"timeAfterExclusionFilter": {
-			configObj: config.ResourceType{
-				ExcludeRule: config.FilterRule{
-					TimeAfter: aws.Time(now),
-				}},
+			configObj: config.EC2ResourceType{
+				ResourceType: config.ResourceType{
+					ExcludeRule: config.FilterRule{
+						TimeAfter: aws.Time(now),
+					}},
+				},
 			expected: []string{testId1},
 		},
 	}

--- a/aws/resources/security_group_types.go
+++ b/aws/resources/security_group_types.go
@@ -13,9 +13,10 @@ import (
 
 type SecurityGroup struct {
 	BaseAwsResource
-	Client         ec2iface.EC2API
-	Region         string
-	SecurityGroups []string
+	Client          ec2iface.EC2API
+	Region          string
+	SecurityGroups  []string
+	NukeOnlyDefault bool
 }
 
 func (sg *SecurityGroup) Init(session *session.Session) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,7 +43,7 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
-		ResourceType{FilterRule{}, FilterRule{}, ""},
+		EC2ResourceType{false, ResourceType{FilterRule{}, FilterRule{}, ""}},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
@@ -95,14 +95,14 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
+		EC2ResourceType{false, ResourceType{FilterRule{}, FilterRule{}, ""}},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
-		ResourceType{FilterRule{}, FilterRule{}, ""},
-		ResourceType{FilterRule{}, FilterRule{}, ""},
+		EC2ResourceType{false, ResourceType{FilterRule{}, FilterRule{}, ""}},
 	}
 }
 

--- a/util/error.go
+++ b/util/error.go
@@ -12,6 +12,7 @@ var ErrInSufficientPermission = errors.New("error:INSUFFICIENT_PERMISSION")
 var ErrDifferentOwner = errors.New("error:DIFFERENT_OWNER")
 var ErrContextExecutionTimeout = errors.New("error:EXECUTION_TIMEOUT")
 var ErrInterfaceIDNotFound = errors.New("error:InterfaceIdNotFound")
+var ErrInvalidPermisionNotFound = errors.New("error:InvalidPermission.NotFound")
 
 const AWsUnauthorizedError string = "UnauthorizedOperation"
 const AwsDryRunSuccess string = "Request would have succeeded, but DryRun flag is set."
@@ -35,6 +36,9 @@ func TransformAWSError(err error) error {
 
 	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "DryRunOperation" && awsErr.Message() == AwsDryRunSuccess {
 		return nil
+	}
+	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "InvalidPermission.NotFound" {
+		return ErrInvalidPermisionNotFound
 	}
 	return err
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Partially Fixing https://github.com/gruntwork-io/cloud-nuke/issues/651
TODO: make sure to use default on all EC2 resources. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

