### PR TITLE
Handle parsing of timestamps in time.DateTime format. Fix #670

### DIFF
--- a/util/time.go
+++ b/util/time.go
@@ -1,10 +1,11 @@
 package util
 
 import (
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/go-commons/errors"
-	"time"
 )
 
 const (
@@ -16,7 +17,8 @@ const (
 	FirstSeenTagKey = "cloud-nuke-first-seen"
 
 	// The time format of the `firstSeenTagKey` tag value.
-	firstSeenTimeFormat = time.RFC3339
+	firstSeenTimeFormat       = time.RFC3339
+	firstSeenTimeFormatLegacy = time.DateTime
 )
 
 func IsFirstSeenTag(key *string) bool {
@@ -26,9 +28,12 @@ func IsFirstSeenTag(key *string) bool {
 func ParseTimestamp(timestamp *string) (*time.Time, error) {
 	parsed, err := time.Parse(firstSeenTimeFormat, aws.StringValue(timestamp))
 	if err != nil {
-		logging.Debugf("Error parsing the timestamp into a `RFC3339` Time format")
-		return nil, errors.WithStackTrace(err)
-
+		logging.Debugf("Error parsing the timestamp into a `RFC3339` Time format. Trying parsing the timestamp using the legacy `time.DateTime` format.")
+		parsed, err = time.Parse(firstSeenTimeFormatLegacy, aws.StringValue(timestamp))
+		if err != nil {
+			logging.Debugf("Error parsing the timestamp into legacy `time.DateTime` Time format")
+			return nil, errors.WithStackTrace(err)
+		}
 	}
 
 	return &parsed, nil

--- a/util/time_test.go
+++ b/util/time_test.go
@@ -1,0 +1,50 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+func TestParseTimestamp(t *testing.T) {
+	type args struct {
+		timestamp *string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *time.Time
+		wantErr bool
+	}{
+		{
+			"it should parse legacy firstSeenTag value \"2023-12-19 10:38:44\" correctly",
+			args{timestamp: aws.String("2023-12-19 10:38:44")},
+			newTime(time.Date(2023, 12, 19, 10, 38, 44, 0, time.UTC)),
+			false,
+		},
+		{
+			"it should parse RFC3339 firstSeenTag value \"2024-04-12T15:18:05Z\" correctly",
+			args{timestamp: aws.String("2024-04-12T15:18:05Z")},
+			newTime(time.Date(2024, 4, 12, 15, 18, 5, 0, time.UTC)),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseTimestamp(tt.args.timestamp)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseTimestamp() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseTimestamp() = %v, want %v", got, &tt.want)
+			}
+		})
+	}
+}
+
+func newTime(t time.Time) *time.Time {
+	return &t
+}


### PR DESCRIPTION
## Description

Handle parsing of timestamps in time.DateTime format. Fixes #670

`cloud-nuke` (`v0.35.0`) is currently unable to parse EIPs (and possibly other resources) that are tagged with `cloud-nuke-first-seen` containing non-RFC3339 timestamp as you can see here:
![image](https://github.com/gruntwork-io/cloud-nuke/assets/4834459/d6e46aad-c048-46ee-8edb-1836e16719f6)

This leads to the [EIP not being deleted](https://github.com/gruntwork-io/cloud-nuke/issues/670) due to the following error:
```
 ERROR   Unable to retrieve eip, parsing time "2023-12-19 10:34:26" as "2006-01-02T15:04:05Z07:00": cannot parse " 10:34:26" as "T"
```

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Fixed parsing of FirstSeenTag in non-RFC3339 format to fix EIP nuke


### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

