### PR TITLE
Option to not add 'cloud-nuke-first-seen' tag + Refactoring

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -24,7 +24,6 @@ func GetAllResources(c context.Context, query *Query, configObj config.Config) (
 	configObj.AddExcludeAfterTime(query.ExcludeAfter)
 	configObj.AddIncludeAfterTime(query.IncludeAfter)
 	configObj.AddTimeout(query.Timeout)
-
 	configObj.KMSCustomerKeys.IncludeUnaliasedKeys = query.ListUnaliasedKMSKeys
 
 	// Setting the DefaultOnly field
@@ -35,6 +34,7 @@ func GetAllResources(c context.Context, query *Query, configObj config.Config) (
 		Resources: make(map[string]AwsResources),
 	}
 
+	c = context.WithValue(c, util.ExcludeFirstSeenTagKey, query.ExcludeFirstSeen)
 	spinner, _ := pterm.DefaultSpinner.WithRemoveWhenDone(true).Start()
 	for _, region := range query.Regions {
 		cloudNukeSession := NewSession(region)

--- a/aws/query.go
+++ b/aws/query.go
@@ -14,11 +14,16 @@ type Query struct {
 	IncludeAfter         *time.Time
 	ListUnaliasedKMSKeys bool
 	Timeout              *time.Duration
+	ExcludeFirstSeen     bool
 	DefaultOnly          bool
 }
 
 // NewQuery configures and returns a Query struct that can be passed into the InspectResources method
-func NewQuery(regions, excludeRegions, resourceTypes, excludeResourceTypes []string, excludeAfter, includeAfter *time.Time, listUnaliasedKMSKeys bool, timeout *time.Duration, defaultOnly bool) (*Query, error) {
+func NewQuery(regions, excludeRegions, resourceTypes, excludeResourceTypes []string,
+	excludeAfter, includeAfter *time.Time,
+	listUnaliasedKMSKeys bool, timeout *time.Duration,
+	defaultOnly, excludeFirstSeen bool,
+) (*Query, error) {
 	q := &Query{
 		Regions:              regions,
 		ExcludeRegions:       excludeRegions,
@@ -29,6 +34,7 @@ func NewQuery(regions, excludeRegions, resourceTypes, excludeResourceTypes []str
 		ListUnaliasedKMSKeys: listUnaliasedKMSKeys,
 		Timeout:              timeout,
 		DefaultOnly:          defaultOnly,
+		ExcludeFirstSeen:     excludeFirstSeen,
 	}
 
 	validationErr := q.Validate()

--- a/aws/query_test.go
+++ b/aws/query_test.go
@@ -53,7 +53,9 @@ func TestNewQueryAcceptsValidExcludeAfterEntries(t *testing.T) {
 				tc.IncludeAfter,
 				false,
 				nil,
-				false)
+				false,
+				false,
+			)
 			require.NoError(t, err)
 		})
 	}

--- a/aws/resource_registry.go
+++ b/aws/resource_registry.go
@@ -33,6 +33,7 @@ func GetAndInitRegisteredResources(session *session.Session, region string) []*A
 // GetRegisteredGlobalResources - returns a list of registered global resources.
 func getRegisteredGlobalResources() []AwsResource {
 	return []AwsResource{
+		&resources.DBGlobalClusters{},
 		&resources.IAMUsers{},
 		&resources.IAMGroups{},
 		&resources.IAMPolicies{},
@@ -99,6 +100,7 @@ func getRegisteredRegionalResources() []AwsResource {
 		&resources.MSKCluster{},
 		&resources.NatGateways{},
 		&resources.OpenSearchDomains{},
+		&resources.DBGlobalClusterMemberships{},
 		&resources.DBInstances{},
 		&resources.DBSubnetGroups{},
 		&resources.DBClusters{},

--- a/aws/resource_registry.go
+++ b/aws/resource_registry.go
@@ -33,7 +33,6 @@ func GetAndInitRegisteredResources(session *session.Session, region string) []*A
 // GetRegisteredGlobalResources - returns a list of registered global resources.
 func getRegisteredGlobalResources() []AwsResource {
 	return []AwsResource{
-		&resources.DBGlobalClusters{},
 		&resources.IAMUsers{},
 		&resources.IAMGroups{},
 		&resources.IAMPolicies{},
@@ -100,7 +99,6 @@ func getRegisteredRegionalResources() []AwsResource {
 		&resources.MSKCluster{},
 		&resources.NatGateways{},
 		&resources.OpenSearchDomains{},
-		&resources.DBGlobalClusterMemberships{},
 		&resources.DBInstances{},
 		&resources.DBSubnetGroups{},
 		&resources.DBClusters{},

--- a/aws/resources/ec2_egress_only_igw.go
+++ b/aws/resources/ec2_egress_only_igw.go
@@ -15,39 +15,6 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-func (egigw *EgressOnlyInternetGateway) setFirstSeenTag(eoig ec2.EgressOnlyInternetGateway, value time.Time) error {
-	_, err := egigw.Client.CreateTags(&ec2.CreateTagsInput{
-		Resources: []*string{eoig.EgressOnlyInternetGatewayId},
-		Tags: []*ec2.Tag{
-			{
-				Key:   awsgo.String(util.FirstSeenTagKey),
-				Value: awsgo.String(util.FormatTimestamp(value)),
-			},
-		},
-	})
-	if err != nil {
-		return errors.WithStackTrace(err)
-	}
-
-	return nil
-}
-
-func (egigw *EgressOnlyInternetGateway) getFirstSeenTag(eoig ec2.EgressOnlyInternetGateway) (*time.Time, error) {
-	tags := eoig.Tags
-	for _, tag := range tags {
-		if util.IsFirstSeenTag(tag.Key) {
-			firstSeenTime, err := util.ParseTimestamp(tag.Value)
-			if err != nil {
-				return nil, errors.WithStackTrace(err)
-			}
-
-			return firstSeenTime, nil
-		}
-	}
-
-	return nil, nil
-}
-
 func shouldIncludeEgressOnlyInternetGateway(gateway *ec2.EgressOnlyInternetGateway, firstSeenTime *time.Time, configObj config.Config) bool {
 	var gatewayName string
 	// get the tags as map
@@ -62,8 +29,10 @@ func shouldIncludeEgressOnlyInternetGateway(gateway *ec2.EgressOnlyInternetGatew
 	})
 }
 
-func (egigw *EgressOnlyInternetGateway) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
+func (egigw *EgressOnlyInternetGateway) getAll(c context.Context, configObj config.Config) ([]*string, error) {
 	var result []*string
+	var firstSeenTime *time.Time
+	var err error
 
 	output, err := egigw.Client.DescribeEgressOnlyInternetGateways(&ec2.DescribeEgressOnlyInternetGatewaysInput{})
 	if err != nil {
@@ -71,39 +40,23 @@ func (egigw *EgressOnlyInternetGateway) getAll(_ context.Context, configObj conf
 	}
 
 	for _, igw := range output.EgressOnlyInternetGateways {
-		// check first seen tag
-		firstSeenTime, err := egigw.getFirstSeenTag(*igw)
+		firstSeenTime, err = util.GetOrCreateFirstSeen(c, egigw.Client, igw.EgressOnlyInternetGatewayId, util.ConvertEC2TagsToMap(igw.Tags))
 		if err != nil {
-			logging.Errorf(
-				"Unable to retrieve tags for Egress IGW: %s, with error: %s", *igw.EgressOnlyInternetGatewayId, err)
-			continue
+			logging.Error("Unable to retrieve tags")
+			return nil, errors.WithStackTrace(err)
 		}
-
-		// if the first seen tag is not there, then create one
-		if firstSeenTime == nil {
-			now := time.Now().UTC()
-			firstSeenTime = &now
-			if err := egigw.setFirstSeenTag(*igw, time.Now().UTC()); err != nil {
-				logging.Errorf(
-					"Unable to apply first seen tag Egress IGW: %s, with error: %s", *igw.EgressOnlyInternetGatewayId, err)
-				continue
-			}
-		}
-
 		if shouldIncludeEgressOnlyInternetGateway(igw, firstSeenTime, configObj) {
 			result = append(result, igw.EgressOnlyInternetGatewayId)
 		}
 	}
-
 	// checking the nukable permissions
 	egigw.VerifyNukablePermissions(result, func(id *string) error {
 		_, err := egigw.Client.DeleteEgressOnlyInternetGateway(&ec2.DeleteEgressOnlyInternetGatewayInput{
 			EgressOnlyInternetGatewayId: id,
 			DryRun:                      awsgo.Bool(true),
 		})
-		return err
+		return errors.WithStackTrace(err)
 	})
-
 	return result, nil
 }
 

--- a/aws/resources/ec2_endpoints.go
+++ b/aws/resources/ec2_endpoints.go
@@ -16,38 +16,6 @@ import (
 	"github.com/gruntwork-io/go-commons/retry"
 )
 
-func (e *EC2Endpoints) setFirstSeenTag(endpoint ec2.VpcEndpoint, value time.Time) error {
-	_, err := e.Client.CreateTags(&ec2.CreateTagsInput{
-		Resources: []*string{endpoint.VpcEndpointId},
-		Tags: []*ec2.Tag{
-			{
-				Key:   awsgo.String(util.FirstSeenTagKey),
-				Value: awsgo.String(util.FormatTimestamp(value)),
-			},
-		},
-	})
-	if err != nil {
-		return errors.WithStackTrace(err)
-	}
-
-	return nil
-}
-
-func (e *EC2Endpoints) getFirstSeenTag(endpoint ec2.VpcEndpoint) (*time.Time, error) {
-	for _, tag := range endpoint.Tags {
-		if util.IsFirstSeenTag(tag.Key) {
-			firstSeenTime, err := util.ParseTimestamp(tag.Value)
-			if err != nil {
-				return nil, errors.WithStackTrace(err)
-			}
-
-			return firstSeenTime, nil
-		}
-	}
-
-	return nil, nil
-}
-
 func ShouldIncludeVpcEndpoint(endpoint *ec2.VpcEndpoint, firstSeenTime *time.Time, configObj config.Config) bool {
 	var endpointName string
 	// get the tags as map
@@ -63,36 +31,26 @@ func ShouldIncludeVpcEndpoint(endpoint *ec2.VpcEndpoint, firstSeenTime *time.Tim
 	})
 }
 
-func (e *EC2Endpoints) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
+func (e *EC2Endpoints) getAll(c context.Context, configObj config.Config) ([]*string, error) {
 	var result []*string
+	var firstSeenTime *time.Time
+	var err error
 	endpoints, err := e.Client.DescribeVpcEndpoints(&ec2.DescribeVpcEndpointsInput{})
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
 	}
 
 	for _, endpoint := range endpoints.VpcEndpoints {
-		// check first seen tag
-		firstSeenTime, err := e.getFirstSeenTag(*endpoint)
+		firstSeenTime, err = util.GetOrCreateFirstSeen(c, e.Client, endpoint.VpcEndpointId, util.ConvertEC2TagsToMap(endpoint.Tags))
 		if err != nil {
-			logging.Errorf(
-				"Unable to retrieve tags for Vpc Endpoint: %s, with error: %s", *endpoint.VpcEndpointId, err)
-			continue
-		}
-
-		// if the first seen tag is not there, then create one
-		if firstSeenTime == nil {
-			now := time.Now().UTC()
-			firstSeenTime = &now
-			if err := e.setFirstSeenTag(*endpoint, time.Now().UTC()); err != nil {
-				logging.Errorf(
-					"Unable to apply first seen tag Vpc Endpoint: %s, with error: %s", *endpoint.VpcEndpointId, err)
-				continue
-			}
+			logging.Error("Unable to retrieve tags")
+			return nil, errors.WithStackTrace(err)
 		}
 
 		if ShouldIncludeVpcEndpoint(endpoint, firstSeenTime, configObj) {
 			result = append(result, endpoint.VpcEndpointId)
 		}
+
 	}
 
 	e.VerifyNukablePermissions(result, func(id *string) error {

--- a/aws/resources/ec2_internet_gateway.go
+++ b/aws/resources/ec2_internet_gateway.go
@@ -15,39 +15,6 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-func (igw *InternetGateway) setFirstSeenTag(gateway ec2.InternetGateway, value time.Time) error {
-	_, err := igw.Client.CreateTags(&ec2.CreateTagsInput{
-		Resources: []*string{gateway.InternetGatewayId},
-		Tags: []*ec2.Tag{
-			{
-				Key:   awsgo.String(util.FirstSeenTagKey),
-				Value: awsgo.String(util.FormatTimestamp(value)),
-			},
-		},
-	})
-	if err != nil {
-		return errors.WithStackTrace(err)
-	}
-
-	return nil
-}
-
-func (igw *InternetGateway) getFirstSeenTag(gateway ec2.InternetGateway) (*time.Time, error) {
-	tags := gateway.Tags
-	for _, tag := range tags {
-		if util.IsFirstSeenTag(tag.Key) {
-			firstSeenTime, err := util.ParseTimestamp(tag.Value)
-			if err != nil {
-				return nil, errors.WithStackTrace(err)
-			}
-
-			return firstSeenTime, nil
-		}
-	}
-
-	return nil, nil
-}
-
 func shouldIncludeGateway(ig *ec2.InternetGateway, firstSeenTime *time.Time, configObj config.Config) bool {
 	var internetGateway string
 	// get the tags as map
@@ -63,8 +30,10 @@ func shouldIncludeGateway(ig *ec2.InternetGateway, firstSeenTime *time.Time, con
 	})
 }
 
-func (igw *InternetGateway) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
+func (igw *InternetGateway) getAll(c context.Context, configObj config.Config) ([]*string, error) {
 	var identifiers []*string
+	var firstSeenTime *time.Time
+	var err error
 
 	input := &ec2.DescribeInternetGatewaysInput{}
 	resp, err := igw.Client.DescribeInternetGateways(input)
@@ -72,25 +41,11 @@ func (igw *InternetGateway) getAll(_ context.Context, configObj config.Config) (
 		logging.Debugf("[Internet Gateway] Failed to list internet gateways: %s", err)
 		return nil, err
 	}
-
 	for _, ig := range resp.InternetGateways {
-		// check first seen tag
-		firstSeenTime, err := igw.getFirstSeenTag(*ig)
+		firstSeenTime, err = util.GetOrCreateFirstSeen(c, igw.Client, ig.InternetGatewayId, util.ConvertEC2TagsToMap(ig.Tags))
 		if err != nil {
-			logging.Errorf(
-				"Unable to retrieve tags for Internet gateway: %s, with error: %s", *ig.InternetGatewayId, err)
-			continue
-		}
-
-		// if the first seen tag is not there, then create one
-		if firstSeenTime == nil {
-			now := time.Now().UTC()
-			firstSeenTime = &now
-			if err := igw.setFirstSeenTag(*ig, time.Now().UTC()); err != nil {
-				logging.Errorf(
-					"Unable to apply first seen tag Internet gateway: %s, with error: %s", *ig.InternetGatewayId, err)
-				continue
-			}
+			logging.Error("Unable to retrieve tags")
+			return nil, errors.WithStackTrace(err)
 		}
 
 		if shouldIncludeGateway(ig, firstSeenTime, configObj) {

--- a/aws/resources/ec2_internet_gateway_test.go
+++ b/aws/resources/ec2_internet_gateway_test.go
@@ -38,6 +38,9 @@ func TestEc2InternetGateway_GetAll(t *testing.T) {
 
 	t.Parallel()
 
+	// Set excludeFirstSeenTag to false for testing
+	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
+
 	var (
 		now      = time.Now()
 		gateway1 = "igw-0b44cfa6103932e1d001"
@@ -82,14 +85,17 @@ func TestEc2InternetGateway_GetAll(t *testing.T) {
 	igw.BaseAwsResource.Init(nil)
 
 	tests := map[string]struct {
+		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
+			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{gateway1, gateway2},
 		},
 		"nameExclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -99,6 +105,7 @@ func TestEc2InternetGateway_GetAll(t *testing.T) {
 			expected: []string{gateway2},
 		},
 		"timeAfterExclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: awsgo.Time(now.Add(-1 * time.Hour)),
@@ -108,7 +115,7 @@ func TestEc2InternetGateway_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := igw.getAll(context.Background(), config.Config{
+			names, err := igw.getAll(tc.ctx, config.Config{
 				InternetGateway: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_ipam_resource_discovery_test.go
+++ b/aws/resources/ec2_ipam_resource_discovery_test.go
@@ -32,6 +32,9 @@ func (m mockedIPAMResourceDiscovery) DeleteIpamResourceDiscovery(params *ec2.Del
 func TestIPAMRDiscovery_GetAll(t *testing.T) {
 	t.Parallel()
 
+	// Set excludeFirstSeenTag to false for testing
+	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
+
 	var (
 		now       = time.Now()
 		testId1   = "ipam-res-disco-0dfc56f901b2c3462"
@@ -76,14 +79,17 @@ func TestIPAMRDiscovery_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
+		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
+			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -93,6 +99,7 @@ func TestIPAMRDiscovery_GetAll(t *testing.T) {
 			expected: []string{testId2},
 		},
 		"timeAfterExclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
@@ -102,7 +109,7 @@ func TestIPAMRDiscovery_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ids, err := ipam.getAll(context.Background(), config.Config{
+			ids, err := ipam.getAll(tc.ctx, config.Config{
 				EC2IPAMResourceDiscovery: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_ipam_scope.go
+++ b/aws/resources/ec2_ipam_scope.go
@@ -14,39 +14,6 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-func (scope *EC2IpamScopes) setFirstSeenTag(ipam ec2.IpamScope, value time.Time) error {
-	_, err := scope.Client.CreateTags(&ec2.CreateTagsInput{
-		Resources: []*string{ipam.IpamScopeId},
-		Tags: []*ec2.Tag{
-			{
-				Key:   awsgo.String(util.FirstSeenTagKey),
-				Value: awsgo.String(util.FormatTimestamp(value)),
-			},
-		},
-	})
-	if err != nil {
-		return errors.WithStackTrace(err)
-	}
-
-	return nil
-}
-
-func (scope *EC2IpamScopes) getFirstSeenTag(ipam ec2.IpamScope) (*time.Time, error) {
-	tags := ipam.Tags
-	for _, tag := range tags {
-		if util.IsFirstSeenTag(tag.Key) {
-			firstSeenTime, err := util.ParseTimestamp(tag.Value)
-			if err != nil {
-				return nil, errors.WithStackTrace(err)
-			}
-
-			return firstSeenTime, nil
-		}
-	}
-
-	return nil, nil
-}
-
 func shouldIncludeIpamScopeID(ipam *ec2.IpamScope, firstSeenTime *time.Time, configObj config.Config) bool {
 	var ipamScopeName string
 	// get the tags as map
@@ -65,26 +32,18 @@ func shouldIncludeIpamScopeID(ipam *ec2.IpamScope, firstSeenTime *time.Time, con
 // Returns a formatted string of IPAM URLs
 func (ec2Scope *EC2IpamScopes) getAll(c context.Context, configObj config.Config) ([]*string, error) {
 	result := []*string{}
+	var firstSeenTime *time.Time
+	var err error
+
 	paginator := func(output *ec2.DescribeIpamScopesOutput, lastPage bool) bool {
 		for _, scope := range output.IpamScopes {
-			// check first seen tag
-			firstSeenTime, err := ec2Scope.getFirstSeenTag(*scope)
+
+			firstSeenTime, err = util.GetOrCreateFirstSeen(c, ec2Scope.Client, scope.IpamScopeId, util.ConvertEC2TagsToMap(scope.Tags))
 			if err != nil {
-				logging.Errorf(
-					"Unable to retrieve tags for IPAM: %s, with error: %s", *scope.IpamScopeId, err)
+				logging.Error("unable to retrieve firstseen tag")
 				continue
 			}
 
-			// if the first seen tag is not there, then create one
-			if firstSeenTime == nil {
-				now := time.Now().UTC()
-				firstSeenTime = &now
-				if err := ec2Scope.setFirstSeenTag(*scope, time.Now().UTC()); err != nil {
-					logging.Errorf(
-						"Unable to apply first seen tag IPAM: %s, with error: %s", *scope.IpamScopeId, err)
-					continue
-				}
-			}
 			// Check for include this ipam
 			if shouldIncludeIpamScopeID(scope, firstSeenTime, configObj) {
 				result = append(result, scope.IpamScopeId)
@@ -103,7 +62,7 @@ func (ec2Scope *EC2IpamScopes) getAll(c context.Context, configObj config.Config
 		},
 	}
 
-	err := ec2Scope.Client.DescribeIpamScopesPages(params, paginator)
+	err = ec2Scope.Client.DescribeIpamScopesPages(params, paginator)
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
 	}

--- a/aws/resources/ec2_ipam_scope_test.go
+++ b/aws/resources/ec2_ipam_scope_test.go
@@ -32,6 +32,9 @@ func (m mockedIPAMScope) DeleteIpamScope(params *ec2.DeleteIpamScopeInput) (*ec2
 func TestIPAMScope_GetAll(t *testing.T) {
 	t.Parallel()
 
+	// Set excludeFirstSeenTag to false for testing
+	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
+
 	var (
 		now       = time.Now()
 		testId1   = "ipam-scope-0dfc56f901b2c3462"
@@ -76,14 +79,17 @@ func TestIPAMScope_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
+		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
+			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -93,6 +99,7 @@ func TestIPAMScope_GetAll(t *testing.T) {
 			expected: []string{testId2},
 		},
 		"timeAfterExclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
@@ -103,7 +110,7 @@ func TestIPAMScope_GetAll(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ids, err := ipam.getAll(context.Background(), config.Config{
+			ids, err := ipam.getAll(tc.ctx, config.Config{
 				EC2IPAMScope: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_network_acl.go
+++ b/aws/resources/ec2_network_acl.go
@@ -14,38 +14,6 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-func (nacl *NetworkACL) setFirstSeenTag(networkAcl ec2.NetworkAcl, value time.Time) error {
-	_, err := nacl.Client.CreateTags(&ec2.CreateTagsInput{
-		Resources: []*string{networkAcl.NetworkAclId},
-		Tags: []*ec2.Tag{
-			{
-				Key:   awsgo.String(util.FirstSeenTagKey),
-				Value: awsgo.String(util.FormatTimestamp(value)),
-			},
-		},
-	})
-	if err != nil {
-		return errors.WithStackTrace(err)
-	}
-
-	return nil
-}
-
-func (nacl *NetworkACL) getFirstSeenTag(networkAcl ec2.NetworkAcl) (*time.Time, error) {
-	for _, tag := range networkAcl.Tags {
-		if util.IsFirstSeenTag(tag.Key) {
-			firstSeenTime, err := util.ParseTimestamp(tag.Value)
-			if err != nil {
-				return nil, errors.WithStackTrace(err)
-			}
-
-			return firstSeenTime, nil
-		}
-	}
-
-	return nil, nil
-}
-
 func shouldIncludeNetworkACL(networkAcl *ec2.NetworkAcl, firstSeenTime *time.Time, configObj config.Config) bool {
 	var naclName string
 	// get the tags as map
@@ -60,8 +28,11 @@ func shouldIncludeNetworkACL(networkAcl *ec2.NetworkAcl, firstSeenTime *time.Tim
 	})
 }
 
-func (nacl *NetworkACL) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
+func (nacl *NetworkACL) getAll(c context.Context, configObj config.Config) ([]*string, error) {
 	var identifiers []*string
+	var firstSeenTime *time.Time
+	var err error
+
 	resp, err := nacl.Client.DescribeNetworkAcls(&ec2.DescribeNetworkAclsInput{
 		Filters: []*ec2.Filter{
 			{
@@ -78,23 +49,10 @@ func (nacl *NetworkACL) getAll(_ context.Context, configObj config.Config) ([]*s
 	}
 
 	for _, networkAcl := range resp.NetworkAcls {
-		// check first seen tag
-		firstSeenTime, err := nacl.getFirstSeenTag(*networkAcl)
+		firstSeenTime, err = util.GetOrCreateFirstSeen(c, nacl.Client, networkAcl.NetworkAclId, util.ConvertEC2TagsToMap(networkAcl.Tags))
 		if err != nil {
-			logging.Errorf(
-				"Unable to retrieve tags for network acl: %s, with error: %s", awsgo.StringValue(networkAcl.NetworkAclId), err)
+			logging.Error("unable to retrieve first seen tag")
 			continue
-		}
-
-		// if the first seen tag is not there, then create one
-		if firstSeenTime == nil {
-			now := time.Now().UTC()
-			firstSeenTime = &now
-			if err := nacl.setFirstSeenTag(*networkAcl, time.Now().UTC()); err != nil {
-				logging.Errorf(
-					"Unable to apply first seen tag network acl: %s, with error: %s", awsgo.StringValue(networkAcl.NetworkAclId), err)
-				continue
-			}
 		}
 
 		if shouldIncludeNetworkACL(networkAcl, firstSeenTime, configObj) {

--- a/aws/resources/ec2_network_acl_test.go
+++ b/aws/resources/ec2_network_acl_test.go
@@ -37,6 +37,9 @@ func (m mockedNetworkACL) ReplaceNetworkAclAssociation(*ec2.ReplaceNetworkAclAss
 
 func TestNetworkAcl_GetAll(t *testing.T) {
 
+	// Set excludeFirstSeenTag to false for testing
+	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
+
 	var (
 		now     = time.Now()
 		testId1 = "acl-09e36c45cbdbfb001"
@@ -83,14 +86,17 @@ func TestNetworkAcl_GetAll(t *testing.T) {
 	resourceObject.BaseAwsResource.Init(nil)
 
 	tests := map[string]struct {
+		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
+			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -100,6 +106,7 @@ func TestNetworkAcl_GetAll(t *testing.T) {
 			expected: []string{testId2},
 		},
 		"nameInclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				IncludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -109,6 +116,7 @@ func TestNetworkAcl_GetAll(t *testing.T) {
 			expected: []string{testId1},
 		},
 		"timeAfterExclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now),
@@ -120,7 +128,7 @@ func TestNetworkAcl_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := resourceObject.getAll(context.Background(), config.Config{
+			names, err := resourceObject.getAll(tc.ctx, config.Config{
 				NetworkACL: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_network_interface.go
+++ b/aws/resources/ec2_network_interface.go
@@ -14,39 +14,6 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-func (ni *NetworkInterface) setFirstSeenTag(networkInterface ec2.NetworkInterface, value time.Time) error {
-	_, err := ni.Client.CreateTags(&ec2.CreateTagsInput{
-		Resources: []*string{networkInterface.NetworkInterfaceId},
-		Tags: []*ec2.Tag{
-			{
-				Key:   awsgo.String(util.FirstSeenTagKey),
-				Value: awsgo.String(util.FormatTimestamp(value)),
-			},
-		},
-	})
-	if err != nil {
-		return errors.WithStackTrace(err)
-	}
-
-	return nil
-}
-
-func (igw *NetworkInterface) getFirstSeenTag(networkInterface ec2.NetworkInterface) (*time.Time, error) {
-	tags := networkInterface.TagSet
-	for _, tag := range tags {
-		if util.IsFirstSeenTag(tag.Key) {
-			firstSeenTime, err := util.ParseTimestamp(tag.Value)
-			if err != nil {
-				return nil, errors.WithStackTrace(err)
-			}
-
-			return firstSeenTime, nil
-		}
-	}
-
-	return nil, nil
-}
-
 func shouldIncludeNetworkInterface(networkInterface *ec2.NetworkInterface, firstSeenTime *time.Time, configObj config.Config) bool {
 	var interfaceName string
 	// get the tags as map
@@ -61,8 +28,11 @@ func shouldIncludeNetworkInterface(networkInterface *ec2.NetworkInterface, first
 	})
 }
 
-func (ni *NetworkInterface) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
+func (ni *NetworkInterface) getAll(c context.Context, configObj config.Config) ([]*string, error) {
 	var identifiers []*string
+	var firstSeenTime *time.Time
+	var err error
+
 	resp, err := ni.Client.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{})
 	if err != nil {
 		logging.Debugf("[Internet Gateway] Failed to list internet gateways: %s", err)
@@ -70,23 +40,10 @@ func (ni *NetworkInterface) getAll(_ context.Context, configObj config.Config) (
 	}
 
 	for _, networkInterface := range resp.NetworkInterfaces {
-		// check first seen tag
-		firstSeenTime, err := ni.getFirstSeenTag(*networkInterface)
+		firstSeenTime, err = util.GetOrCreateFirstSeen(c, ni.Client, networkInterface.NetworkInterfaceId, util.ConvertEC2TagsToMap(networkInterface.TagSet))
 		if err != nil {
-			logging.Errorf(
-				"Unable to retrieve tags for Internet gateway: %s, with error: %s", *networkInterface.NetworkInterfaceId, err)
+			logging.Error("unable to retrieve first seen tag")
 			continue
-		}
-
-		// if the first seen tag is not there, then create one
-		if firstSeenTime == nil {
-			now := time.Now().UTC()
-			firstSeenTime = &now
-			if err := ni.setFirstSeenTag(*networkInterface, time.Now().UTC()); err != nil {
-				logging.Errorf(
-					"Unable to apply first seen tag Internet gateway: %s, with error: %s", *networkInterface.NetworkInterfaceId, err)
-				continue
-			}
 		}
 
 		if shouldIncludeNetworkInterface(networkInterface, firstSeenTime, configObj) {

--- a/aws/resources/ec2_network_interface_test.go
+++ b/aws/resources/ec2_network_interface_test.go
@@ -50,6 +50,9 @@ func (m mockedNetworkInterface) WaitUntilInstanceTerminated(*ec2.DescribeInstanc
 
 func TestNetworkInterface_GetAll(t *testing.T) {
 
+	// Set excludeFirstSeenTag to false for testing
+	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
+
 	var (
 		now     = time.Now()
 		testId1 = "eni-09e36c45cbdbfb001"
@@ -96,14 +99,17 @@ func TestNetworkInterface_GetAll(t *testing.T) {
 	resourceObject.BaseAwsResource.Init(nil)
 
 	tests := map[string]struct {
+		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
+			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -113,6 +119,7 @@ func TestNetworkInterface_GetAll(t *testing.T) {
 			expected: []string{testId2},
 		},
 		"nameInclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				IncludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -122,6 +129,7 @@ func TestNetworkInterface_GetAll(t *testing.T) {
 			expected: []string{testId1},
 		},
 		"timeAfterExclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: awsgo.Time(now),
@@ -133,7 +141,7 @@ func TestNetworkInterface_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := resourceObject.getAll(context.Background(), config.Config{
+			names, err := resourceObject.getAll(tc.ctx, config.Config{
 				NetworkInterface: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_subnet_test.go
+++ b/aws/resources/ec2_subnet_test.go
@@ -32,6 +32,9 @@ func TestEc2Subnets_GetAll(t *testing.T) {
 
 	t.Parallel()
 
+	// Set excludeFirstSeenTag to false for testing
+	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
+
 	var (
 		now       = time.Now()
 		subnet1   = "subnet-0631b58700ba3db41"
@@ -75,10 +78,12 @@ func TestEc2Subnets_GetAll(t *testing.T) {
 	ec2subnet.BaseAwsResource.Init(nil)
 
 	tests := map[string]struct {
+		ctx       context.Context
 		configObj config.EC2ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
+			ctx:       ctx,
 			configObj: config.EC2ResourceType{},
 			expected:  []string{subnet1, subnet2},
 		},
@@ -95,6 +100,7 @@ func TestEc2Subnets_GetAll(t *testing.T) {
 			expected: []string{subnet2},
 		},
 		"timeAfterExclusionFilter": {
+			ctx: ctx,
 			configObj: config.EC2ResourceType{
 				ResourceType: config.ResourceType{
 					ExcludeRule: config.FilterRule{
@@ -106,7 +112,7 @@ func TestEc2Subnets_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := ec2subnet.getAll(context.Background(), config.Config{
+			names, err := ec2subnet.getAll(tc.ctx, config.Config{
 				EC2Subnet: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_vpc_test.go
+++ b/aws/resources/ec2_vpc_test.go
@@ -60,6 +60,9 @@ func TestEC2VPC_GetAll(t *testing.T) {
 
 	t.Parallel()
 
+	// Set excludeFirstSeenTag to false for testing
+	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
+
 	testName1 := "test-vpc-name1"
 	testName2 := "test-vpc-name2"
 	now := time.Now()
@@ -101,14 +104,17 @@ func TestEC2VPC_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
+		ctx       context.Context
 		configObj config.EC2ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
+			ctx:       ctx,
 			configObj: config.EC2ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
+			ctx: ctx,
 			configObj: config.EC2ResourceType{
 				ResourceType: config.ResourceType{
 					ExcludeRule: config.FilterRule{
@@ -121,6 +127,7 @@ func TestEC2VPC_GetAll(t *testing.T) {
 			expected: []string{testId2},
 		},
 		"timeAfterExclusionFilter": {
+			ctx: ctx,
 			configObj: config.EC2ResourceType{
 				ResourceType: config.ResourceType{
 					ExcludeRule: config.FilterRule{
@@ -132,7 +139,7 @@ func TestEC2VPC_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := vpc.getAll(context.Background(), config.Config{
+			names, err := vpc.getAll(tc.ctx, config.Config{
 				VPC: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ecs_cluster.go
+++ b/aws/resources/ecs_cluster.go
@@ -100,23 +100,29 @@ func (clusters *ECSClusters) getAll(c context.Context, configObj config.Config) 
 		return nil, errors.WithStackTrace(err)
 	}
 
+	excludeFirstSeenTag, err := util.GetBoolFromContext(c, util.ExcludeFirstSeenTagKey)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
 	var filteredEcsClusters []*string
 	for _, clusterArn := range clusterArns {
-
-		firstSeenTime, err := clusters.getFirstSeenTag(clusterArn)
-		if err != nil {
-			logging.Debugf("Error getting the `cloud-nuke-first-seen` tag for ECS cluster with ARN %s", aws.StringValue(clusterArn))
-			return nil, errors.WithStackTrace(err)
-		}
-
-		if firstSeenTime == nil {
-			err := clusters.setFirstSeenTag(clusterArn, time.Now().UTC())
+		if !excludeFirstSeenTag {
+			firstSeenTime, err := clusters.getFirstSeenTag(clusterArn)
 			if err != nil {
-				logging.Debugf("Error tagging the ECS cluster with ARN %s", aws.StringValue(clusterArn))
+				logging.Debugf("Error getting the `cloud-nuke-first-seen` tag for ECS cluster with ARN %s", aws.StringValue(clusterArn))
 				return nil, errors.WithStackTrace(err)
 			}
-		} else if configObj.ECSCluster.ShouldInclude(config.ResourceValue{Time: firstSeenTime}) {
-			filteredEcsClusters = append(filteredEcsClusters, clusterArn)
+
+			if firstSeenTime == nil {
+				err := clusters.setFirstSeenTag(clusterArn, time.Now().UTC())
+				if err != nil {
+					logging.Debugf("Error tagging the ECS cluster with ARN %s", aws.StringValue(clusterArn))
+					return nil, errors.WithStackTrace(err)
+				}
+			} else if configObj.ECSCluster.ShouldInclude(config.ResourceValue{Time: firstSeenTime}) {
+				filteredEcsClusters = append(filteredEcsClusters, clusterArn)
+			}
 		}
 	}
 	return filteredEcsClusters, nil

--- a/aws/resources/network_firewall.go
+++ b/aws/resources/network_firewall.go
@@ -14,34 +14,6 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-func (nfw *NetworkFirewall) setFirstSeenTag(resource *networkfirewall.Firewall, value time.Time) error {
-	_, err := nfw.Client.TagResource(&networkfirewall.TagResourceInput{
-		ResourceArn: resource.FirewallArn,
-		Tags: []*networkfirewall.Tag{
-			{
-				Key:   awsgo.String(util.FirstSeenTagKey),
-				Value: awsgo.String(util.FormatTimestamp(value)),
-			},
-		},
-	})
-	return errors.WithStackTrace(err)
-}
-
-func (nfw *NetworkFirewall) getFirstSeenTag(resource *networkfirewall.Firewall) (*time.Time, error) {
-	for _, tag := range resource.Tags {
-		if util.IsFirstSeenTag(tag.Key) {
-			firstSeenTime, err := util.ParseTimestamp(tag.Value)
-			if err != nil {
-				return nil, errors.WithStackTrace(err)
-			}
-
-			return firstSeenTime, nil
-		}
-	}
-
-	return nil, nil
-}
-
 func shouldIncludeNetworkFirewall(firewall *networkfirewall.Firewall, firstSeenTime *time.Time, configObj config.Config) bool {
 	var identifierName string
 	tags := util.ConvertNetworkFirewallTagsToMap(firewall.Tags)
@@ -58,8 +30,10 @@ func shouldIncludeNetworkFirewall(firewall *networkfirewall.Firewall, firstSeenT
 	})
 }
 
-func (nfw *NetworkFirewall) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
+func (nfw *NetworkFirewall) getAll(c context.Context, configObj config.Config) ([]*string, error) {
 	var identifiers []*string
+	var firstSeenTime *time.Time
+	var err error
 
 	metaOutput, err := nfw.Client.ListFirewalls(nil)
 	if err != nil {
@@ -82,23 +56,10 @@ func (nfw *NetworkFirewall) getAll(_ context.Context, configObj config.Config) (
 			continue
 		}
 
-		// check first seen tag
-		firstSeenTime, err := nfw.getFirstSeenTag(output.Firewall)
+		firstSeenTime, err = util.GetOrCreateFirstSeen(c, nfw.Client, firewall.FirewallArn, util.ConvertNetworkFirewallTagsToMap(output.Firewall.Tags))
 		if err != nil {
-			logging.Errorf(
-				"Unable to retrieve tags for Firewall: %s, with error: %s", awsgo.StringValue(firewall.FirewallName), err)
-			continue
-		}
-
-		// if the first seen tag is not there, then create one
-		if firstSeenTime == nil {
-			now := time.Now().UTC()
-			firstSeenTime = &now
-			if err := nfw.setFirstSeenTag(output.Firewall, time.Now().UTC()); err != nil {
-				logging.Errorf(
-					"Unable to apply first seen tag Firewall: %s, with error: %s", awsgo.StringValue(firewall.FirewallName), err)
-				continue
-			}
+			logging.Error("Unable to retrieve tags")
+			return nil, errors.WithStackTrace(err)
 		}
 
 		// check the resource is delete protected

--- a/aws/resources/network_firewall_policy_test.go
+++ b/aws/resources/network_firewall_policy_test.go
@@ -56,6 +56,7 @@ func TestNetworkFirewallPolicy_GetAll(t *testing.T) {
 		testId2   = "test-network-firewall-id2"
 		testName1 = "test-network-firewall-1"
 		testName2 = "test-network-firewall-2"
+		ctx       = context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
 	)
 
 	nfw := NetworkFirewallPolicy{
@@ -134,7 +135,7 @@ func TestNetworkFirewallPolicy_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := nfw.getAll(context.Background(), config.Config{
+			names, err := nfw.getAll(ctx, config.Config{
 				NetworkFirewallPolicy: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/network_firewall_rule_group.go
+++ b/aws/resources/network_firewall_rule_group.go
@@ -14,34 +14,6 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-func (nfw *NetworkFirewallRuleGroup) setFirstSeenTag(resource *networkfirewall.RuleGroupResponse, value time.Time) error {
-	_, err := nfw.Client.TagResource(&networkfirewall.TagResourceInput{
-		ResourceArn: resource.RuleGroupArn,
-		Tags: []*networkfirewall.Tag{
-			{
-				Key:   awsgo.String(util.FirstSeenTagKey),
-				Value: awsgo.String(util.FormatTimestamp(value)),
-			},
-		},
-	})
-	return errors.WithStackTrace(err)
-}
-
-func (nfw *NetworkFirewallRuleGroup) getFirstSeenTag(resource *networkfirewall.RuleGroupResponse) (*time.Time, error) {
-	for _, tag := range resource.Tags {
-		if util.IsFirstSeenTag(tag.Key) {
-			firstSeenTime, err := util.ParseTimestamp(tag.Value)
-			if err != nil {
-				return nil, errors.WithStackTrace(err)
-			}
-
-			return firstSeenTime, nil
-		}
-	}
-
-	return nil, nil
-}
-
 func shouldIncludeNetworkFirewallRuleGroup(group *networkfirewall.RuleGroupResponse, firstSeenTime *time.Time, configObj config.Config) bool {
 	// if the firewall policy has any attachments, then we can't remove that policy
 	if awsgo.Int64Value(group.NumberOfAssociations) > 0 {
@@ -64,8 +36,12 @@ func shouldIncludeNetworkFirewallRuleGroup(group *networkfirewall.RuleGroupRespo
 	})
 }
 
-func (nfw *NetworkFirewallRuleGroup) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
-	var identifiers []*string
+func (nfw *NetworkFirewallRuleGroup) getAll(c context.Context, configObj config.Config) ([]*string, error) {
+	var (
+		identifiers   []*string
+		firstSeenTime *time.Time
+		err           error
+	)
 
 	meta, err := nfw.Client.ListRuleGroups(nil)
 	if err != nil {
@@ -86,23 +62,10 @@ func (nfw *NetworkFirewallRuleGroup) getAll(_ context.Context, configObj config.
 			continue
 		}
 
-		// check first seen tag
-		firstSeenTime, err := nfw.getFirstSeenTag(output.RuleGroupResponse)
+		firstSeenTime, err = util.GetOrCreateFirstSeen(c, nfw.Client, group.Arn, util.ConvertNetworkFirewallTagsToMap(output.RuleGroupResponse.Tags))
 		if err != nil {
-			logging.Errorf(
-				"Unable to retrieve tags for Rule group: %s, with error: %s", awsgo.StringValue(group.Name), err)
-			continue
-		}
-
-		// if the first seen tag is not there, then create one
-		if firstSeenTime == nil {
-			now := time.Now().UTC()
-			firstSeenTime = &now
-			if err := nfw.setFirstSeenTag(output.RuleGroupResponse, time.Now().UTC()); err != nil {
-				logging.Errorf(
-					"Unable to apply first seen tag Rule group: %s, with error: %s", awsgo.StringValue(group.Name), err)
-				continue
-			}
+			logging.Error("Unable to retrieve tags")
+			return nil, errors.WithStackTrace(err)
 		}
 
 		if shouldIncludeNetworkFirewallRuleGroup(output.RuleGroupResponse, firstSeenTime, configObj) {

--- a/aws/resources/network_firewall_rule_group_test.go
+++ b/aws/resources/network_firewall_rule_group_test.go
@@ -56,6 +56,7 @@ func TestNetworkFirewallRuleGroup_GetAll(t *testing.T) {
 		testId2   = "test-network-firewall-id2"
 		testName1 = "test-network-firewall-1"
 		testName2 = "test-network-firewall-2"
+		ctx       = context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
 	)
 
 	nfw := NetworkFirewallRuleGroup{
@@ -135,7 +136,7 @@ func TestNetworkFirewallRuleGroup_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := nfw.getAll(context.Background(), config.Config{
+			names, err := nfw.getAll(ctx, config.Config{
 				NetworkFirewallRuleGroup: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/network_firewall_test.go
+++ b/aws/resources/network_firewall_test.go
@@ -56,6 +56,7 @@ func TestNetworkFirewall_GetAll(t *testing.T) {
 		testId2   = "test-network-firewall-id2"
 		testName1 = "test-network-firewall-1"
 		testName2 = "test-network-firewall-2"
+		ctx       = context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
 	)
 
 	nfw := NetworkFirewall{
@@ -134,7 +135,7 @@ func TestNetworkFirewall_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := nfw.getAll(context.Background(), config.Config{
+			names, err := nfw.getAll(ctx, config.Config{
 				NetworkFirewall: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/network_firewall_tls_config_test.go
+++ b/aws/resources/network_firewall_tls_config_test.go
@@ -56,6 +56,7 @@ func TestNetworkFirewallTLSConfig_GetAll(t *testing.T) {
 		testId2   = "test-network-firewall-id2"
 		testName1 = "test-network-firewall-1"
 		testName2 = "test-network-firewall-2"
+		ctx       = context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
 	)
 
 	nfw := NetworkFirewallTLSConfig{
@@ -134,7 +135,7 @@ func TestNetworkFirewallTLSConfig_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := nfw.getAll(context.Background(), config.Config{
+			names, err := nfw.getAll(ctx, config.Config{
 				NetworkFirewallTLSConfig: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/opensearch_test.go
+++ b/aws/resources/opensearch_test.go
@@ -42,6 +42,9 @@ func TestOpenSearch_GetAll(t *testing.T) {
 
 	t.Parallel()
 
+	// Set excludeFirstSeenTag to false for testing
+	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
+
 	testName1 := "test-domain1"
 	testName2 := "test-domain2"
 	now := time.Now()
@@ -85,14 +88,17 @@ func TestOpenSearch_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
+		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
+			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{testName1, testName2},
 		},
 		"nameExclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -102,6 +108,7 @@ func TestOpenSearch_GetAll(t *testing.T) {
 			expected: []string{testName2},
 		},
 		"timeAfterExclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
@@ -111,7 +118,7 @@ func TestOpenSearch_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := osd.getAll(context.Background(), config.Config{
+			names, err := osd.getAll(tc.ctx, config.Config{
 				OpenSearchDomain: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/rds_cluster.go
+++ b/aws/resources/rds_cluster.go
@@ -2,9 +2,8 @@ package resources
 
 import (
 	"context"
-	"time"
-
 	"github.com/gruntwork-io/cloud-nuke/util"
+	"time"
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
 
@@ -91,6 +90,7 @@ func (instance *DBClusters) nukeAll(names []*string) error {
 
 	if len(deletedNames) > 0 {
 		for _, name := range deletedNames {
+
 			err := instance.waitUntilRdsClusterDeleted(&rds.DescribeDBClustersInput{
 				DBClusterIdentifier: name,
 			})

--- a/aws/resources/security_group.go
+++ b/aws/resources/security_group.go
@@ -15,37 +15,6 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-func (sg *SecurityGroup) setFirstSeenTag(securityGroup ec2.SecurityGroup, value time.Time) error {
-	_, err := sg.Client.CreateTags(&ec2.CreateTagsInput{
-		Resources: []*string{securityGroup.GroupId},
-		Tags: []*ec2.Tag{
-			{
-				Key:   awsgo.String(util.FirstSeenTagKey),
-				Value: awsgo.String(util.FormatTimestamp(value)),
-			},
-		},
-	})
-	if err != nil {
-		return errors.WithStackTrace(err)
-	}
-	return nil
-}
-
-func (sg *SecurityGroup) getFirstSeenTag(securityGroup ec2.SecurityGroup) (*time.Time, error) {
-	tags := securityGroup.Tags
-	for _, tag := range tags {
-		if util.IsFirstSeenTag(tag.Key) {
-			firstSeenTime, err := util.ParseTimestamp(tag.Value)
-			if err != nil {
-				return nil, errors.WithStackTrace(err)
-			}
-
-			return firstSeenTime, nil
-		}
-	}
-	return nil, nil
-}
-
 // shouldIncludeSecurityGroup determines whether a security group should be included for deletion based on the provided configuration.
 func shouldIncludeSecurityGroup(sg *ec2.SecurityGroup, firstSeenTime *time.Time, configObj config.Config) bool {
 	var groupName = sg.GroupName
@@ -63,8 +32,10 @@ func shouldIncludeSecurityGroup(sg *ec2.SecurityGroup, firstSeenTime *time.Time,
 }
 
 // getAll retrieves all security group identifiers based on the provided configuration.
-func (sg *SecurityGroup) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
+func (sg *SecurityGroup) getAll(c context.Context, configObj config.Config) ([]*string, error) {
 	var identifiers []*string
+	var firstSeenTime *time.Time
+	var err error
 
 	var filters []*ec2.Filter
 	if configObj.SecurityGroup.DefaultOnly {
@@ -90,24 +61,12 @@ func (sg *SecurityGroup) getAll(_ context.Context, configObj config.Config) ([]*
 	}
 
 	for _, group := range resp.SecurityGroups {
-		// check first seen tag
-		firstSeenTime, err := sg.getFirstSeenTag(*group)
+		firstSeenTime, err = util.GetOrCreateFirstSeen(c, sg.Client, group.GroupId, util.ConvertEC2TagsToMap(group.Tags))
 		if err != nil {
-			logging.Errorf(
-				"Unable to retrieve tags for Security group: %s, with error: %s", *group.GroupId, err)
-			continue
+			logging.Error("unable to retrieve first seen tag")
+			return nil, errors.WithStackTrace(err)
 		}
 
-		// if the first seen tag is not there, then create one
-		if firstSeenTime == nil {
-			now := time.Now().UTC()
-			firstSeenTime = &now
-			if err := sg.setFirstSeenTag(*group, time.Now().UTC()); err != nil {
-				logging.Errorf(
-					"Unable to apply first seen tag Security group: %s, with error: %s", *group.GroupId, err)
-				continue
-			}
-		}
 		if shouldIncludeSecurityGroup(group, firstSeenTime, configObj) {
 			identifiers = append(identifiers, group.GroupId)
 		}

--- a/aws/resources/security_group_test.go
+++ b/aws/resources/security_group_test.go
@@ -44,6 +44,9 @@ func TestSecurityGroup_GetAll(t *testing.T) {
 		now       = time.Now()
 	)
 
+	// Set excludeFirstSeenTag to false for testing
+	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
+
 	sg := SecurityGroup{
 		BaseAwsResource: BaseAwsResource{
 			Nukables: map[string]error{
@@ -88,14 +91,17 @@ func TestSecurityGroup_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
+		ctx       context.Context
 		configObj config.EC2ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
+			ctx:ctx,
 			configObj: config.EC2ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
+			ctx:ctx,
 			configObj: config.EC2ResourceType{
 				ResourceType: config.ResourceType{
 					ExcludeRule: config.FilterRule{
@@ -107,6 +113,7 @@ func TestSecurityGroup_GetAll(t *testing.T) {
 			expected: []string{testId2},
 		},
 		"timeAfterExclusionFilter": {
+			ctx:ctx,
 			configObj: config.EC2ResourceType{
 				ResourceType: config.ResourceType{
 					ExcludeRule: config.FilterRule{
@@ -120,7 +127,7 @@ func TestSecurityGroup_GetAll(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			names, err := sg.getAll(context.Background(), config.Config{
+			names, err := sg.getAll(tc.ctx, config.Config{
 				SecurityGroup: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/sns.go
+++ b/aws/resources/sns.go
@@ -2,11 +2,12 @@ package resources
 
 import (
 	"context"
-	"github.com/aws/aws-sdk-go/service/sns"
-	"github.com/gruntwork-io/cloud-nuke/util"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/gruntwork-io/cloud-nuke/util"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/gruntwork-io/cloud-nuke/config"
@@ -22,25 +23,33 @@ import (
 func (s *SNSTopic) getAll(c context.Context, configObj config.Config) ([]*string, error) {
 
 	var snsTopics []*string
-	err := s.Client.ListTopicsPages(&sns.ListTopicsInput{}, func(page *sns.ListTopicsOutput, lastPage bool) bool {
-		for _, topic := range page.Topics {
-			firstSeenTime, err := s.getFirstSeenTag(*topic.TopicArn)
-			if err != nil {
-				logging.Errorf(
-					"Unable to retrieve tags for SNS Topic: %s, with error: %s", *topic.TopicArn, err)
-				continue
-			}
+	var firstSeenTime *time.Time
+	var err error
 
-			if firstSeenTime == nil {
-				now := time.Now().UTC()
-				firstSeenTime = &now
-				if err := s.setFirstSeenTag(*topic.TopicArn, now); err != nil {
+	excludeFirstSeenTag, err := util.GetBoolFromContext(c, util.ExcludeFirstSeenTagKey)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+	err = s.Client.ListTopicsPages(&sns.ListTopicsInput{}, func(page *sns.ListTopicsOutput, lastPage bool) bool {
+		for _, topic := range page.Topics {
+			if !excludeFirstSeenTag {
+				firstSeenTime, err = s.getFirstSeenTag(*topic.TopicArn)
+				if err != nil {
 					logging.Errorf(
-						"Unable to apply first seen tag SNS Topic: %s, with error: %s", *topic.TopicArn, err)
+						"Unable to retrieve tags for SNS Topic: %s, with error: %s", *topic.TopicArn, err)
 					continue
 				}
-			}
 
+				if firstSeenTime == nil {
+					now := time.Now().UTC()
+					firstSeenTime = &now
+					if err := s.setFirstSeenTag(*topic.TopicArn, now); err != nil {
+						logging.Errorf(
+							"Unable to apply first seen tag SNS Topic: %s, with error: %s", *topic.TopicArn, err)
+						continue
+					}
+				}
+			}
 			// a topic arn is of the form arn:aws:sns:us-east-1:123456789012:MyTopic
 			// so we can search for the index of the last colon, then slice the string to get the topic name
 			nameIndex := strings.LastIndex(*topic.TopicArn, ":")

--- a/aws/resources/sns_test.go
+++ b/aws/resources/sns_test.go
@@ -2,10 +2,13 @@ package resources
 
 import (
 	"context"
-	"github.com/aws/aws-sdk-go/service/sns/snsiface"
 	"regexp"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go/service/sns/snsiface"
+
+	"github.com/gruntwork-io/cloud-nuke/util"
 
 	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
@@ -41,6 +44,9 @@ func TestSNS_GetAll(t *testing.T) {
 
 	t.Parallel()
 
+	// Set excludeFirstSeenTag to false for testing
+	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
+
 	testTopic1 := "arn:aws:sns:us-east-1:123456789012:MyTopic1"
 	testTopic2 := "arn:aws:sns:us-east-1:123456789012:MyTopic2"
 	now := time.Now()
@@ -70,14 +76,17 @@ func TestSNS_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
+		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
+			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{testTopic1, testTopic2},
 		},
 		"nameExclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -87,6 +96,7 @@ func TestSNS_GetAll(t *testing.T) {
 			expected: []string{testTopic2},
 		},
 		"timeAfterExclusionFilter": {
+			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
@@ -96,7 +106,7 @@ func TestSNS_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := s.getAll(context.Background(), config.Config{
+			names, err := s.getAll(tc.ctx, config.Config{
 				SNS: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/sqs.go
+++ b/aws/resources/sqs.go
@@ -2,6 +2,9 @@ package resources
 
 import (
 	"context"
+	"strconv"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sqs"
@@ -9,8 +12,6 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
 	"github.com/gruntwork-io/go-commons/errors"
-	"strconv"
-	"time"
 )
 
 // Returns a formatted string of SQS Queue URLs

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -173,6 +173,10 @@ func CreateCli(version string) *cli.App {
 					Usage:   "Set log level",
 					EnvVars: []string{"LOG_LEVEL"},
 				},
+				&cli.BoolFlag{
+					Name:  "exclude-first-seen",
+					Usage: "Set a flag for excluding first-seen-tag",
+				},
 			},
 		},
 	}
@@ -396,6 +400,7 @@ func generateQuery(c *cli.Context, includeUnaliasedKmsKeys bool, overridingResou
 		includeUnaliasedKmsKeys,
 		timeout,
 		onlyDefault,
+		c.Bool("exclude-first-seen"),
 	)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -30,10 +30,8 @@ type Config struct {
 	CodeDeployApplications          ResourceType               `yaml:"CodeDeployApplications"`
 	ConfigServiceRecorder           ResourceType               `yaml:"ConfigServiceRecorder"`
 	ConfigServiceRule               ResourceType               `yaml:"ConfigServiceRule"`
-	DBGlobalClusters                ResourceType               `yaml:"DBGlobalClusters"`
 	DBClusters                      ResourceType               `yaml:"DBClusters"`
 	DBInstances                     ResourceType               `yaml:"DBInstances"`
-	DBGlobalClusterMemberships      ResourceType               `yaml:"DBGlobalClusterMemberships"`
 	DBSubnetGroups                  ResourceType               `yaml:"DBSubnetGroups"`
 	DynamoDB                        ResourceType               `yaml:"DynamoDB"`
 	EBSVolume                       ResourceType               `yaml:"EBSVolume"`

--- a/config/config.go
+++ b/config/config.go
@@ -30,8 +30,10 @@ type Config struct {
 	CodeDeployApplications          ResourceType               `yaml:"CodeDeployApplications"`
 	ConfigServiceRecorder           ResourceType               `yaml:"ConfigServiceRecorder"`
 	ConfigServiceRule               ResourceType               `yaml:"ConfigServiceRule"`
+	DBGlobalClusters                ResourceType               `yaml:"DBGlobalClusters"`
 	DBClusters                      ResourceType               `yaml:"DBClusters"`
 	DBInstances                     ResourceType               `yaml:"DBInstances"`
+	DBGlobalClusterMemberships      ResourceType               `yaml:"DBGlobalClusterMemberships"`
 	DBSubnetGroups                  ResourceType               `yaml:"DBSubnetGroups"`
 	DynamoDB                        ResourceType               `yaml:"DynamoDB"`
 	EBSVolume                       ResourceType               `yaml:"EBSVolume"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,6 +43,8 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
+		ResourceType{FilterRule{}, FilterRule{}, ""},
+		ResourceType{FilterRule{}, FilterRule{}, ""},
 		EC2ResourceType{false, ResourceType{FilterRule{}, FilterRule{}, ""}},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,8 +43,6 @@ func emptyConfig() *Config {
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
-		ResourceType{FilterRule{}, FilterRule{}, ""},
-		ResourceType{FilterRule{}, FilterRule{}, ""},
 		EC2ResourceType{false, ResourceType{FilterRule{}, FilterRule{}, ""}},
 		ResourceType{FilterRule{}, FilterRule{}, ""},
 		ResourceType{FilterRule{}, FilterRule{}, ""},

--- a/util/context.go
+++ b/util/context.go
@@ -1,0 +1,19 @@
+package util
+
+import (
+	"context"
+	"errors"
+)
+
+const (
+	ExcludeFirstSeenTagKey = "exclude-first-seen-tag"
+)
+
+func GetBoolFromContext(ctx context.Context, key string) (bool, error) {
+	result, ok := ctx.Value(key).(bool)
+	if !ok {
+		return result, errors.New("unable to find the boolean context value or correct type mismatch.")
+	}
+
+	return result, nil
+}

--- a/util/time.go
+++ b/util/time.go
@@ -1,9 +1,16 @@
 package util
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/networkfirewall"
+	"github.com/aws/aws-sdk-go/service/networkfirewall/networkfirewalliface"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/go-commons/errors"
 )
@@ -41,4 +48,61 @@ func ParseTimestamp(timestamp *string) (*time.Time, error) {
 
 func FormatTimestamp(timestamp time.Time) string {
 	return timestamp.Format(firstSeenTimeFormat)
+}
+
+func GetOrCreateFirstSeen(ctx context.Context, client interface{}, identifier *string, tags map[string]string) (*time.Time, error) {
+
+	var firstSeenTime *time.Time
+	var err error
+
+	excludeFirstSeenTag, err := GetBoolFromContext(ctx, ExcludeFirstSeenTagKey)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	if excludeFirstSeenTag {
+		return nil, nil
+	}
+
+	// check the first seen already exists in the given map
+	for key, value := range tags {
+		if IsFirstSeenTag(awsgo.String(key)) {
+			firstSeenTime, err = ParseTimestamp(awsgo.String(value))
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+		}
+	}
+
+	if firstSeenTime == nil {
+		now := time.Now().UTC()
+		firstSeenTime = &now
+
+		switch v := client.(type) {
+		case ec2iface.EC2API:
+			_, err = v.CreateTags(&ec2.CreateTagsInput{
+				Resources: []*string{identifier},
+				Tags: []*ec2.Tag{
+					{
+						Key:   awsgo.String(FirstSeenTagKey),
+						Value: awsgo.String(FormatTimestamp(now)),
+					},
+				},
+			})
+		case networkfirewalliface.NetworkFirewallAPI:
+			_, err = v.TagResource(&networkfirewall.TagResourceInput{
+				ResourceArn: identifier,
+				Tags: []*networkfirewall.Tag{
+					{
+						Key:   awsgo.String(FirstSeenTagKey),
+						Value: awsgo.String(FormatTimestamp(now)),
+					},
+				},
+			})
+		default:
+			return nil, errors.WithStackTrace(fmt.Errorf("invalid type %v for first seen tag", v))
+		}
+	}
+
+	return firstSeenTime, err
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/675

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

