### PR TITLE
Add more Secrets Manager patterns

### DIFF
--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -48,6 +48,9 @@ SecretsManager:
   include:
     names_regex:
       - "^test-name-[a-zA-Z0-9]{6}$"
+      - "^test-cloud-nuke-.*"
+      - ".*-lambda-docker-[a-zA-Z0-9]{6}$"
+      - "^test[a-zA-Z0-9]{6}-db-secret$"
       - "^GruntworkSampleAppFrontendCA[a-zA-Z0-9]{6}$"
       - "^GruntworkSampleAppBackendCA[a-zA-Z0-9]{6}$"
       - "^RDSDBConfig[a-zA-Z0-9]{6}$"


### PR DESCRIPTION
## Description

Add a few patterns to clean up left over test resources.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

