### PR TITLE
Refactor telemetry reporting logic.

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -63,6 +63,15 @@ func GetAllResources(c context.Context, query *Query, configObj config.Config) (
 				identifiers, err := (*resource).GetAndSetIdentifiers(c, configObj)
 				if err != nil {
 					logging.Errorf("Unable to retrieve %v, %v", (*resource).ResourceName(), err)
+
+					// Reporting resource-level failures encountered during the GetIdentifiers phase
+					// 	Note: This is useful to understand which resources are failing more often than others.
+					telemetry.TrackEvent(commonTelemetry.EventContext{
+						EventName: fmt.Sprintf("error:GetIdentifiers:%s", (*resource).ResourceName()),
+					}, map[string]interface{}{
+						"region": region,
+					})
+
 					ge := report.GeneralError{
 						Error:        err,
 						Description:  fmt.Sprintf("Unable to retrieve %s", (*resource).ResourceName()),
@@ -155,6 +164,14 @@ func nukeAllResourcesInRegion(account *AwsAccountResources, region string, bar *
 				// of the current job.Since we handle each individual resource deletion error within its own resource-specific code,
 				// we can safely discard this error
 				_ = err
+
+				// Report to telemetry - aggregated metrics of failures per resources.
+				// 	Note: This is useful to understand which resources are failing more often than others.
+				telemetry.TrackEvent(commonTelemetry.EventContext{
+					EventName: fmt.Sprintf("error:Nuke:%s", (*awsResource).ResourceName()),
+				}, map[string]interface{}{
+					"region": region,
+				})
 			}
 
 			if i != len(batches)-1 {

--- a/aws/resources/access_analyzer.go
+++ b/aws/resources/access_analyzer.go
@@ -5,9 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/accessanalyzer"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"github.com/hashicorp/go-multierror"
 	"sync"
 )
@@ -64,11 +62,6 @@ func (analyzer *AccessAnalyzer) nukeAll(names []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Access Analyzer",
-			}, map[string]interface{}{
-				"region": analyzer.Region,
-			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/resources/access_analyzer_test.go
+++ b/aws/resources/access_analyzer_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/accessanalyzer"
 	"github.com/aws/aws-sdk-go/service/accessanalyzer/accessanalyzeriface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -30,7 +29,7 @@ func (m mockedAccessAnalyzer) DeleteAnalyzer(input *accessanalyzer.DeleteAnalyze
 }
 
 func TestAccessAnalyzer_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()
@@ -91,7 +90,7 @@ func TestAccessAnalyzer_GetAll(t *testing.T) {
 }
 
 func TestAccessAnalyzer_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	aa := AccessAnalyzer{

--- a/aws/resources/acm.go
+++ b/aws/resources/acm.go
@@ -7,9 +7,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 // Returns a list of strings of ACM ARNs
@@ -80,11 +78,6 @@ func (a *ACM) nukeAll(arns []*string) error {
 		_, err := a.Client.DeleteCertificate(params)
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking ACM",
-			}, map[string]interface{}{
-				"region": a.Region,
-			})
 		} else {
 			deletedCount++
 			logging.Debugf("Deleted ACM: %s", *acmArn)

--- a/aws/resources/acm_test.go
+++ b/aws/resources/acm_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/acm"
 	"github.com/aws/aws-sdk-go/service/acm/acmiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,7 +31,7 @@ func (m mockedACM) DeleteCertificate(input *acm.DeleteCertificateInput) (*acm.De
 }
 
 func TestACMGetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testDomainName := "test-domain-name"
@@ -80,7 +79,7 @@ func TestACMGetAll(t *testing.T) {
 }
 
 func TestACMGetAll_FilterInUse(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testDomainName := "test-domain-name"
@@ -105,7 +104,7 @@ func TestACMGetAll_FilterInUse(t *testing.T) {
 }
 
 func TestACMNukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testDomainName := "test-domain-name"

--- a/aws/resources/acmpca.go
+++ b/aws/resources/acmpca.go
@@ -6,9 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/acmpca"
 	"github.com/gruntwork-io/cloud-nuke/config"
@@ -84,11 +81,6 @@ func (ap *ACMPCA) nukeAll(arns []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Errorf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking ACMPCA",
-			}, map[string]interface{}{
-				"region": ap.Region,
-			})
 		}
 	}
 

--- a/aws/resources/acmpca_test.go
+++ b/aws/resources/acmpca_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/acmpca"
 	"github.com/aws/aws-sdk-go/service/acmpca/acmpcaiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,7 +44,7 @@ func (m mockedACMPCA) DeleteCertificateAuthority(
 }
 
 func TestAcmPcaGetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testArn := "test-arn"
