### PR TITLE
Implementation for removing VPC peer connection

### DIFF
--- a/aws/resources/ec2_vpc_test.go
+++ b/aws/resources/ec2_vpc_test.go
@@ -6,10 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
@@ -17,8 +19,13 @@ import (
 
 type mockedEC2VPCs struct {
 	ec2iface.EC2API
-	DescribeVpcsOutput ec2.DescribeVpcsOutput
-	DeleteVpcOutput    ec2.DeleteVpcOutput
+	DescribeVpcsOutput                             ec2.DescribeVpcsOutput
+	DeleteVpcOutput                                ec2.DeleteVpcOutput
+	DescribeVpcPeeringConnectionsOutput            ec2.DescribeVpcPeeringConnectionsOutput
+	DescribeInstancesOutput                        ec2.DescribeInstancesOutput
+	TerminateInstancesOutput                       ec2.TerminateInstancesOutput
+	DescribeVpcEndpointServiceConfigurationsOutput ec2.DescribeVpcEndpointServiceConfigurationsOutput
+	DeleteVpcEndpointServiceConfigurationsOutput   ec2.DeleteVpcEndpointServiceConfigurationsOutput
 }
 
 func (m mockedEC2VPCs) DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
@@ -28,7 +35,27 @@ func (m mockedEC2VPCs) DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.Describe
 func (m mockedEC2VPCs) DeleteVpc(input *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error) {
 	return &m.DeleteVpcOutput, nil
 }
+func (m mockedEC2VPCs) DescribeVpcPeeringConnectionsPages(input *ec2.DescribeVpcPeeringConnectionsInput, callback func(page *ec2.DescribeVpcPeeringConnectionsOutput, lastPage bool) bool) error {
+	callback(&m.DescribeVpcPeeringConnectionsOutput, true)
+	return nil
+}
+func (m mockedEC2VPCs) DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+	return &m.DescribeInstancesOutput, nil
+}
 
+func (m mockedEC2VPCs) TerminateInstances(*ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error) {
+	return &m.TerminateInstancesOutput, nil
+}
+func (m mockedEC2VPCs) WaitUntilInstanceTerminated(*ec2.DescribeInstancesInput) error {
+	return nil
+}
+
+func (m mockedEC2VPCs) DescribeVpcEndpointServiceConfigurations(*ec2.DescribeVpcEndpointServiceConfigurationsInput) (*ec2.DescribeVpcEndpointServiceConfigurationsOutput, error) {
+	return &m.DescribeVpcEndpointServiceConfigurationsOutput, nil
+}
+func (m mockedEC2VPCs) DeleteVpcEndpointServiceConfigurations(*ec2.DeleteVpcEndpointServiceConfigurationsInput) (*ec2.DeleteVpcEndpointServiceConfigurationsOutput, error) {
+	return &m.DeleteVpcEndpointServiceConfigurationsOutput, nil
+}
 func TestEC2VPC_GetAll(t *testing.T) {
 
 	t.Parallel()
@@ -128,3 +155,115 @@ func TestEC2VPC_GetAll(t *testing.T) {
 //	err := vpc.nukeAll([]string{"test-vpc-id1", "test-vpc-id2"})
 //	require.NoError(t, err)
 //}
+
+func TestEC2VPCPeeringConnections_NukeAll(t *testing.T) {
+	t.Parallel()
+	vpc := EC2VPCs{
+		Client: mockedEC2VPCs{
+			DescribeVpcPeeringConnectionsOutput: ec2.DescribeVpcPeeringConnectionsOutput{},
+		},
+	}
+
+	err := nukePeeringConnections(vpc.Client, "vpc-test-00001")
+	require.NoError(t, err)
+}
+
+type mockedEC2ELB struct {
+	elbv2iface.ELBV2API
+	DescribeLoadBalancersOutput elbv2.DescribeLoadBalancersOutput
+	DeleteLoadBalancerOutput    elbv2.DeleteLoadBalancerOutput
+
+	DescribeTargetGroupsOutput elbv2.DescribeTargetGroupsOutput
+	DeleteTargetGroupOutput    elbv2.DeleteTargetGroupOutput
+}
+
+func (m mockedEC2ELB) DescribeLoadBalancers(*elbv2.DescribeLoadBalancersInput) (*elbv2.DescribeLoadBalancersOutput, error) {
+	return &m.DescribeLoadBalancersOutput, nil
+}
+func (m mockedEC2ELB) DescribeTargetGroups(*elbv2.DescribeTargetGroupsInput) (*elbv2.DescribeTargetGroupsOutput, error) {
+	return &m.DescribeTargetGroupsOutput, nil
+}
+
+func (m mockedEC2ELB) DeleteLoadBalancer(*elbv2.DeleteLoadBalancerInput) (*elbv2.DeleteLoadBalancerOutput, error) {
+	return &m.DeleteLoadBalancerOutput, nil
+}
+func (m mockedEC2ELB) DeleteTargetGroup(*elbv2.DeleteTargetGroupInput) (*elbv2.DeleteTargetGroupOutput, error) {
+	return &m.DeleteTargetGroupOutput, nil
+}
+
+func TestAttachedLB_Nuke(t *testing.T) {
+	t.Parallel()
+	vpcID := "vpc-0e9a3e7c72d9f3a0f"
+
+	vpc := EC2VPCs{
+		Client: mockedEC2VPCs{
+			DescribeVpcEndpointServiceConfigurationsOutput: ec2.DescribeVpcEndpointServiceConfigurationsOutput{
+				ServiceConfigurations: []*ec2.ServiceConfiguration{
+					{
+						GatewayLoadBalancerArns: awsgo.StringSlice([]string{
+							"load-balancer-arn-00012",
+						}),
+					},
+				},
+			},
+		},
+		ELBClient: mockedEC2ELB{
+			DescribeLoadBalancersOutput: elbv2.DescribeLoadBalancersOutput{
+				LoadBalancers: []*elbv2.LoadBalancer{
+					{
+						VpcId:           awsgo.String(vpcID),
+						LoadBalancerArn: awsgo.String("load-balancer-arn-00012"),
+					},
+				},
+			},
+		},
+	}
+
+	err := nukeAttachedLB(vpc.Client, vpc.ELBClient, vpcID)
+	require.NoError(t, err)
+}
+
+func TestTargetGroup_Nuke(t *testing.T) {
+	t.Parallel()
+	vpcID := "vpc-0e9a3e7c72d9f3a0f"
+
+	vpc := EC2VPCs{
+		ELBClient: mockedEC2ELB{
+			DescribeTargetGroupsOutput: elbv2.DescribeTargetGroupsOutput{
+				TargetGroups: []*elbv2.TargetGroup{
+					{
+						VpcId:          awsgo.String(vpcID),
+						TargetGroupArn: awsgo.String("arn:aws:elasticloadbalancing:us-east-1:tg-001"),
+					},
+				},
+			},
+		},
+	}
+
+	err := nukeTargetGroups(vpc.ELBClient, vpcID)
+	require.NoError(t, err)
+}
+
+func TestEc2Instance_Nuke(t *testing.T) {
+	t.Parallel()
+	vpcID := "vpc-0e9a3e7c72d9f3a0f"
+
+	vpc := EC2VPCs{
+		Client: mockedEC2VPCs{
+			DescribeInstancesOutput: ec2.DescribeInstancesOutput{
+				Reservations: []*ec2.Reservation{
+					{
+						Instances: []*ec2.Instance{
+							{
+								InstanceId: awsgo.String("instance-001"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := nukeEc2Instances(vpc.Client, vpcID)
+	require.NoError(t, err)
+}

--- a/aws/resources/ec2_vpc_types.go
+++ b/aws/resources/ec2_vpc_types.go
@@ -7,19 +7,23 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
 type EC2VPCs struct {
 	BaseAwsResource
-	Client ec2iface.EC2API
-	Region string
-	VPCIds []string
+	Client    ec2iface.EC2API
+	ELBClient elbv2iface.ELBV2API
+	Region    string
+	VPCIds    []string
 }
 
 func (v *EC2VPCs) Init(session *session.Session) {
 	v.Client = ec2.New(session)
+	v.ELBClient = elbv2.New(session)
 }
 
 // ResourceName - the simple name of the aws resource


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #https://github.com/gruntwork-io/cloud-nuke/issues/443.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