@@ -79,7 +78,7 @@ func TestAcmPcaGetAll(t *testing.T) {
 }
 
 func TestAcmPcaNukeAll_DisabledCA(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testArn := "test-arn"
@@ -102,7 +101,7 @@ func TestAcmPcaNukeAll_DisabledCA(t *testing.T) {
 }
 
 func TestAcmPcaNukeAll_EnabledCA(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testArn := "test-arn"

--- a/aws/resources/ami.go
+++ b/aws/resources/ami.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/gruntwork-io/cloud-nuke/util"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,7 +11,6 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
@@ -86,11 +84,6 @@ func (ami *AMIs) nukeAll(imageIds []*string) error {
 
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking AMI",
-			}, map[string]interface{}{
-				"region": ami.Region,
-			})
 		} else {
 			deletedCount++
 			logging.Debugf("Deleted AMI: %s", *imageID)

--- a/aws/resources/ami_test.go
+++ b/aws/resources/ami_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/assert"
 	"regexp"
 	"testing"
@@ -30,7 +29,7 @@ func (m mockedAMI) DeregisterImage(input *ec2.DeregisterImageInput) (*ec2.Deregi
 }
 
 func TestAMIGetAll_SkipAWSManaged(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName := "test-ami"
@@ -75,7 +74,7 @@ func TestAMIGetAll_SkipAWSManaged(t *testing.T) {
 }
 
 func TestAMIGetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName := "test-ami"
@@ -118,7 +117,7 @@ func TestAMIGetAll(t *testing.T) {
 }
 
 func TestAMINukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName := "test-ami"

--- a/aws/resources/apigateway.go
+++ b/aws/resources/apigateway.go
@@ -4,14 +4,11 @@ import (
 	"context"
 	"sync"
 
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/hashicorp/go-multierror"
 )
@@ -62,12 +59,6 @@ func (gateway *ApiGateway) nukeAll(identifiers []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Debugf("[Failed] %s", err)
-
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking API Gateway",
-			}, map[string]interface{}{
-				"region": gateway.Region,
-			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/resources/apigateway_test.go
+++ b/aws/resources/apigateway_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/aws/aws-sdk-go/service/apigateway/apigatewayiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,7 +41,7 @@ func (m mockedApiGateway) DeleteClientCertificate(*apigateway.DeleteClientCertif
 }
 
 func TestAPIGatewayGetAllAndNukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testApiID := "aws-nuke-test-" + util.UniqueID()
@@ -66,7 +65,7 @@ func TestAPIGatewayGetAllAndNukeAll(t *testing.T) {
 }
 
 func TestAPIGatewayGetAllTimeFilter(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testApiID := "aws-nuke-test-" + util.UniqueID()
@@ -106,7 +105,7 @@ func TestAPIGatewayGetAllTimeFilter(t *testing.T) {
 }
 
 func TestNukeAPIGatewayMoreThanOne(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testApiID1 := "aws-nuke-test-" + util.UniqueID()
@@ -133,7 +132,7 @@ func TestNukeAPIGatewayMoreThanOne(t *testing.T) {
 }
 
 func TestNukeAPIGatewayWithCertificates(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testApiID1 := "aws-nuke-test-" + util.UniqueID()

--- a/aws/resources/apigatewayv2.go
+++ b/aws/resources/apigatewayv2.go
@@ -3,19 +3,15 @@ package resources
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/apigatewayv2/apigatewayv2iface"
-	"github.com/gruntwork-io/cloud-nuke/logging"
-	"sync"
-
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2/apigatewayv2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/hashicorp/go-multierror"
+	"sync"
 )
 
 func (gw *ApiGatewayV2) getAll(c context.Context, configObj config.Config) ([]*string, error) {
@@ -68,11 +64,6 @@ func (gw *ApiGatewayV2) nukeAll(identifiers []*string) error {
 	for _, errChan := range errChans {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking API Gateway V2",
-			}, map[string]interface{}{
-				"region": gw.Region,
-			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/resources/apigatewayv2_test.go
+++ b/aws/resources/apigatewayv2_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go/service/apigatewayv2/apigatewayv2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,7 +47,7 @@ func (m mockedApiGatewayV2) DeleteApiMapping(*apigatewayv2.DeleteApiMappingInput
 }
 
 func TestApiGatewayV2GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testApiID := "test-api-id"
@@ -93,7 +92,7 @@ func TestApiGatewayV2GetAll(t *testing.T) {
 }
 
 func TestApiGatewayV2NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	gw := ApiGatewayV2{

--- a/aws/resources/asg.go
+++ b/aws/resources/asg.go
@@ -7,10 +7,8 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 // Returns a formatted string of ASG Names
@@ -62,11 +60,6 @@ func (ag *ASGroups) nukeAll(groupNames []*string) error {
 
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking ASG",
-			}, map[string]interface{}{
-				"region": ag.Region,
-			})
 		} else {
 			deletedGroupNames = append(deletedGroupNames, groupName)
 			logging.Debugf("Deleted Auto Scaling Group: %s", *groupName)
@@ -79,11 +72,6 @@ func (ag *ASGroups) nukeAll(groupNames []*string) error {
 		})
 		if err != nil {
 			logging.Errorf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking ASG",
-			}, map[string]interface{}{
-				"region": ag.Region,
-			})
 			return errors.WithStackTrace(err)
 		}
 	}

--- a/aws/resources/asg_test.go
+++ b/aws/resources/asg_test.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"regexp"
 	"testing"
 	"time"
@@ -33,7 +32,7 @@ func (m mockedASGroups) WaitUntilGroupNotExists(input *autoscaling.DescribeAutoS
 }
 
 func TestAutoScalingGroupGetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName := "cloud-nuke-test"
@@ -72,7 +71,7 @@ func TestAutoScalingGroupGetAll(t *testing.T) {
 }
 
 func TestAutoScalingGroupNukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	ag := ASGroups{

--- a/aws/resources/backup_vault.go
+++ b/aws/resources/backup_vault.go
@@ -7,9 +7,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 func (bv *BackupVault) getAll(c context.Context, configObj config.Config) ([]*string, error) {
@@ -59,11 +57,6 @@ func (bv *BackupVault) nukeAll(names []*string) error {
 
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking BackupVault",
-			}, map[string]interface{}{
-				"region": bv.Region,
-			})
 		} else {
 			deletedNames = append(deletedNames, name)
 			logging.Debugf("Deleted backup vault: %s", aws.StringValue(name))

--- a/aws/resources/backup_vault_test.go
+++ b/aws/resources/backup_vault_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/backup"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,7 +30,7 @@ func (m mockedBackupVault) DeleteBackupVault(*backup.DeleteBackupVaultInput) (*b
 }
 
 func TestBackupVaultGetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-backup-vault-1"
@@ -91,7 +90,7 @@ func TestBackupVaultGetAll(t *testing.T) {
 }
 
 func TestBackupVaultNuke(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	bv := BackupVault{

--- a/aws/resources/cloudtrail.go
+++ b/aws/resources/cloudtrail.go
@@ -7,9 +7,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 func (ct *CloudtrailTrail) getAll(c context.Context, configObj config.Config) ([]*string, error) {
@@ -62,11 +60,6 @@ func (ct *CloudtrailTrail) nukeAll(arns []*string) error {
 
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Cloudtrail",
-			}, map[string]interface{}{
-				"region": ct.Region,
-			})
 		} else {
 			deletedArns = append(deletedArns, arn)
 			logging.Debugf("Deleted Cloudtrail Trail: %s", aws.StringValue(arn))

--- a/aws/resources/cloudtrail_test.go
+++ b/aws/resources/cloudtrail_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudtrail"
 	"github.com/aws/aws-sdk-go/service/cloudtrail/cloudtrailiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -28,7 +27,7 @@ func (m mockedCloudTrail) DeleteTrail(input *cloudtrail.DeleteTrailInput) (*clou
 }
 
 func TestCloudTrailGetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-name1"
@@ -81,7 +80,7 @@ func TestCloudTrailGetAll(t *testing.T) {
 }
 
 func TestCloudTrailNukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	ct := CloudtrailTrail{

--- a/aws/resources/cloudwatch_alarm.go
+++ b/aws/resources/cloudwatch_alarm.go
@@ -7,10 +7,8 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 func (cw *CloudWatchAlarms) getAll(c context.Context, configObj config.Config) ([]*string, error) {
@@ -68,11 +66,6 @@ func (cw *CloudWatchAlarms) nukeAll(identifiers []*string) error {
 	})
 	if err != nil {
 		logging.Debugf("[Failed] %s", err)
-		telemetry.TrackEvent(commonTelemetry.EventContext{
-			EventName: "Error Nuking Cloudwatch Alarm Dependency",
-		}, map[string]interface{}{
-			"region": cw.Region,
-		})
 	}
 
 	var compositeAlarmNames []*string
@@ -85,11 +78,6 @@ func (cw *CloudWatchAlarms) nukeAll(identifiers []*string) error {
 		})
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Cloudwatch Composite Alarm",
-			}, map[string]interface{}{
-				"region": cw.Region,
-			})
 		}
 
 		// Note: for composite alarms, we need to delete one by one according to the documentation
@@ -120,11 +108,6 @@ func (cw *CloudWatchAlarms) nukeAll(identifiers []*string) error {
 
 	if err != nil {
 		logging.Debugf("[Failed] %s", err)
-		telemetry.TrackEvent(commonTelemetry.EventContext{
-			EventName: "Error Nuking Cloudwatch Alarm",
-		}, map[string]interface{}{
-			"region": cw.Region,
-		})
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/resources/cloudwatch_alarm_test.go
+++ b/aws/resources/cloudwatch_alarm_test.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"regexp"
 	"testing"
 	"time"
@@ -39,7 +38,7 @@ func (m mockedCloudWatchAlarms) DeleteAlarms(input *cloudwatch.DeleteAlarmsInput
 }
 
 func TestCloudWatchAlarm_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-name1"
@@ -93,7 +92,7 @@ func TestCloudWatchAlarm_GetAll(t *testing.T) {
 }
 
 func TestCloudWatchAlarms_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-name1"
@@ -115,7 +114,7 @@ func TestCloudWatchAlarms_NukeAll(t *testing.T) {
 }
 
 func TestCloudWatchCompositeAlarms_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testCompositeAlaram1 := "test-name1"

--- a/aws/resources/cloudwatch_dashboard.go
+++ b/aws/resources/cloudwatch_dashboard.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/go-commons/errors"
 )
 
 func (cwdb *CloudWatchDashboards) getAll(c context.Context, configObj config.Config) ([]*string, error) {
@@ -63,11 +60,6 @@ func (cwdb *CloudWatchDashboards) nukeAll(identifiers []*string) error {
 
 	if err != nil {
 		logging.Debugf("[Failed] %s", err)
-		telemetry.TrackEvent(commonTelemetry.EventContext{
-			EventName: "Error Nuking Cloudwatch Dashboard",
-		}, map[string]interface{}{
-			"region": cwdb.Region,
-		})
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/resources/cloudwatch_dashboard_test.go
+++ b/aws/resources/cloudwatch_dashboard_test.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"regexp"
 	"testing"
 	"time"
@@ -30,7 +29,7 @@ func (m mockedCloudWatchDashboard) DeleteDashboards(input *cloudwatch.DeleteDash
 }
 
 func TestCloudWatchDashboard_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-name1"
@@ -90,7 +89,7 @@ func TestCloudWatchDashboard_GetAll(t *testing.T) {
 }
 
 func TestCloudWatchDashboard_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 	cw := CloudWatchDashboards{
 		Client: mockedCloudWatchDashboard{

--- a/aws/resources/cloudwatch_loggroup.go
+++ b/aws/resources/cloudwatch_loggroup.go
@@ -2,8 +2,6 @@ package resources
 
 import (
 	"context"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -80,11 +78,6 @@ func (csr *CloudWatchLogGroups) nukeAll(identifiers []*string) error {
 		if err := <-errChan; err != nil {
 			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() != "OperationAbortedException" {
 				allErrs = multierror.Append(allErrs, err)
-				telemetry.TrackEvent(commonTelemetry.EventContext{
-					EventName: "Error Nuking Cloudwatch Log Group",
-				}, map[string]interface{}{
-					"region": csr.Region,
-				})
 			}
 		}
 	}

--- a/aws/resources/cloudwatch_loggroup_test.go
+++ b/aws/resources/cloudwatch_loggroup_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -29,7 +28,7 @@ func (m mockedCloudWatchLogGroup) DeleteLogGroup(input *cloudwatchlogs.DeleteLog
 }
 
 func TestCloudWatchLogGroup_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-name1"
@@ -90,7 +89,7 @@ func TestCloudWatchLogGroup_GetAll(t *testing.T) {
 }
 
 func TestCloudWatchLogGroup_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 	cw := CloudWatchLogGroups{
 		Client: mockedCloudWatchLogGroup{

--- a/aws/resources/codedeploy_application.go
+++ b/aws/resources/codedeploy_application.go
@@ -7,9 +7,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"github.com/hashicorp/go-multierror"
 	"sync"
 )
@@ -106,11 +104,6 @@ func (cda *CodeDeployApplications) nukeAll(identifiers []string) error {
 		allErrors = multierror.Append(allErrors, err)
 
 		logging.Errorf("[Failed] Error deleting CodeDeploy Application: %s", err)
-		telemetry.TrackEvent(commonTelemetry.EventContext{
-			EventName: "Error Nuking CodeDeploy Application",
-		}, map[string]interface{}{
-			"region": cda.Region,
-		})
 	}
 
 	finalErr := allErrors.ErrorOrNil()

--- a/aws/resources/codedeploy_application_test.go
+++ b/aws/resources/codedeploy_application_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/codedeploy/codedeployiface"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -51,7 +50,7 @@ func (m mockedCodeDeployApplications) DeleteApplication(input *codedeploy.Delete
 }
 
 func TestCodeDeployApplication_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "cloud-nuke-test-1"

--- a/aws/resources/config_recorder.go
+++ b/aws/resources/config_recorder.go
@@ -7,9 +7,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 func (csr *ConfigServiceRecorders) getAll(c context.Context, configObj config.Config) ([]*string, error) {
@@ -58,11 +56,6 @@ func (csr *ConfigServiceRecorders) nukeAll(configRecorderNames []string) error {
 
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Config Recorder",
-			}, map[string]interface{}{
-				"region": csr.Region,
-			})
 		} else {
 			deletedNames = append(deletedNames, aws.String(configRecorderName))
 			logging.Debugf("Deleted Config Recorder: %s", configRecorderName)

--- a/aws/resources/config_recorder_test.go
+++ b/aws/resources/config_recorder_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/configservice"
 	"github.com/aws/aws-sdk-go/service/configservice/configserviceiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -27,7 +26,7 @@ func (m mockedConfigServiceRecorders) DeleteConfigurationRecorder(input *configs
 }
 
 func TestConfigServiceRecorder_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-recorder-1"
@@ -74,7 +73,7 @@ func TestConfigServiceRecorder_GetAll(t *testing.T) {
 }
 
 func TestConfigServiceRecorder_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	csr := ConfigServiceRecorders{

--- a/aws/resources/config_service_test.go
+++ b/aws/resources/config_service_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/configservice"
 	"github.com/aws/aws-sdk-go/service/configservice/configserviceiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -33,7 +32,7 @@ func (m mockedConfigServiceRule) DeleteRemediationConfiguration(input *configser
 }
 
 func TestConfigServiceRule_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-rule-1"
@@ -80,7 +79,7 @@ func TestConfigServiceRule_GetAll(t *testing.T) {
 }
 
 func TestConfigServiceRule_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	csr := ConfigServiceRule{

--- a/aws/resources/dynamodb.go
+++ b/aws/resources/dynamodb.go
@@ -8,8 +8,6 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"log"
 )
@@ -67,11 +65,6 @@ func (ddb *DynamoDB) nukeAll(tables []*string) error {
 
 		if err != nil {
 			if aerr, ok := err.(awserr.Error); ok {
-				telemetry.TrackEvent(commonTelemetry.EventContext{
-					EventName: "Error Nuking DynamoDB Table",
-				}, map[string]interface{}{
-					"region": ddb.Region,
-				})
 				switch aerr.Error() {
 				case dynamodb.ErrCodeInternalServerError:
 					return errors.WithStackTrace(aerr)

--- a/aws/resources/dynamodb_test.go
+++ b/aws/resources/dynamodb_test.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"regexp"
 	"testing"
 	"time"
@@ -36,7 +35,7 @@ func (m mockedDynamoDB) DeleteTable(input *dynamodb.DeleteTableInput) (*dynamodb
 }
 
 func TestDynamoDB_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "table1"
@@ -104,7 +103,7 @@ func TestDynamoDB_GetAll(t *testing.T) {
 }
 
 func TestDynamoDb_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	ddb := DynamoDB{

--- a/aws/resources/ebs.go
+++ b/aws/resources/ebs.go
@@ -2,16 +2,13 @@ package resources
 
 import (
 	"context"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	"github.com/gruntwork-io/cloud-nuke/util"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
@@ -82,27 +79,10 @@ func (ev *EBSVolumes) nukeAll(volumeIds []*string) error {
 
 		if err != nil {
 			if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == "VolumeInUse" {
-				telemetry.TrackEvent(commonTelemetry.EventContext{
-					EventName: "Error Nuking EBS Volume",
-				}, map[string]interface{}{
-					"region": ev.Region,
-					"reason": "VolumeInUse",
-				})
 				logging.Debugf("EBS volume %s can't be deleted, it is still attached to an active resource", *volumeID)
 			} else if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == "InvalidVolume.NotFound" {
-				telemetry.TrackEvent(commonTelemetry.EventContext{
-					EventName: "Error Nuking EBS Volume",
-				}, map[string]interface{}{
-					"region": ev.Region,
-					"reason": "InvalidVolume.NotFound",
-				})
 				logging.Debugf("EBS volume %s has already been deleted", *volumeID)
 			} else {
-				telemetry.TrackEvent(commonTelemetry.EventContext{
-					EventName: "Error Nuking EBS Volume",
-				}, map[string]interface{}{
-					"region": ev.Region,
-				})
 				logging.Debugf("[Failed] %s", err)
 			}
 		} else {
@@ -117,11 +97,6 @@ func (ev *EBSVolumes) nukeAll(volumeIds []*string) error {
 		})
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking EBS Volume",
-			}, map[string]interface{}{
-				"region": ev.Region,
-			})
 			return errors.WithStackTrace(err)
 		}
 	}

--- a/aws/resources/ebs_test.go
+++ b/aws/resources/ebs_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-
 	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -35,7 +33,7 @@ func (m mockedEBS) WaitUntilVolumeDeleted(input *ec2.DescribeVolumesInput) error
 }
 
 func TestEBSVolume_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-name1"
@@ -103,7 +101,7 @@ func TestEBSVolume_GetAll(t *testing.T) {
 }
 
 func TestEBSVolumne_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	ev := EBSVolumes{

--- a/aws/resources/ec2.go
+++ b/aws/resources/ec2.go
@@ -6,9 +6,7 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/cloud-nuke/externalcreds"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pterm/pterm"
@@ -136,11 +134,6 @@ func (ei *EC2Instances) nukeAll(instanceIds []*string) error {
 	err := ei.releaseEIPs(instanceIds)
 	if err != nil {
 		logging.Debugf("[Failed EIP release] %s", err)
-		telemetry.TrackEvent(commonTelemetry.EventContext{
-			EventName: "Error Nuking EC2 Instance EPI release",
-		}, map[string]interface{}{
-			"region": ei.Region,
-		})
 		return errors.WithStackTrace(err)
 	}
 
@@ -153,11 +146,6 @@ func (ei *EC2Instances) nukeAll(instanceIds []*string) error {
 	_, err = ei.Client.TerminateInstances(params)
 	if err != nil {
 		logging.Debugf("[Failed] %s", err)
-		telemetry.TrackEvent(commonTelemetry.EventContext{
-			EventName: "Error Nuking EC2 Instance",
-		}, map[string]interface{}{
-			"region": ei.Region,
-		})
 		return errors.WithStackTrace(err)
 	}
 
@@ -175,11 +163,6 @@ func (ei *EC2Instances) nukeAll(instanceIds []*string) error {
 
 	if err != nil {
 		logging.Debugf("[Failed] %s", err)
-		telemetry.TrackEvent(commonTelemetry.EventContext{
-			EventName: "Error Nuking EC2 Instance",
-		}, map[string]interface{}{
-			"region": ei.Region,
-		})
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/resources/ec2_dedicated_host.go
+++ b/aws/resources/ec2_dedicated_host.go
@@ -10,10 +10,8 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 func (h *EC2DedicatedHosts) getAll(c context.Context, configObj config.Config) ([]*string, error) {
@@ -86,11 +84,6 @@ func (h *EC2DedicatedHosts) nukeAll(hostIds []*string) error {
 
 	if err != nil {
 		logging.Debugf("[Failed] %s", err)
-		telemetry.TrackEvent(commonTelemetry.EventContext{
-			EventName: "Error Nuking EC2 Dedicated Hosts",
-		}, map[string]interface{}{
-			"region": h.Region,
-		})
 		return errors.WithStackTrace(err)
 	}
 
@@ -105,11 +98,6 @@ func (h *EC2DedicatedHosts) nukeAll(hostIds []*string) error {
 	}
 
 	for _, hostFailed := range releaseResult.Unsuccessful {
-		telemetry.TrackEvent(commonTelemetry.EventContext{
-			EventName: "Error Nuking EC2 Dedicated Host",
-		}, map[string]interface{}{
-			"region": h.Region,
-		})
 		logging.Debugf("[ERROR] Unable to release dedicated host %s in %s: %s", aws.StringValue(hostFailed.ResourceId), h.Region, aws.StringValue(hostFailed.Error.Message))
 		e := report.Entry{
 			Identifier:   aws.StringValue(hostFailed.ResourceId),

--- a/aws/resources/ec2_dedicated_host_test.go
+++ b/aws/resources/ec2_dedicated_host_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -30,7 +29,7 @@ func (m mockedEC2DedicatedHosts) ReleaseHosts(input *ec2.ReleaseHostsInput) (*ec
 }
 
 func TestEC2DedicatedHosts_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testId1 := "test-host-id-1"
@@ -105,7 +104,7 @@ func TestEC2DedicatedHosts_GetAll(t *testing.T) {
 }
 
 func TestEC2DedicatedHosts_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	h := EC2DedicatedHosts{

--- a/aws/resources/ec2_dhcp_option_test.go
+++ b/aws/resources/ec2_dhcp_option_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -27,7 +26,7 @@ func (m mockedEC2DhcpOption) DeleteDhcpOptions(input *ec2.DeleteDhcpOptionsInput
 }
 
 func TestEC2DhcpOption_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testId1 := "test-id-1"
@@ -65,7 +64,7 @@ func TestEC2DhcpOption_GetAll(t *testing.T) {
 }
 
 func TestEC2DhcpOption_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	h := EC2DhcpOption{

--- a/aws/resources/ec2_egress_only_igw_test.go
+++ b/aws/resources/ec2_egress_only_igw_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +30,7 @@ func (m mockedEgressOnlyIgw) DeleteEgressOnlyInternetGateway(_ *ec2.DeleteEgress
 }
 
 func TestEgressOnlyInternetGateway_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	var (
@@ -121,7 +120,7 @@ func TestEgressOnlyInternetGateway_GetAll(t *testing.T) {
 }
 
 func TestEc2EgressOnlyInternetGateway_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	var (

--- a/aws/resources/ec2_endpoints_test.go
+++ b/aws/resources/ec2_endpoints_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +30,7 @@ func (m mockedEc2VpcEndpoints) DeleteVpcEndpoints(_ *ec2.DeleteVpcEndpointsInput
 }
 
 func TestVcpEndpoint_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	var (
@@ -121,7 +120,7 @@ func TestVcpEndpoint_GetAll(t *testing.T) {
 }
 
 func TestEc2Endpoints_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	var (

--- a/aws/resources/ec2_internet_gateway_test.go
+++ b/aws/resources/ec2_internet_gateway_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 )
@@ -36,7 +35,7 @@ func (m mockedInternetGateway) DeleteInternetGateway(_ *ec2.DeleteInternetGatewa
 }
 
 func TestEc2InternetGateway_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	var (
@@ -120,7 +119,7 @@ func TestEc2InternetGateway_GetAll(t *testing.T) {
 }
 
 func TestEc2InternetGateway_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	var (

--- a/aws/resources/ec2_key_pair.go
+++ b/aws/resources/ec2_key_pair.go
@@ -5,9 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/hashicorp/go-multierror"
 )
@@ -60,11 +58,6 @@ func (k *EC2KeyPairs) nukeAll(keypairIds []*string) error {
 	var multiErr *multierror.Error
 	for _, keypair := range keypairIds {
 		if err := k.deleteKeyPair(keypair); err != nil {
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking EC2 Key Pair",
-			}, map[string]interface{}{
-				"region": k.Region,
-			})
 			logging.Errorf("[Failed] %s", err)
 			multiErr = multierror.Append(multiErr, err)
 		} else {

--- a/aws/resources/ec2_key_pair_test.go
+++ b/aws/resources/ec2_key_pair_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -29,7 +28,7 @@ func (m mockedEC2KeyPairs) DeleteKeyPair(input *ec2.DeleteKeyPairInput) (*ec2.De
 }
 
 func TestEC2KeyPairs_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()
@@ -93,7 +92,7 @@ func TestEC2KeyPairs_GetAll(t *testing.T) {
 }
 
 func TestEC2KeyPairs_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	h := EC2KeyPairs{

--- a/aws/resources/ec2_network_acl_test.go
+++ b/aws/resources/ec2_network_acl_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 )
@@ -37,7 +36,6 @@ func (m mockedNetworkACL) ReplaceNetworkAclAssociation(*ec2.ReplaceNetworkAclAss
 }
 
 func TestNetworkAcl_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
 
 	var (
 		now     = time.Now()
@@ -133,7 +131,6 @@ func TestNetworkAcl_GetAll(t *testing.T) {
 }
 
 func TestNetworkAcl_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
 
 	var (
 		testId1 = "acl-09e36c45cbdbfb001"

--- a/aws/resources/ec2_network_interface_test.go
+++ b/aws/resources/ec2_network_interface_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 )
@@ -50,7 +49,6 @@ func (m mockedNetworkInterface) WaitUntilInstanceTerminated(*ec2.DescribeInstanc
 }
 
 func TestNetworkInterface_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
 
 	var (
 		now     = time.Now()
@@ -146,7 +144,7 @@ func TestNetworkInterface_GetAll(t *testing.T) {
 }
 
 func TestNetworkInterface_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	var (

--- a/aws/resources/ec2_subnet_test.go
+++ b/aws/resources/ec2_subnet_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +29,7 @@ func (m mockedEC2Subnets) DeleteSubnet(_ *ec2.DeleteSubnetInput) (*ec2.DeleteSub
 }
 
 func TestEc2Subnets_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	var (
@@ -118,7 +117,7 @@ func TestEc2Subnets_GetAll(t *testing.T) {
 }
 
 func TestEc2Subnet_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	tgw := EC2Subnet{

--- a/aws/resources/ec2_test.go
+++ b/aws/resources/ec2_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,7 +50,7 @@ func (m mockedEC2Instances) ReleaseAddress(input *ec2.ReleaseAddressInput) (*ec2
 }
 
 func TestEc2Instances_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testId1 := "testId1"
@@ -141,7 +140,7 @@ func TestEc2Instances_GetAll(t *testing.T) {
 }
 
 func TestEc2Instances_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	ei := EC2Instances{

--- a/aws/resources/ec2_vpc.go
+++ b/aws/resources/ec2_vpc.go
@@ -13,9 +13,6 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/pterm/pterm"
 
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
@@ -128,11 +125,6 @@ func (v *EC2VPCs) nukeAll(vpcIds []string) error {
 		if err != nil {
 
 			pterm.Error.Println(fmt.Sprintf("Failed to nuke vpc with err: %s", err))
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking VPC",
-			}, map[string]interface{}{
-				"region": v.Region,
-			})
 			multierror.Append(multiErr, err)
 		} else {
 			deletedVPCs++

--- a/aws/resources/ec2_vpc_test.go
+++ b/aws/resources/ec2_vpc_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +30,7 @@ func (m mockedEC2VPCs) DeleteVpc(input *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutpu
 }
 
 func TestEC2VPC_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-vpc-name1"
@@ -117,7 +116,7 @@ func TestEC2VPC_GetAll(t *testing.T) {
 
 // TODO: Fix this test
 //func TestEC2VPC_NukeAll(t *testing.T) {
-//	telemetry.InitTelemetry("cloud-nuke", "")
+//
 //	t.Parallel()
 //
 //	vpc := EC2VPCs{

--- a/aws/resources/ecr.go
+++ b/aws/resources/ecr.go
@@ -7,9 +7,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 func (registry *ECR) getAll(c context.Context, configObj config.Config) ([]*string, error) {
@@ -61,11 +59,6 @@ func (registry *ECR) nukeAll(repositoryNames []string) error {
 		report.Record(e)
 
 		if err != nil {
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking ECR Repo",
-			}, map[string]interface{}{
-				"region": registry.Region,
-			})
 			logging.Debugf("[Failed] %s", err)
 		} else {
 

--- a/aws/resources/ecr_test.go
+++ b/aws/resources/ecr_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/aws/aws-sdk-go/service/ecr/ecriface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -29,7 +28,7 @@ func (m mockedECR) DeleteRepository(input *ecr.DeleteRepositoryInput) (*ecr.Dele
 }
 
 func TestECR_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-repo1"
@@ -90,7 +89,7 @@ func TestECR_GetAll(t *testing.T) {
 }
 
 func TestECR_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	er := ECR{

--- a/aws/resources/ecs_cluster.go
+++ b/aws/resources/ecs_cluster.go
@@ -6,9 +6,6 @@ import (
 
 	"github.com/gruntwork-io/cloud-nuke/util"
 
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-
 	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -188,11 +185,6 @@ func (clusters *ECSClusters) nukeAll(ecsClusterArns []*string) error {
 
 		if err != nil {
 			logging.Debugf("Error, failed to delete cluster with ARN %s %s", aws.StringValue(clusterArn), err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking ECS Cluster",
-			}, map[string]interface{}{
-				"region": clusters.Region,
-			})
 			return errors.WithStackTrace(err)
 		}
 

--- a/aws/resources/ecs_cluster_test.go
+++ b/aws/resources/ecs_cluster_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 )
@@ -54,7 +53,7 @@ func (m mockedEC2Cluster) StopTask(*ecs.StopTaskInput) (*ecs.StopTaskOutput, err
 }
 
 func TestEC2Cluster_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testArn1 := "arn:aws:ecs:us-east-1:123456789012:cluster/cluster1"
@@ -141,7 +140,7 @@ func TestEC2Cluster_GetAll(t *testing.T) {
 }
 
 func TestEC2Cluster_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	ec := ECSClusters{
@@ -155,7 +154,7 @@ func TestEC2Cluster_NukeAll(t *testing.T) {
 }
 
 func TestEC2ClusterWithTasks_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	ec := ECSClusters{

--- a/aws/resources/ecs_service.go
+++ b/aws/resources/ecs_service.go
@@ -2,9 +2,7 @@ package resources
 
 import (
 	"context"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 
 	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
@@ -116,12 +114,6 @@ func (services *ECSServices) drainEcsServices(ecsServiceArns []*string) []*strin
 		describeServicesOutput, err := services.Client.DescribeServices(describeParams)
 		if err != nil {
 			logging.Errorf("[Failed] Failed to describe service %s: %s", *ecsServiceArn, err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking ECS Service",
-			}, map[string]interface{}{
-				"region": services.Region,
-				"reason": "Unable to describe",
-			})
 		} else {
 
 			schedulingStrategy := *describeServicesOutput.Services[0].SchedulingStrategy
@@ -136,12 +128,6 @@ func (services *ECSServices) drainEcsServices(ecsServiceArns []*string) []*strin
 				_, err = services.Client.UpdateService(params)
 				if err != nil {
 					logging.Errorf("[Failed] Failed to drain service %s: %s", *ecsServiceArn, err)
-					telemetry.TrackEvent(commonTelemetry.EventContext{
-						EventName: "Error Nuking ECS Service",
-					}, map[string]interface{}{
-						"region": services.Region,
-						"reason": "Unable to drain",
-					})
 				} else {
 					requestedDrains = append(requestedDrains, ecsServiceArn)
 				}
@@ -165,12 +151,6 @@ func (services *ECSServices) waitUntilServicesDrained(ecsServiceArns []*string) 
 		err := services.Client.WaitUntilServicesStable(params)
 		if err != nil {
 			logging.Debugf("[Failed] Failed waiting for service to be stable %s: %s", *ecsServiceArn, err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking ECS Service",
-			}, map[string]interface{}{
-				"region": services.Region,
-				"reason": "Failed Waiting for Drain",
-			})
 		} else {
 			logging.Debugf("Drained service: %s", *ecsServiceArn)
 			successfullyDrained = append(successfullyDrained, ecsServiceArn)
@@ -191,12 +171,6 @@ func (services *ECSServices) deleteEcsServices(ecsServiceArns []*string) []*stri
 		_, err := services.Client.DeleteService(params)
 		if err != nil {
 			logging.Debugf("[Failed] Failed deleting service %s: %s", *ecsServiceArn, err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking ECS Service",
-			}, map[string]interface{}{
-				"region": services.Region,
-				"reason": "Unable to Delete",
-			})
 		} else {
 			requestedDeletes = append(requestedDeletes, ecsServiceArn)
 		}
@@ -226,12 +200,6 @@ func (services *ECSServices) waitUntilServicesDeleted(ecsServiceArns []*string) 
 
 		if err != nil {
 			logging.Debugf("[Failed] Failed waiting for service to be deleted %s: %s", *ecsServiceArn, err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking ECS Service",
-			}, map[string]interface{}{
-				"region": services.Region,
-				"reason": "Failed Waiting for Delete",
-			})
 		} else {
 			logging.Debugf("Deleted service: %s", *ecsServiceArn)
 			successfullyDeleted = append(successfullyDeleted, ecsServiceArn)

--- a/aws/resources/ecs_service_test.go
+++ b/aws/resources/ecs_service_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -51,7 +50,7 @@ func (m mockedEC2Service) WaitUntilServicesInactive(*ecs.DescribeServicesInput) 
 }
 
 func TestEC2Service_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testArn1 := "testArn1"
@@ -126,7 +125,7 @@ func TestEC2Service_GetAll(t *testing.T) {
 }
 
 func TestEC2Service_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	es := ECSServices{

--- a/aws/resources/efs.go
+++ b/aws/resources/efs.go
@@ -2,8 +2,6 @@ package resources
 
 import (
 	"context"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -61,11 +59,6 @@ func (ef *ElasticFileSystem) nukeAll(identifiers []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking EFS",
-			}, map[string]interface{}{
-				"region": ef.Region,
-			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/resources/efs_test.go
+++ b/aws/resources/efs_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/efs"
 	"github.com/aws/aws-sdk-go/service/efs/efsiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -49,7 +48,7 @@ func (m mockedElasticFileSystem) DeleteFileSystem(input *efs.DeleteFileSystemInp
 }
 
 func TestEFS_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testId1 := "testId1"
@@ -114,7 +113,7 @@ func TestEFS_GetAll(t *testing.T) {
 }
 
 func TestEFS_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	ef := ElasticFileSystem{

--- a/aws/resources/eip.go
+++ b/aws/resources/eip.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	"github.com/gruntwork-io/cloud-nuke/util"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-
 	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -15,6 +11,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
@@ -121,19 +118,8 @@ func (ea *EIPAddresses) nukeAll(allocationIds []*string) error {
 			if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == "AuthFailure" {
 				// TODO: Figure out why we get an AuthFailure
 				logging.Debugf("EIP %s can't be deleted, it is still attached to an active resource", *allocationID)
-				telemetry.TrackEvent(commonTelemetry.EventContext{
-					EventName: "Error Nuking EIP",
-				}, map[string]interface{}{
-					"region": ea.Region,
-					"reason": "Still Attached to an Active Resource",
-				})
 			} else {
 				logging.Debugf("[Failed] %s", err)
-				telemetry.TrackEvent(commonTelemetry.EventContext{
-					EventName: "Error Nuking EIP",
-				}, map[string]interface{}{
-					"region": ea.Region,
-				})
 			}
 		} else {
 			deletedAllocationIDs = append(deletedAllocationIDs, allocationID)

--- a/aws/resources/eip_test.go
+++ b/aws/resources/eip_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 	"regexp"
@@ -30,7 +29,7 @@ func (m mockedEIPAddresses) ReleaseAddress(*ec2.ReleaseAddressInput) (*ec2.Relea
 }
 
 func TestEIPAddress_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()
@@ -111,7 +110,7 @@ func TestEIPAddress_GetAll(t *testing.T) {
 }
 
 func TestEIPAddress_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	ea := EIPAddresses{

--- a/aws/resources/eks.go
+++ b/aws/resources/eks.go
@@ -7,10 +7,8 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"github.com/hashicorp/go-multierror"
 	"sync"
 )
@@ -252,11 +250,6 @@ func (clusters *EKSClusters) nukeAll(eksClusterNames []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking EKS Cluster",
-			}, map[string]interface{}{
-				"region": clusters.Region,
-			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/resources/eks_test.go
+++ b/aws/resources/eks_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,7 +79,7 @@ func (m mockedEKSCluster) DeleteCluster(input *eks.DeleteClusterInput) (*eks.Del
 }
 
 func TestEKSClusterGetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testClusterName := "test_cluster1"
@@ -102,7 +101,7 @@ func TestEKSClusterGetAll(t *testing.T) {
 }
 
 func TestEKSClusterNukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testClusterName := "test_cluster1"

--- a/aws/resources/elasticache.go
+++ b/aws/resources/elasticache.go
@@ -9,9 +9,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"strings"
 )
 
@@ -182,11 +180,6 @@ func (cache *Elasticaches) nukeAll(clusterIds []*string) error {
 
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Elasticache Cluster",
-			}, map[string]interface{}{
-				"region": cache.Region,
-			})
 		} else {
 			deletedClusterIds = append(deletedClusterIds, clusterId)
 			logging.Debugf("Deleted Elasticache cluster: %s", *clusterId)
@@ -260,11 +253,6 @@ func (pg *ElasticacheParameterGroups) nukeAll(paramGroupNames []*string) error {
 		report.Record(e)
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Elasticache Parameter Group",
-			}, map[string]interface{}{
-				"region": pg.Region,
-			})
 		} else {
 			deletedGroupNames = append(deletedGroupNames, pgName)
 			logging.Debugf("Deleted Elasticache parameter group: %s", aws.StringValue(pgName))
@@ -316,11 +304,6 @@ func (sg *ElasticacheSubnetGroups) nukeAll(subnetGroupNames []*string) error {
 		report.Record(e)
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Elasticache Subnet Group",
-			}, map[string]interface{}{
-				"region": sg.Region,
-			})
 		} else {
 			deletedGroupNames = append(deletedGroupNames, sgName)
 			logging.Debugf("Deleted Elasticache subnet group: %s", aws.StringValue(sgName))

--- a/aws/resources/elasticache_test.go
+++ b/aws/resources/elasticache_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/elasticache/elasticacheiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -37,7 +36,7 @@ func (m mockedElasticache) WaitUntilReplicationGroupDeleted(input *elasticache.D
 }
 
 func TestElasticache_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()
@@ -100,7 +99,7 @@ func TestElasticache_GetAll(t *testing.T) {
 }
 
 func TestElasticache_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()

--- a/aws/resources/elb.go
+++ b/aws/resources/elb.go
@@ -3,8 +3,6 @@ package resources
 import (
 	"context"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -80,11 +78,6 @@ func (balancer *LoadBalancers) nukeAll(names []*string) error {
 
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Load Balancer (v1)",
-			}, map[string]interface{}{
-				"region": balancer.Region,
-			})
 		} else {
 			deletedNames = append(deletedNames, name)
 			logging.Debugf("Deleted ELB: %s", *name)

--- a/aws/resources/elb_test.go
+++ b/aws/resources/elb_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elb/elbiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -30,7 +29,7 @@ func (m mockedLoadBalancers) DeleteLoadBalancer(input *elb.DeleteLoadBalancerInp
 }
 
 func TestElb_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-name-1"
@@ -90,7 +89,7 @@ func TestElb_GetAll(t *testing.T) {
 }
 
 func TestElb_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	balancer := LoadBalancers{

--- a/aws/resources/elbv2.go
+++ b/aws/resources/elbv2.go
@@ -7,9 +7,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 // Returns a formatted string of ELBv2 Arns
@@ -59,11 +57,6 @@ func (balancer *LoadBalancersV2) nukeAll(arns []*string) error {
 
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Load Balancer V2",
-			}, map[string]interface{}{
-				"region": balancer.Region,
-			})
 		} else {
 			deletedArns = append(deletedArns, arn)
 			logging.Debugf("Deleted ELBv2: %s", *arn)

--- a/aws/resources/elbv2_test.go
+++ b/aws/resources/elbv2_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -32,7 +31,7 @@ func (m mockedElbV2) WaitUntilLoadBalancersDeleted(input *elbv2.DescribeLoadBala
 }
 
 func TestElbV2_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-name-1"
@@ -97,7 +96,7 @@ func TestElbV2_GetAll(t *testing.T) {
 }
 
 func TestElbV2_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	balancer := LoadBalancersV2{

--- a/aws/resources/guardduty.go
+++ b/aws/resources/guardduty.go
@@ -7,10 +7,8 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 type DetectorOutputWithID struct {
@@ -85,11 +83,6 @@ func (gd *GuardDuty) nukeAll(detectorIds []string) error {
 
 		if err != nil {
 			logging.Debugf("[Failed] %s: %s", detectorId, err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking GuardDuty Detector",
-			}, map[string]interface{}{
-				"region": gd.Region,
-			})
 		} else {
 			deletedIds = append(deletedIds, detectorId)
 			logging.Debugf("Deleted GuardDuty detector: %s", detectorId)

--- a/aws/resources/guardduty_test.go
+++ b/aws/resources/guardduty_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/guardduty"
 	"github.com/aws/aws-sdk-go/service/guardduty/guarddutyiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
@@ -33,7 +32,7 @@ func (m mockedGuardDuty) DeleteDetector(input *guardduty.DeleteDetectorInput) (*
 }
 
 func TestGuardDuty_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testId1 := "test-detector-id-1"
@@ -81,7 +80,7 @@ func TestGuardDuty_GetAll(t *testing.T) {
 }
 
 func TestGuardDuty_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	gd := GuardDuty{

--- a/aws/resources/iam.go
+++ b/aws/resources/iam.go
@@ -3,9 +3,7 @@ package resources
 import (
 	"context"
 	"fmt"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -365,9 +363,6 @@ func (iu *IAMUsers) nukeAll(userNames []*string) error {
 		if err != nil {
 			logging.Errorf("[Failed] %s", err)
 			multierror.Append(multiErr, err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking IAM User",
-			}, map[string]interface{}{})
 		} else {
 			deletedUsers++
 			logging.Debugf("Deleted IAM User: %s", *userName)

--- a/aws/resources/iam_group.go
+++ b/aws/resources/iam_group.go
@@ -7,8 +7,6 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/hashicorp/go-multierror"
 	"sync"
@@ -67,9 +65,6 @@ func (ig *IAMGroups) nukeAll(groupNames []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Errorf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking IAM Group",
-			}, map[string]interface{}{})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/resources/iam_group_test.go
+++ b/aws/resources/iam_group_test.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"regexp"
 	"testing"
 	"time"
@@ -62,7 +61,7 @@ func (m mockedIAMGroups) RemoveUserFromGroup(input *iam.RemoveUserFromGroupInput
 }
 
 func TestIamGroups_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "group1"
@@ -122,7 +121,7 @@ func TestIamGroups_GetAll(t *testing.T) {
 }
 
 func TestIamGroups_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	ig := IAMGroups{

--- a/aws/resources/iam_policy.go
+++ b/aws/resources/iam_policy.go
@@ -7,9 +7,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"github.com/hashicorp/go-multierror"
 	"sync"
 )
@@ -69,9 +67,6 @@ func (ip *IAMPolicies) nukeAll(policyArns []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Errorf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking IAM Policy",
-			}, map[string]interface{}{})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/resources/iam_policy_test.go
+++ b/aws/resources/iam_policy_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -62,7 +61,7 @@ func (m mockedIAMPolicies) DeletePolicy(input *iam.DeletePolicyInput) (*iam.Dele
 }
 
 func TestIAMPolicy_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "MyPolicy1"
@@ -126,7 +125,7 @@ func TestIAMPolicy_GetAll(t *testing.T) {
 }
 
 func TestIAMPolicy_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	ip := IAMPolicies{

--- a/aws/resources/iam_role.go
+++ b/aws/resources/iam_role.go
@@ -7,9 +7,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"github.com/hashicorp/go-multierror"
 	"strings"
 	"sync"
@@ -160,9 +158,6 @@ func (ir *IAMRoles) nukeAll(roleNames []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking IAM Role",
-			}, map[string]interface{}{})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/resources/iam_role_test.go
+++ b/aws/resources/iam_role_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -64,7 +63,7 @@ func (m mockedIAMRoles) DeleteRole(input *iam.DeleteRoleInput) (*iam.DeleteRoleO
 }
 
 func TestIAMRoles_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-role1"
@@ -125,7 +124,7 @@ func TestIAMRoles_GetAll(t *testing.T) {
 }
 
 func TestIAMRoles_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	ir := IAMRoles{

--- a/aws/resources/iam_service_linked_role.go
+++ b/aws/resources/iam_service_linked_role.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"strings"
 	"sync"
 	"time"
@@ -115,9 +113,6 @@ func (islr *IAMServiceLinkedRoles) nukeAll(roleNames []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking IAM Service Linked Role",
-			}, map[string]interface{}{})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/resources/iam_service_linked_role_test.go
+++ b/aws/resources/iam_service_linked_role_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -34,7 +33,7 @@ func (m mockedIAMServiceLinkedRoles) GetServiceLinkedRoleDeletionStatus(input *i
 }
 
 func TestIAMServiceLinkedRoles_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()
@@ -97,7 +96,7 @@ func TestIAMServiceLinkedRoles_GetAll(t *testing.T) {
 }
 
 func TestIAMServiceLinkedRoles_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	islr := IAMServiceLinkedRoles{

--- a/aws/resources/iam_test.go
+++ b/aws/resources/iam_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -120,7 +119,7 @@ func (m mockedIAMUsers) DeleteUser(input *iam.DeleteUserInput) (*iam.DeleteUserO
 }
 
 func TestIAMUsers_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()
@@ -181,7 +180,7 @@ func TestIAMUsers_GetAll(t *testing.T) {
 }
 
 func TestIAMUsers_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	iu := IAMUsers{

--- a/aws/resources/kinesis_stream.go
+++ b/aws/resources/kinesis_stream.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/kinesis"
@@ -70,11 +67,6 @@ func (ks *KinesisStreams) nukeAll(identifiers []*string) error {
 	for _, errChan := range errChans {
 		if err := <-errChan; err != nil {
 			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() != "OperationAbortedException" {
-				telemetry.TrackEvent(commonTelemetry.EventContext{
-					EventName: "Error Nuking Kinesis Stream",
-				}, map[string]interface{}{
-					"region": ks.Region,
-				})
 				allErrs = multierror.Append(allErrs, err)
 			}
 		}

--- a/aws/resources/kinesis_stream_test.go
+++ b/aws/resources/kinesis_stream_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -28,7 +27,7 @@ func (m mockedKinesisClient) DeleteStream(input *kinesis.DeleteStreamInput) (*ki
 }
 
 func TestKinesisStreams_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "stream1"
@@ -72,7 +71,7 @@ func TestKinesisStreams_GetAll(t *testing.T) {
 }
 
 func TestKinesisStreams_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	ks := KinesisStreams{

--- a/aws/resources/kms_customer_key.go
+++ b/aws/resources/kms_customer_key.go
@@ -2,8 +2,6 @@ package resources
 
 import (
 	"context"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 
 	"github.com/gruntwork-io/cloud-nuke/config"
@@ -196,11 +194,6 @@ func (kck *KmsCustomerKeys) nukeAll(keyIds []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking KMS Key",
-			}, map[string]interface{}{
-				"region": kck.Region,
-			})
 		}
 	}
 	return errors.WithStackTrace(allErrs.ErrorOrNil())

--- a/aws/resources/kms_customer_key_test.go
+++ b/aws/resources/kms_customer_key_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/kms/kmsiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -48,7 +47,7 @@ func (m mockedKmsCustomerKeys) DeleteAlias(input *kms.DeleteAliasInput) (*kms.De
 }
 
 func TestKMS_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	key1 := "key1"
@@ -140,7 +139,7 @@ func TestKMS_GetAll(t *testing.T) {
 }
 
 func TestKMS_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	kck := KmsCustomerKeys{

--- a/aws/resources/lambda.go
+++ b/aws/resources/lambda.go
@@ -10,8 +10,6 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 func (lf *LambdaFunctions) getAll(c context.Context, configObj config.Config) ([]*string, error) {
@@ -81,11 +79,6 @@ func (lf *LambdaFunctions) nukeAll(names []*string) error {
 
 		if err != nil {
 			logging.Errorf("[Failed] %s: %s", *name, err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Lambda Function",
-			}, map[string]interface{}{
-				"region": lf.Region,
-			})
 		} else {
 			deletedNames = append(deletedNames, name)
 			logging.Debugf("Deleted Lambda Function: %s", awsgo.StringValue(name))

--- a/aws/resources/lambda_layer.go
+++ b/aws/resources/lambda_layer.go
@@ -10,8 +10,6 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 func (ll *LambdaLayers) getAll(c context.Context, configObj config.Config) ([]*string, error) {
@@ -132,11 +130,6 @@ func (ll *LambdaLayers) nukeAll(names []*string) error {
 
 		if err != nil {
 			logging.Logger.Errorf("[Failed] %s: %s", *params.LayerName, err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Lambda Layer",
-			}, map[string]interface{}{
-				"region": ll.Region,
-			})
 		} else {
 			deletedNames = append(deletedNames, params.LayerName)
 			logging.Logger.Debugf("Deleted Lambda Layer: %s", awsgo.StringValue(params.LayerName))

--- a/aws/resources/lambda_layer_test.go
+++ b/aws/resources/lambda_layer_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,7 +31,7 @@ func (m mockedLambdaLayer) ListLayerVersionsPages(input *lambda.ListLayerVersion
 }
 
 func TestLambdaLayer_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-lambda-layer1"
@@ -112,7 +111,7 @@ func TestLambdaLayer_GetAll(t *testing.T) {
 }
 
 func TestLambdaLayer_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	ll := LambdaLayers{

--- a/aws/resources/lambda_test.go
+++ b/aws/resources/lambda_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,7 +29,7 @@ func (m mockedLambda) DeleteFunction(input *lambda.DeleteFunctionInput) (*lambda
 }
 
 func TestLambdaFunction_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-lambda-function1"
@@ -96,7 +95,7 @@ func TestLambdaFunction_GetAll(t *testing.T) {
 }
 
 func TestLambdaFunction_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	lf := LambdaFunctions{

--- a/aws/resources/launch_config.go
+++ b/aws/resources/launch_config.go
@@ -7,9 +7,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 // Returns a formatted string of Launch config Names
@@ -60,11 +58,6 @@ func (lc *LaunchConfigs) nukeAll(configNames []*string) error {
 
 		if err != nil {
 			logging.Errorf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Launch Configuration",
-			}, map[string]interface{}{
-				"region": lc.Region,
-			})
 		} else {
 			deletedConfigNames = append(deletedConfigNames, configName)
 			logging.Debugf("Deleted Launch configuration: %s", *configName)

--- a/aws/resources/launch_config_test.go
+++ b/aws/resources/launch_config_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -29,7 +28,7 @@ func (m mockedLaunchConfiguration) DeleteLaunchConfiguration(input *autoscaling.
 }
 
 func TestLaunchConfigurations_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-launch-config1"
@@ -89,7 +88,7 @@ func TestLaunchConfigurations_GetAll(t *testing.T) {
 }
 
 func TestLaunchConfigurations_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	lc := LaunchConfigs{

--- a/aws/resources/launch_template.go
+++ b/aws/resources/launch_template.go
@@ -7,9 +7,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 // Returns a formatted string of Launch Template Names
@@ -59,11 +57,6 @@ func (lt *LaunchTemplates) nukeAll(templateNames []*string) error {
 
 		if err != nil {
 			logging.Errorf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Launch Template",
-			}, map[string]interface{}{
-				"region": lt.Region,
-			})
 		} else {
 			deletedTemplateNames = append(deletedTemplateNames, templateName)
 			logging.Debugf("Deleted Launch template: %s", *templateName)

--- a/aws/resources/launch_template_test.go
+++ b/aws/resources/launch_template_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -28,7 +27,7 @@ func (m mockedLaunchTemplate) DeleteLaunchTemplate(input *ec2.DeleteLaunchTempla
 }
 
 func TestLaunchTemplate_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()
@@ -88,7 +87,7 @@ func TestLaunchTemplate_GetAll(t *testing.T) {
 }
 
 func TestLaunchTemplate_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	lt := LaunchTemplates{

--- a/aws/resources/macie.go
+++ b/aws/resources/macie.go
@@ -3,8 +3,6 @@ package resources
 import (
 	"context"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -98,23 +96,11 @@ func (mm *MacieMember) nukeAll(identifier []string) error {
 	// Macie cannot be disabled with active member accounts
 	memberAccountIds, err := mm.getAllMacieMembers()
 	if err != nil {
-		telemetry.TrackEvent(commonTelemetry.EventContext{
-			EventName: "Error finding macie member accounts",
-		}, map[string]interface{}{
-			"region": mm.Region,
-			"reason": "Error finding macie member accounts",
-		})
 	}
 	if err == nil && len(memberAccountIds) > 0 {
 		err = mm.removeMacieMembers(memberAccountIds)
 		if err != nil {
 			logging.Errorf("[Failed] Failed to remove members from macie")
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error removing members from macie",
-			}, map[string]interface{}{
-				"region": mm.Region,
-				"reason": "Unable to remove members",
-			})
 		}
 	}
 
@@ -126,12 +112,6 @@ func (mm *MacieMember) nukeAll(identifier []string) error {
 			logging.Debugf("No delegated Macie administrator found to remove.")
 		} else {
 			logging.Errorf("[Failed] Failed to check for administrator account")
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error checking for administrator account in Macie",
-			}, map[string]interface{}{
-				"region": mm.Region,
-				"reason": "Unable to find admin account",
-			})
 		}
 	}
 
@@ -140,12 +120,6 @@ func (mm *MacieMember) nukeAll(identifier []string) error {
 		_, err := mm.Client.DisassociateFromAdministratorAccount(&macie2.DisassociateFromAdministratorAccountInput{})
 		if err != nil {
 			logging.Errorf("[Failed] Failed to disassociate from administrator account")
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error disassociating administrator account in Macie",
-			}, map[string]interface{}{
-				"region": mm.Region,
-				"reason": "Unable to disassociate admin account",
-			})
 		}
 	}
 
@@ -153,12 +127,6 @@ func (mm *MacieMember) nukeAll(identifier []string) error {
 	_, err = mm.Client.DisableMacie(&macie2.DisableMacieInput{})
 	if err != nil {
 		logging.Errorf("[Failed] Failed to disable macie.")
-		telemetry.TrackEvent(commonTelemetry.EventContext{
-			EventName: "Error Nuking MACIE",
-		}, map[string]interface{}{
-			"region": mm.Region,
-			"reason": "Error Nuking MACIE",
-		})
 		e := report.Entry{
 			Identifier:   aws.StringValue(&identifier[0]),
 			ResourceType: "Macie",

--- a/aws/resources/macie_test.go
+++ b/aws/resources/macie_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/macie2"
 	"github.com/aws/aws-sdk-go/service/macie2/macie2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
@@ -52,7 +51,7 @@ func (m mockedMacie) DisableMacie(input *macie2.DisableMacieInput) (*macie2.Disa
 }
 
 func TestMacie_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()
@@ -70,7 +69,7 @@ func TestMacie_GetAll(t *testing.T) {
 }
 
 func TestMacie_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	mm := MacieMember{

--- a/aws/resources/nat_gateway.go
+++ b/aws/resources/nat_gateway.go
@@ -3,9 +3,7 @@ package resources
 import (
 	"context"
 	"fmt"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -97,11 +95,6 @@ func (ngw *NatGateways) nukeAll(identifiers []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking NAT Gateway",
-			}, map[string]interface{}{
-				"region": ngw.Region,
-			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/resources/nat_gateway_test.go
+++ b/aws/resources/nat_gateway_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"regexp"
 	"testing"
 	"time"
@@ -36,7 +35,7 @@ func (m mockedNatGateway) DescribeNatGateways(input *ec2.DescribeNatGatewaysInpu
 }
 
 func TestNatGateway_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testId1 := "test-nat-gateway-id1"
@@ -110,7 +109,7 @@ func TestNatGateway_GetAll(t *testing.T) {
 }
 
 func TestNatGateway_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	ngw := NatGateways{

--- a/aws/resources/oidc_provider.go
+++ b/aws/resources/oidc_provider.go
@@ -2,8 +2,6 @@ package resources
 
 import (
 	"context"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -160,9 +158,6 @@ func (oidcprovider *OIDCProviders) nukeAll(identifiers []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking OIDC Provider",
-			}, map[string]interface{}{})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/resources/oidc_provider_test.go
+++ b/aws/resources/oidc_provider_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -36,7 +35,7 @@ func (m mockedOIDCProvider) GetOpenIDConnectProvider(input *iam.GetOpenIDConnect
 }
 
 func TestOIDCProvider_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testArn1 := "test-arn1"
@@ -103,7 +102,7 @@ func TestOIDCProvider_GetAll(t *testing.T) {
 }
 
 func TestOIDCProvider_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	oidcp := OIDCProviders{

--- a/aws/resources/opensearch.go
+++ b/aws/resources/opensearch.go
@@ -3,9 +3,7 @@ package resources
 import (
 	"context"
 	"fmt"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -167,11 +165,6 @@ func (osd *OpenSearchDomains) nukeAll(identifiers []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Errorf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Opensearch",
-			}, map[string]interface{}{
-				"region": osd.Region,
-			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/resources/opensearch_test.go
+++ b/aws/resources/opensearch_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
 	"github.com/aws/aws-sdk-go/service/opensearchservice/opensearchserviceiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 	"regexp"
@@ -40,7 +39,7 @@ func (m mockedOpenSearch) ListTags(*opensearchservice.ListTagsInput) (*opensearc
 
 // Test we can create an OpenSearch Domain, tag it, and then find the tag
 func TestOpenSearch_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-domain1"
@@ -122,7 +121,7 @@ func TestOpenSearch_GetAll(t *testing.T) {
 }
 
 func TestOpenSearch_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	osd := OpenSearchDomains{

--- a/aws/resources/rds.go
+++ b/aws/resources/rds.go
@@ -8,10 +8,8 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 func (di *DBInstances) getAll(c context.Context, configObj config.Config) ([]*string, error) {
@@ -53,11 +51,6 @@ func (di *DBInstances) nukeAll(names []*string) error {
 		_, err := di.Client.DeleteDBInstance(params)
 
 		if err != nil {
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking RDS Instance",
-			}, map[string]interface{}{
-				"region": di.Region,
-			})
 			logging.Errorf("[Failed] %s: %s", *name, err)
 		} else {
 			deletedNames = append(deletedNames, name)
@@ -81,11 +74,6 @@ func (di *DBInstances) nukeAll(names []*string) error {
 			report.Record(e)
 
 			if err != nil {
-				telemetry.TrackEvent(commonTelemetry.EventContext{
-					EventName: "Error Nuking RDS Instance",
-				}, map[string]interface{}{
-					"region": di.Region,
-				})
 				logging.Errorf("[Failed] %s", err)
 				return errors.WithStackTrace(err)
 			}

--- a/aws/resources/rds_cluster.go
+++ b/aws/resources/rds_cluster.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -14,7 +13,6 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
@@ -84,11 +82,6 @@ func (instance *DBClusters) nukeAll(names []*string) error {
 
 		if err != nil {
 			logging.Debugf("[Failed] %s: %s", *name, err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking RDS Cluster",
-			}, map[string]interface{}{
-				"region": instance.Region,
-			})
 		} else {
 			deletedNames = append(deletedNames, name)
 			logging.Debugf("Deleted RDS DB Cluster: %s", awsgo.StringValue(name))

--- a/aws/resources/rds_cluster_test.go
+++ b/aws/resources/rds_cluster_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,7 +34,7 @@ func (m mockedDBClusters) DescribeDBClusters(input *rds.DescribeDBClustersInput)
 }
 
 func TestRDSClusterGetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName := "test-db-cluster"
@@ -69,7 +68,7 @@ func TestRDSClusterGetAll(t *testing.T) {
 }
 
 func TestRDSClusterNukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName := "test-db-cluster"

--- a/aws/resources/rds_snapshot_test.go
+++ b/aws/resources/rds_snapshot_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"regexp"
@@ -30,7 +29,7 @@ func (m mockedRdsSnapshot) DeleteDBSnapshot(input *rds.DeleteDBSnapshotInput) (*
 }
 
 func TestRdsSnapshot_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-name1"
@@ -90,7 +89,7 @@ func TestRdsSnapshot_GetAll(t *testing.T) {
 }
 
 func TestRdsSnapshot_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName := "test-db-cluster"

--- a/aws/resources/rds_subnet_group.go
+++ b/aws/resources/rds_subnet_group.go
@@ -11,9 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 func (dsg *DBSubnetGroups) waitUntilRdsDbSubnetGroupDeleted(name *string) error {
@@ -81,11 +79,6 @@ func (dsg *DBSubnetGroups) nukeAll(names []*string) error {
 
 		if err != nil {
 			logging.Debugf("[Failed] %s: %s", *name, err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking RDS DB subnet group",
-			}, map[string]interface{}{
-				"region": dsg.Region,
-			})
 		} else {
 			deletedNames = append(deletedNames, name)
 			logging.Debugf("Deleted RDS DB subnet group: %s", awsgo.StringValue(name))

--- a/aws/resources/rds_subnet_group_test.go
+++ b/aws/resources/rds_subnet_group_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -34,7 +33,7 @@ func (m mockedDBSubnetGroups) DeleteDBSubnetGroup(*rds.DeleteDBSubnetGroupInput)
 }
 
 func TestDBSubnetGroups_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-db-subnet-group1"
@@ -85,7 +84,7 @@ func TestDBSubnetGroups_GetAll(t *testing.T) {
 }
 
 func TestDBSubnetGroups_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	dsg := DBSubnetGroups{

--- a/aws/resources/rds_test.go
+++ b/aws/resources/rds_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"regexp"
 	"testing"
 	"time"
@@ -35,7 +34,7 @@ func (m mockedDBInstance) WaitUntilDBInstanceDeleted(*rds.DescribeDBInstancesInp
 }
 
 func TestDBInstances_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-db-instance1"
@@ -100,7 +99,7 @@ func TestDBInstances_GetAll(t *testing.T) {
 }
 
 func TestDBInstances_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	di := DBInstances{

--- a/aws/resources/redshift.go
+++ b/aws/resources/redshift.go
@@ -7,9 +7,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 func (rc *RedshiftClusters) getAll(c context.Context, configObj config.Config) ([]*string, error) {
@@ -46,11 +44,6 @@ func (rc *RedshiftClusters) nukeAll(identifiers []*string) error {
 			SkipFinalClusterSnapshot: aws.Bool(true),
 		})
 		if err != nil {
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking RedshiftCluster",
-			}, map[string]interface{}{
-				"region": rc.Region,
-			})
 			logging.Errorf("[Failed] %s: %s", *id, err)
 		} else {
 			deletedIds = append(deletedIds, id)
@@ -69,11 +62,6 @@ func (rc *RedshiftClusters) nukeAll(identifiers []*string) error {
 			}
 			report.Record(e)
 			if err != nil {
-				telemetry.TrackEvent(commonTelemetry.EventContext{
-					EventName: "Error Nuking Redshift Cluster",
-				}, map[string]interface{}{
-					"region": rc.Region,
-				})
 				logging.Errorf("[Failed] %s", err)
 				return errors.WithStackTrace(err)
 			}

--- a/aws/resources/redshift_test.go
+++ b/aws/resources/redshift_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/aws-sdk-go/service/redshift/redshiftiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -34,7 +33,7 @@ func (m mockedRedshift) WaitUntilClusterDeleted(*redshift.DescribeClustersInput)
 }
 
 func TestRedshiftCluster_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()
@@ -94,7 +93,7 @@ func TestRedshiftCluster_GetAll(t *testing.T) {
 }
 
 func TestRedshiftCluster_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	rc := RedshiftClusters{

--- a/aws/resources/route53_cidr_collection_test.go
+++ b/aws/resources/route53_cidr_collection_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,7 +35,7 @@ func (mock mockedR53CidrCollection) DeleteCidrCollection(_ *route53.DeleteCidrCo
 }
 
 func TestR53CidrCollection_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testId1 := "d8c6f2db-89dd-5533-f30c-13e28eba8818"
@@ -92,7 +91,7 @@ func TestR53CidrCollection_GetAll(t *testing.T) {
 }
 
 func TestR53CidrCollection_Nuke(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	rc := Route53CidrCollection{

--- a/aws/resources/route53_hostedzone_test.go
+++ b/aws/resources/route53_hostedzone_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,7 +27,7 @@ func (mock mockedR53HostedZone) DeleteHostedZone(_ *route53.DeleteHostedZoneInpu
 }
 
 func TestR53HostedZone_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testId1 := "d8c6f2db-89dd-5533-f30c-13e28eba8818"
@@ -84,7 +83,7 @@ func TestR53HostedZone_GetAll(t *testing.T) {
 }
 
 func TestR53HostedZone_Nuke(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	rc := Route53HostedZone{

--- a/aws/resources/route53_traffic_policy_test.go
+++ b/aws/resources/route53_traffic_policy_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,7 +27,7 @@ func (mock mockedR53TrafficPolicy) DeleteTrafficPolicy(_ *route53.DeleteTrafficP
 }
 
 func TestR53TrafficPolicy_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testId1 := "d8c6f2db-89dd-5533-f30c-13e28eba8818"
@@ -87,7 +86,7 @@ func TestR53TrafficPolicy_GetAll(t *testing.T) {
 }
 
 func TestR53TrafficPolicy_Nuke(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	rc := Route53TrafficPolicy{

--- a/aws/resources/s3.go
+++ b/aws/resources/s3.go
@@ -7,20 +7,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	"github.com/gruntwork-io/cloud-nuke/util"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/gruntwork-io/go-commons/errors"
-
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/hashicorp/go-multierror"
 )
 
 const AwsResourceExclusionTagKey = "cloud-nuke-excluded"
@@ -456,11 +451,6 @@ func (sb S3Buckets) nukeAll(bucketNames []*string) (delCount int, err error) {
 
 		if err != nil {
 			logging.Debugf("[Failed] - %d/%d - Bucket: %s - bucket deletion error - %s", bucketIndex+1, totalCount, *bucketName, err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking S3 Bucket",
-			}, map[string]interface{}{
-				"region": sb.Region,
-			})
 		} else {
 			deleted = append(deleted, bucketName)
 			logging.Debugf("[OK] - %d/%d - Bucket: %s - deleted", bucketIndex+1, totalCount, *bucketName)

--- a/aws/resources/s3_access_point_test.go
+++ b/aws/resources/s3_access_point_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3control"
 	"github.com/aws/aws-sdk-go/service/s3control/s3controliface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +28,7 @@ func (m mocks3AccessPoint) DeleteAccessPoint(_ *s3control.DeleteAccessPointInput
 }
 
 func TestS3AccessPoint_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName01 := "test-access-point-01"
@@ -85,7 +84,7 @@ func TestS3AccessPoint_GetAll(t *testing.T) {
 }
 
 func TestS3AccessPoint_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	rc := S3AccessPoint{

--- a/aws/resources/s3_multi_region_access_point_test.go
+++ b/aws/resources/s3_multi_region_access_point_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3control"
 	"github.com/aws/aws-sdk-go/service/s3control/s3controliface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +29,7 @@ func (m mockS3MultiRegionAccessPoint) DeleteMultiRegionAccessPoint(_ *s3control.
 }
 
 func TestS3MultiRegionAccessPoint_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName01 := "test-access-point-01"
@@ -98,7 +97,7 @@ func TestS3MultiRegionAccessPoint_GetAll(t *testing.T) {
 }
 
 func TestS3MultiRegionAccessPoint_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	rc := S3MultiRegionAccessPoint{

--- a/aws/resources/s3_object_lambda_access_point_test.go
+++ b/aws/resources/s3_object_lambda_access_point_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3control"
 	"github.com/aws/aws-sdk-go/service/s3control/s3controliface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +28,7 @@ func (m mocks3ObjectLambdaAccessPoint) DeleteAccessPointForObjectLambda(_ *s3con
 }
 
 func TestS3ObjectLambdaAccessPoint_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName01 := "test-access-point-01"
@@ -85,7 +84,7 @@ func TestS3ObjectLambdaAccessPoint_GetAll(t *testing.T) {
 }
 
 func TestS3ObjectLambdaAccessPoint_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	rc := S3ObjectLambdaAccessPoint{

--- a/aws/resources/s3_test.go
+++ b/aws/resources/s3_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,7 +64,7 @@ func (m mockedS3Buckets) DeleteBucketWithContext(aws.Context, *s3.DeleteBucketIn
 }
 
 func TestS3Bucket_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-bucket-1"
@@ -136,7 +135,7 @@ func TestS3Bucket_GetAll(t *testing.T) {
 }
 
 func TestS3Bucket_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	sb := S3Buckets{

--- a/aws/resources/sagemaker_notebook_instance.go
+++ b/aws/resources/sagemaker_notebook_instance.go
@@ -8,9 +8,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 func (smni *SageMakerNotebookInstances) getAll(c context.Context, configObj config.Config) ([]*string, error) {
@@ -48,12 +46,6 @@ func (smni *SageMakerNotebookInstances) nukeAll(names []*string) error {
 		})
 		if err != nil {
 			logging.Errorf("[Failed] %s: %s", *name, err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Sagemaker Notebook Instance",
-			}, map[string]interface{}{
-				"region": smni.Region,
-				"reason": "Failed to Stop Notebook",
-			})
 		}
 
 		err = smni.Client.WaitUntilNotebookInstanceStopped(&sagemaker.DescribeNotebookInstanceInput{
@@ -61,12 +53,6 @@ func (smni *SageMakerNotebookInstances) nukeAll(names []*string) error {
 		})
 		if err != nil {
 			logging.Errorf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Sagemaker Notebook Instance",
-			}, map[string]interface{}{
-				"region": smni.Region,
-				"reason": "Failed waiting for notebook to stop",
-			})
 		}
 
 		_, err = smni.Client.DeleteNotebookInstance(&sagemaker.DeleteNotebookInstanceInput{
@@ -75,12 +61,6 @@ func (smni *SageMakerNotebookInstances) nukeAll(names []*string) error {
 
 		if err != nil {
 			logging.Errorf("[Failed] %s: %s", *name, err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Sagemaker Notebook Instance",
-			}, map[string]interface{}{
-				"region": smni.Region,
-				"reason": "Failed to Delete Notebook",
-			})
 		} else {
 			deletedNames = append(deletedNames, name)
 			logging.Debugf("Deleted Sagemaker Notebook Instance: %s", awsgo.StringValue(name))
@@ -104,12 +84,6 @@ func (smni *SageMakerNotebookInstances) nukeAll(names []*string) error {
 
 			if err != nil {
 				logging.Errorf("[Failed] %s", err)
-				telemetry.TrackEvent(commonTelemetry.EventContext{
-					EventName: "Error Nuking Sagemaker Notebook Instance",
-				}, map[string]interface{}{
-					"region": smni.Region,
-					"reason": "Failed waiting for notebook instance to delete",
-				})
 				return errors.WithStackTrace(err)
 			}
 		}

--- a/aws/resources/sagemaker_notebook_instance_test.go
+++ b/aws/resources/sagemaker_notebook_instance_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 	"github.com/aws/aws-sdk-go/service/sagemaker/sagemakeriface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -46,7 +45,7 @@ func (m mockedSageMakerNotebookInstance) DeleteNotebookInstance(input *sagemaker
 }
 
 func TestSageMakerNotebookInstances_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()
@@ -107,7 +106,7 @@ func TestSageMakerNotebookInstances_GetAll(t *testing.T) {
 }
 
 func TestSageMakerNotebookInstances_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	smni := SageMakerNotebookInstances{

--- a/aws/resources/secrets_manager.go
+++ b/aws/resources/secrets_manager.go
@@ -2,8 +2,6 @@ package resources
 
 import (
 	"context"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"sync"
 	"time"
 
@@ -77,11 +75,6 @@ func (sms *SecretsManagerSecrets) nukeAll(identifiers []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Errorf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Secrets Manager Secret",
-			}, map[string]interface{}{
-				"region": sms.Region,
-			})
 		}
 	}
 	return errors.WithStackTrace(allErrs.ErrorOrNil())

--- a/aws/resources/secrets_manager_test.go
+++ b/aws/resources/secrets_manager_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
@@ -39,7 +38,7 @@ func (m mockedSecretsManager) RemoveRegionsFromReplication(input *secretsmanager
 }
 
 func TestSecretsManagerSecrets_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testName1 := "test-name-1"
@@ -103,7 +102,7 @@ func TestSecretsManagerSecrets_GetAll(t *testing.T) {
 }
 
 func TestSecretsManagerSecrets_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	sms := SecretsManagerSecrets{

--- a/aws/resources/security_group_test.go
+++ b/aws/resources/security_group_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 )
@@ -131,7 +130,7 @@ func TestSecurityGroup_GetAll(t *testing.T) {
 }
 
 func Test_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	er := SecurityGroup{

--- a/aws/resources/security_hub_test.go
+++ b/aws/resources/security_hub_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/securityhub"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,7 +52,7 @@ func (m mockedSecurityHub) DisableSecurityHub(*securityhub.DisableSecurityHubInp
 }
 
 func TestSecurityHub_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()
@@ -96,7 +95,7 @@ func TestSecurityHub_GetAll(t *testing.T) {
 }
 
 func TestSecurityHub_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	sh := SecurityHub{

--- a/aws/resources/snapshot.go
+++ b/aws/resources/snapshot.go
@@ -2,16 +2,13 @@ package resources
 
 import (
 	"context"
-	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	"github.com/gruntwork-io/cloud-nuke/util"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-
 	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
@@ -90,11 +87,6 @@ func (s *Snapshots) nukeAll(snapshotIds []*string) error {
 
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking EBS Snapshot",
-			}, map[string]interface{}{
-				"region": s.Region,
-			})
 		} else {
 			deletedSnapshotIDs = append(deletedSnapshotIDs, snapshotID)
 			logging.Debugf("Deleted Snapshot: %s", *snapshotID)

--- a/aws/resources/snapshot_test.go
+++ b/aws/resources/snapshot_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
@@ -29,7 +28,7 @@ func (m mockedSnapshot) DescribeSnapshots(input *ec2.DescribeSnapshotsInput) (*e
 }
 
 func TestSnapshot_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testSnapshot1 := "test-snapshot1"
@@ -87,7 +86,7 @@ func TestSnapshot_GetAll(t *testing.T) {
 }
 
 func TestSnapshot_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	s := Snapshots{

--- a/aws/resources/sns.go
+++ b/aws/resources/sns.go
@@ -8,9 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
@@ -150,11 +147,6 @@ func (s *SNSTopic) nukeAll(identifiers []*string) error {
 		if err := <-errChan; err != nil {
 			allErrs = multierror.Append(allErrs, err)
 			logging.Errorf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking SNS Topic",
-			}, map[string]interface{}{
-				"region": s.Region,
-			})
 		}
 	}
 	finalErr := allErrs.ErrorOrNil()

--- a/aws/resources/sns_test.go
+++ b/aws/resources/sns_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
-
 	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
@@ -40,7 +38,7 @@ func (m mockedSNSTopic) DeleteTopic(input *sns.DeleteTopicInput) (*sns.DeleteTop
 }
 
 func TestSNS_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	testTopic1 := "arn:aws:sns:us-east-1:123456789012:MyTopic1"
@@ -108,7 +106,7 @@ func TestSNS_GetAll(t *testing.T) {
 }
 
 func TestSNS_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	s := SNSTopic{

--- a/aws/resources/sqs.go
+++ b/aws/resources/sqs.go
@@ -2,17 +2,15 @@ package resources
 
 import (
 	"context"
-	"strconv"
-	"time"
 	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
+	"strconv"
+	"time"
 )
 
 // Returns a formatted string of SQS Queue URLs
@@ -89,11 +87,6 @@ func (sq *SqsQueue) nukeAll(urls []*string) error {
 
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking SQS Queue",
-			}, map[string]interface{}{
-				"region": sq.Region,
-			})
 		} else {
 			deletedUrls = append(deletedUrls, url)
 			logging.Debugf("Deleted SQS Queue: %s", *url)

--- a/aws/resources/sqs_test.go
+++ b/aws/resources/sqs_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 	"regexp"
 	"strconv"
@@ -39,7 +38,7 @@ func (m mockedSqsQueue) DeleteQueue(*sqs.DeleteQueueInput) (*sqs.DeleteQueueOutp
 }
 
 func TestSqsQueue_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	queue1 := "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue1"
@@ -105,7 +104,7 @@ func TestSqsQueue_GetAll(t *testing.T) {
 }
 
 func TestSqsQueue_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	sq := SqsQueue{

--- a/aws/resources/transit_gateway.go
+++ b/aws/resources/transit_gateway.go
@@ -11,10 +11,8 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 )
 
 // [Note 1] :  NOTE on the Apporach used:-Using the `dry run` approach on verifying the nuking permission in case of a scoped IAM role.
@@ -97,11 +95,6 @@ func (tgw *TransitGateways) nukeAll(ids []*string) error {
 
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Error Nuking Transit Gateway Instance",
-			}, map[string]interface{}{
-				"region": tgw.Region,
-			})
 		} else {
 			deletedIds = append(deletedIds, id)
 			logging.Debugf("Deleted Transit Gateway: %s", *id)

--- a/aws/resources/transit_gateway_test.go
+++ b/aws/resources/transit_gateway_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,7 +79,7 @@ func (m mockedTransitGatewayVpcAttachment) DeleteTransitGatewayVpcAttachment(
 }
 
 func TestTransitGateways_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()
@@ -135,7 +134,7 @@ func TestTransitGateways_GetAll(t *testing.T) {
 }
 
 func TestTransitGateways_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	tgw := TransitGateways{
@@ -149,7 +148,7 @@ func TestTransitGateways_NukeAll(t *testing.T) {
 }
 
 func TestTransitGatewayRouteTables_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()
@@ -201,7 +200,7 @@ func TestTransitGatewayRouteTables_GetAll(t *testing.T) {
 }
 
 func TestTransitGatewayRouteTables_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	tgw := TransitGatewaysRouteTables{
@@ -215,7 +214,7 @@ func TestTransitGatewayRouteTables_NukeAll(t *testing.T) {
 }
 
 func TestTransitGatewayVpcAttachments_GetAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()
@@ -267,7 +266,7 @@ func TestTransitGatewayVpcAttachments_GetAll(t *testing.T) {
 }
 
 func TestTransitGatewayVpcAttachments_NukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	tgw := TransitGatewaysVpcAttachment{
@@ -281,7 +280,7 @@ func TestTransitGatewayVpcAttachments_NukeAll(t *testing.T) {
 }
 
 func TestTransitGatewayPeeringAttachment_getAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	now := time.Now()
@@ -332,7 +331,7 @@ func TestTransitGatewayPeeringAttachment_getAll(t *testing.T) {
 }
 
 func TestTransitGatewayPeeringAttachment_nukeAll(t *testing.T) {
-	telemetry.InitTelemetry("cloud-nuke", "")
+
 	t.Parallel()
 
 	tgw := TransitGatewayPeeringAttachment{


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Rather than having individual resources independently make telemetry calls, we are more interested in aggregating errors. While we occasionally report various types of errors, I don't see much usefulness in this detail. To be honest, we aren't really acting on the telemetry reports we receive. It would likely be more effective to focus on resource-level errors to identify which resources fail most frequently and potentially address these issues

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

