### PR TITLE
[WIP] nukable permission check for resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,40 @@ of the file that are supported are listed here.
 | network-firewall-resource-policy | NetworkFirewallResourcePolicy     | ✅ (Firewall Resource Policy ARN)   			  |  ❌             |  ❌    |    ❌   |
 
 
+### Resource Deletion and 'IsNukable' Check Option
+#### Supported Resources for 'IsNukable' Check
+For certain resources, such as `AMI`, `EBS`, `DHCP Option`, and others listed below, we support an option to verify whether the user has sufficient permissions to nuke the resources. If not, it will raise `error: INSUFFICIENT_PERMISSION` error.
+
+Supported resources:
+- AMI
+- EBS
+- DHCP Option
+- Egress only Internet Gateway
+- Endpoints
+- Internet Gatway
+- IPAM
+- IPAM BYOASN
+- IPAM Custom Allocation
+- IPAM Pool
+- IPAM Resource Discovery
+- IPAM Scope
+- Key Pair
+- Network ACL
+- Network Interface
+- Subnet
+- VPC
+- Elastic IP
+- Launch Template
+- NAT Gateway
+- Network Firewall
+- Security Group
+- SnapShot
+- Transit Gateway
+
+#### Unsupported Resources
+Please note that the eligibility check for nukability relies on the `DryRun` feature provided by AWS. Regrettably, this feature is not available for all delete APIs of resource types. Hence, the 'eligibility check for nukability' option may not be accessible for all resource types
+
+
 ### How to Use
 
 Once you created your config file, you can run a command like this to nuke resources with your config file:

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -24,6 +24,7 @@ func GetAllResources(c context.Context, query *Query, configObj config.Config) (
 	configObj.AddExcludeAfterTime(query.ExcludeAfter)
 	configObj.AddIncludeAfterTime(query.IncludeAfter)
 	configObj.AddTimeout(query.Timeout)
+
 	configObj.KMSCustomerKeys.IncludeUnaliasedKeys = query.ListUnaliasedKMSKeys
 
 	// Setting the DefaultOnly field
@@ -34,7 +35,6 @@ func GetAllResources(c context.Context, query *Query, configObj config.Config) (
 		Resources: make(map[string]AwsResources),
 	}
 
-	c = context.WithValue(c, util.ExcludeFirstSeenTagKey, query.ExcludeFirstSeen)
 	spinner, _ := pterm.DefaultSpinner.WithRemoveWhenDone(true).Start()
 	for _, region := range query.Regions {
 		cloudNukeSession := NewSession(region)

--- a/aws/query.go
+++ b/aws/query.go
@@ -14,16 +14,11 @@ type Query struct {
 	IncludeAfter         *time.Time
 	ListUnaliasedKMSKeys bool
 	Timeout              *time.Duration
-	ExcludeFirstSeen     bool
 	DefaultOnly          bool
 }
 
 // NewQuery configures and returns a Query struct that can be passed into the InspectResources method
-func NewQuery(regions, excludeRegions, resourceTypes, excludeResourceTypes []string,
-	excludeAfter, includeAfter *time.Time,
-	listUnaliasedKMSKeys bool, timeout *time.Duration,
-	defaultOnly, excludeFirstSeen bool,
-) (*Query, error) {
+func NewQuery(regions, excludeRegions, resourceTypes, excludeResourceTypes []string, excludeAfter, includeAfter *time.Time, listUnaliasedKMSKeys bool, timeout *time.Duration, defaultOnly bool) (*Query, error) {
 	q := &Query{
 		Regions:              regions,
 		ExcludeRegions:       excludeRegions,
@@ -34,7 +29,6 @@ func NewQuery(regions, excludeRegions, resourceTypes, excludeResourceTypes []str
 		ListUnaliasedKMSKeys: listUnaliasedKMSKeys,
 		Timeout:              timeout,
 		DefaultOnly:          defaultOnly,
-		ExcludeFirstSeen:     excludeFirstSeen,
 	}
 
 	validationErr := q.Validate()

--- a/aws/query_test.go
+++ b/aws/query_test.go
@@ -53,9 +53,7 @@ func TestNewQueryAcceptsValidExcludeAfterEntries(t *testing.T) {
 				tc.IncludeAfter,
 				false,
 				nil,
-				false,
-				false,
-			)
+				false)
 			require.NoError(t, err)
 		})
 	}

--- a/aws/resources/ami.go
+++ b/aws/resources/ami.go
@@ -2,9 +2,10 @@ package resources
 
 import (
 	"context"
+	"strings"
+
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/gruntwork-io/cloud-nuke/util"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -54,6 +55,15 @@ func (ami *AMIs) getAll(c context.Context, configObj config.Config) ([]*string, 
 		}
 	}
 
+	// checking the nukable permissions
+	ami.VerifyNukablePermissions(imageIds, func(id *string) error {
+		_, err := ami.Client.DeregisterImage(&ec2.DeregisterImageInput{
+			ImageId: id,
+			DryRun:  awsgo.Bool(true),
+		})
+		return err
+	})
+
 	return imageIds, nil
 }
 
@@ -62,17 +72,21 @@ func (ami *AMIs) nukeAll(imageIds []*string) error {
 	if len(imageIds) == 0 {
 		logging.Debugf("No AMI to nuke in region %s", ami.Region)
 		return nil
+
 	}
 
 	logging.Debugf("Deleting all AMI in region %s", ami.Region)
 
 	deletedCount := 0
 	for _, imageID := range imageIds {
-		params := &ec2.DeregisterImageInput{
-			ImageId: imageID,
+		if nukable, err := ami.IsNukable(awsgo.StringValue(imageID)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(imageID), err)
+			continue
 		}
 
-		_, err := ami.Client.DeregisterImage(params)
+		_, err := ami.Client.DeregisterImage(&ec2.DeregisterImageInput{
+			ImageId: imageID,
+		})
 
 		// Record status of this resource
 		e := report.Entry{

--- a/aws/resources/base_resource.go
+++ b/aws/resources/base_resource.go
@@ -74,6 +74,11 @@ func (br *BaseAwsResource) PrepareContext(parentContext context.Context, resourc
 // executed, and the result (error or success) is recorded using the SetNukableStatus method, indicating whether
 // the specified action is nukable
 func (br *BaseAwsResource) VerifyNukablePermissions(ids []*string, nukableCheckfn func(id *string) error) {
+	// check if the 'Nukables' map is initialized, and if it's not, initialize it
+	if br.Nukables == nil {
+		br.Nukables = make(map[string]error)
+	}
+
 	for _, id := range ids {
 		// skip if the id is already exists
 		if _, ok := br.GetNukableStatus(*id); ok {

--- a/aws/resources/ec2_dhcp_option.go
+++ b/aws/resources/ec2_dhcp_option.go
@@ -30,11 +30,24 @@ func (v *EC2DhcpOption) getAll(_ context.Context, configObj config.Config) ([]*s
 		return nil, errors.WithStackTrace(err)
 	}
 
+	// checking the nukable permissions
+	v.VerifyNukablePermissions(dhcpOptionIds, func(id *string) error {
+		_, err := v.Client.DeleteDhcpOptions(&ec2.DeleteDhcpOptionsInput{
+			DhcpOptionsId: id,
+			DryRun:        awsgo.Bool(true),
+		})
+		return err
+	})
+
 	return dhcpOptionIds, nil
 }
 
 func (v *EC2DhcpOption) nukeAll(identifiers []*string) error {
 	for _, identifier := range identifiers {
+		if nukable, err := v.IsNukable(awsgo.StringValue(identifier)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(identifier), err)
+			continue
+		}
 
 		err := nukeDhcpOption(v.Client, identifier)
 		if err != nil {

--- a/aws/resources/ec2_egress_only_igw.go
+++ b/aws/resources/ec2_egress_only_igw.go
@@ -15,6 +15,39 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+func (egigw *EgressOnlyInternetGateway) setFirstSeenTag(eoig ec2.EgressOnlyInternetGateway, value time.Time) error {
+	_, err := egigw.Client.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{eoig.EgressOnlyInternetGatewayId},
+		Tags: []*ec2.Tag{
+			{
+				Key:   awsgo.String(util.FirstSeenTagKey),
+				Value: awsgo.String(util.FormatTimestamp(value)),
+			},
+		},
+	})
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+func (egigw *EgressOnlyInternetGateway) getFirstSeenTag(eoig ec2.EgressOnlyInternetGateway) (*time.Time, error) {
+	tags := eoig.Tags
+	for _, tag := range tags {
+		if util.IsFirstSeenTag(tag.Key) {
+			firstSeenTime, err := util.ParseTimestamp(tag.Value)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			return firstSeenTime, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func shouldIncludeEgressOnlyInternetGateway(gateway *ec2.EgressOnlyInternetGateway, firstSeenTime *time.Time, configObj config.Config) bool {
 	var gatewayName string
 	// get the tags as map
@@ -29,10 +62,8 @@ func shouldIncludeEgressOnlyInternetGateway(gateway *ec2.EgressOnlyInternetGatew
 	})
 }
 
-func (egigw *EgressOnlyInternetGateway) getAll(c context.Context, configObj config.Config) ([]*string, error) {
+func (egigw *EgressOnlyInternetGateway) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
 	var result []*string
-	var firstSeenTime *time.Time
-	var err error
 
 	output, err := egigw.Client.DescribeEgressOnlyInternetGateways(&ec2.DescribeEgressOnlyInternetGatewaysInput{})
 	if err != nil {
@@ -40,23 +71,39 @@ func (egigw *EgressOnlyInternetGateway) getAll(c context.Context, configObj conf
 	}
 
 	for _, igw := range output.EgressOnlyInternetGateways {
-		firstSeenTime, err = util.GetOrCreateFirstSeen(c, egigw.Client, igw.EgressOnlyInternetGatewayId, util.ConvertEC2TagsToMap(igw.Tags))
+		// check first seen tag
+		firstSeenTime, err := egigw.getFirstSeenTag(*igw)
 		if err != nil {
-			logging.Error("Unable to retrieve tags")
-			return nil, errors.WithStackTrace(err)
+			logging.Errorf(
+				"Unable to retrieve tags for Egress IGW: %s, with error: %s", *igw.EgressOnlyInternetGatewayId, err)
+			continue
 		}
+
+		// if the first seen tag is not there, then create one
+		if firstSeenTime == nil {
+			now := time.Now().UTC()
+			firstSeenTime = &now
+			if err := egigw.setFirstSeenTag(*igw, time.Now().UTC()); err != nil {
+				logging.Errorf(
+					"Unable to apply first seen tag Egress IGW: %s, with error: %s", *igw.EgressOnlyInternetGatewayId, err)
+				continue
+			}
+		}
+
 		if shouldIncludeEgressOnlyInternetGateway(igw, firstSeenTime, configObj) {
 			result = append(result, igw.EgressOnlyInternetGatewayId)
 		}
 	}
+
 	// checking the nukable permissions
 	egigw.VerifyNukablePermissions(result, func(id *string) error {
 		_, err := egigw.Client.DeleteEgressOnlyInternetGateway(&ec2.DeleteEgressOnlyInternetGatewayInput{
 			EgressOnlyInternetGatewayId: id,
 			DryRun:                      awsgo.Bool(true),
 		})
-		return errors.WithStackTrace(err)
+		return err
 	})
+
 	return result, nil
 }
 

--- a/aws/resources/ec2_egress_only_igw_test.go
+++ b/aws/resources/ec2_egress_only_igw_test.go
@@ -33,9 +33,6 @@ func TestEgressOnlyInternetGateway_GetAll(t *testing.T) {
 
 	t.Parallel()
 
-	// Set excludeFirstSeenTag to false for testing
-	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
-
 	var (
 		now      = time.Now()
 		gateway1 = "igw-0b44cfa6103932e1d001"
@@ -79,17 +76,14 @@ func TestEgressOnlyInternetGateway_GetAll(t *testing.T) {
 	object.BaseAwsResource.Init(nil)
 
 	tests := map[string]struct {
-		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{gateway1, gateway2},
 		},
 		"nameExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -99,7 +93,6 @@ func TestEgressOnlyInternetGateway_GetAll(t *testing.T) {
 			expected: []string{gateway2},
 		},
 		"timeAfterExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: awsgo.Time(now),
@@ -107,7 +100,6 @@ func TestEgressOnlyInternetGateway_GetAll(t *testing.T) {
 			expected: []string{gateway1},
 		},
 		"timeBeforeExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeBefore: awsgo.Time(now.Add(1)),
@@ -117,7 +109,7 @@ func TestEgressOnlyInternetGateway_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := object.getAll(tc.ctx, config.Config{
+			names, err := object.getAll(context.Background(), config.Config{
 				EgressOnlyInternetGateway: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_endpoints_test.go
+++ b/aws/resources/ec2_endpoints_test.go
@@ -33,9 +33,6 @@ func TestVcpEndpoint_GetAll(t *testing.T) {
 
 	t.Parallel()
 
-	// Set excludeFirstSeenTag to false for testing
-	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
-
 	var (
 		now       = time.Now()
 		endpoint1 = "vpce-0b201b2dcd4f77a2f001"
@@ -79,17 +76,14 @@ func TestVcpEndpoint_GetAll(t *testing.T) {
 	vpcEndpoint.BaseAwsResource.Init(nil)
 
 	tests := map[string]struct {
-		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{endpoint1, endpoint2},
 		},
 		"nameExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -99,7 +93,6 @@ func TestVcpEndpoint_GetAll(t *testing.T) {
 			expected: []string{endpoint2},
 		},
 		"timeAfterExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now),
@@ -107,7 +100,6 @@ func TestVcpEndpoint_GetAll(t *testing.T) {
 			expected: []string{endpoint1},
 		},
 		"timeBeforeExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeBefore: aws.Time(now.Add(1)),
@@ -117,7 +109,7 @@ func TestVcpEndpoint_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := vpcEndpoint.getAll(tc.ctx, config.Config{
+			names, err := vpcEndpoint.getAll(context.Background(), config.Config{
 				EC2Endpoint: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_internet_gateway_test.go
+++ b/aws/resources/ec2_internet_gateway_test.go
@@ -38,9 +38,6 @@ func TestEc2InternetGateway_GetAll(t *testing.T) {
 
 	t.Parallel()
 
-	// Set excludeFirstSeenTag to false for testing
-	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
-
 	var (
 		now      = time.Now()
 		gateway1 = "igw-0b44cfa6103932e1d001"
@@ -85,17 +82,14 @@ func TestEc2InternetGateway_GetAll(t *testing.T) {
 	igw.BaseAwsResource.Init(nil)
 
 	tests := map[string]struct {
-		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{gateway1, gateway2},
 		},
 		"nameExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -105,7 +99,6 @@ func TestEc2InternetGateway_GetAll(t *testing.T) {
 			expected: []string{gateway2},
 		},
 		"timeAfterExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: awsgo.Time(now.Add(-1 * time.Hour)),
@@ -115,7 +108,7 @@ func TestEc2InternetGateway_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := igw.getAll(tc.ctx, config.Config{
+			names, err := igw.getAll(context.Background(), config.Config{
 				InternetGateway: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_ipam.go
+++ b/aws/resources/ec2_ipam.go
@@ -15,6 +15,39 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+func (ec2Ipam *EC2IPAMs) setFirstSeenTag(ipam ec2.Ipam, value time.Time) error {
+	_, err := ec2Ipam.Client.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{ipam.IpamId},
+		Tags: []*ec2.Tag{
+			{
+				Key:   awsgo.String(util.FirstSeenTagKey),
+				Value: awsgo.String(util.FormatTimestamp(value)),
+			},
+		},
+	})
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+func (ec2Ipam *EC2IPAMs) getFirstSeenTag(ipam ec2.Ipam) (*time.Time, error) {
+	tags := ipam.Tags
+	for _, tag := range tags {
+		if util.IsFirstSeenTag(tag.Key) {
+			firstSeenTime, err := util.ParseTimestamp(tag.Value)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			return firstSeenTime, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func shouldIncludeIpamID(ipam *ec2.Ipam, firstSeenTime *time.Time, configObj config.Config) bool {
 	var ipamName string
 	// get the tags as map
@@ -33,16 +66,27 @@ func shouldIncludeIpamID(ipam *ec2.Ipam, firstSeenTime *time.Time, configObj con
 // Returns a formatted string of IPAM URLs
 func (ec2Ipam *EC2IPAMs) getAll(c context.Context, configObj config.Config) ([]*string, error) {
 	result := []*string{}
-	var firstSeenTime *time.Time
-	var err error
-
 	paginator := func(output *ec2.DescribeIpamsOutput, lastPage bool) bool {
 		for _, ipam := range output.Ipams {
-			firstSeenTime, err = util.GetOrCreateFirstSeen(c, ec2Ipam.Client, ipam.IpamId, util.ConvertEC2TagsToMap(ipam.Tags))
+			// check first seen tag
+			firstSeenTime, err := ec2Ipam.getFirstSeenTag(*ipam)
 			if err != nil {
-				logging.Error("Unable to retrieve tags")
+				logging.Errorf(
+					"Unable to retrieve tags for IPAM: %s, with error: %s", *ipam.IpamId, err)
 				continue
 			}
+
+			// if the first seen tag is not there, then create one
+			if firstSeenTime == nil {
+				now := time.Now().UTC()
+				firstSeenTime = &now
+				if err := ec2Ipam.setFirstSeenTag(*ipam, time.Now().UTC()); err != nil {
+					logging.Errorf(
+						"Unable to apply first seen tag IPAM: %s, with error: %s", *ipam.IpamId, err)
+					continue
+				}
+			}
+
 			// Check for include this ipam
 			if shouldIncludeIpamID(ipam, firstSeenTime, configObj) {
 				result = append(result, ipam.IpamId)
@@ -55,10 +99,20 @@ func (ec2Ipam *EC2IPAMs) getAll(c context.Context, configObj config.Config) ([]*
 		MaxResults: awsgo.Int64(10),
 	}
 
-	err = ec2Ipam.Client.DescribeIpamsPages(params, paginator)
+	err := ec2Ipam.Client.DescribeIpamsPages(params, paginator)
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
 	}
+
+	// checking the nukable permissions
+	ec2Ipam.VerifyNukablePermissions(result, func(id *string) error {
+		_, err := ec2Ipam.Client.DeleteIpam(&ec2.DeleteIpamInput{
+			IpamId:  id,
+			Cascade: aws.Bool(true),
+			DryRun:  awsgo.Bool(true),
+		})
+		return err
+	})
 
 	return result, nil
 }
@@ -220,7 +274,7 @@ func (ec2Ipam *EC2IPAMs) nukeIPAM(id *string) error {
 	// items we need delete/detach them before actually deleting it.
 	// NOTE: The actual IPAM deletion should always be the last one. This way we
 	// can guarantee that it will fail if we forgot to delete/detach an item.
-	functions := []func(userName *string) error{
+	functions := []func(*string) error{
 		ec2Ipam.nukePublicIPAMPools,
 		ec2Ipam.deleteIPAM,
 	}
@@ -245,6 +299,11 @@ func (ec2Ipam *EC2IPAMs) nukeAll(ids []*string) error {
 	var deletedAddresses []*string
 
 	for _, id := range ids {
+
+		if nukable, err := ec2Ipam.IsNukable(awsgo.StringValue(id)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), err)
+			continue
+		}
 
 		err := ec2Ipam.nukeIPAM(id)
 

--- a/aws/resources/ec2_ipam_byoasn.go
+++ b/aws/resources/ec2_ipam_byoasn.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
@@ -26,6 +27,15 @@ func (byoasn *EC2IPAMByoasn) getAll(c context.Context, configObj config.Config) 
 	for _, out := range output.Byoasns {
 		result = append(result, out.Asn)
 	}
+
+	// checking the nukable permissions
+	byoasn.VerifyNukablePermissions(result, func(id *string) error {
+		_, err := byoasn.Client.DisassociateIpamByoasn(&ec2.DisassociateIpamByoasnInput{
+			Asn:    id,
+			DryRun: awsgo.Bool(true),
+		})
+		return err
+	})
 	return result, nil
 }
 
@@ -40,11 +50,14 @@ func (byoasn *EC2IPAMByoasn) nukeAll(asns []*string) error {
 	var list []*string
 
 	for _, id := range asns {
-		params := &ec2.DisassociateIpamByoasnInput{
-			Asn: id,
+		if nukable, err := byoasn.IsNukable(awsgo.StringValue(id)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), err)
+			continue
 		}
 
-		_, err := byoasn.Client.DisassociateIpamByoasn(params)
+		_, err := byoasn.Client.DisassociateIpamByoasn(&ec2.DisassociateIpamByoasnInput{
+			Asn: id,
+		})
 
 		// Record status of this resource
 		e := report.Entry{

--- a/aws/resources/ec2_ipam_custom_allocation.go
+++ b/aws/resources/ec2_ipam_custom_allocation.go
@@ -92,6 +92,29 @@ func (cs *EC2IPAMCustomAllocation) getAll(c context.Context, configObj config.Co
 		}
 	}
 
+	// checking the nukable permissions
+	cs.VerifyNukablePermissions(result, func(id *string) error {
+		cidr, err := cs.getPoolAllocationCIDR(id)
+		if err != nil {
+			logging.Errorf("[Failed] %s", err)
+			return err
+		}
+
+		allocationIPAMPoolID, ok := cs.PoolAndAllocationMap[*id]
+		if !ok {
+			logging.Errorf("[Failed] %s", fmt.Errorf("unable to find the pool allocation with %s", *id))
+			return fmt.Errorf("unable to find the pool allocation with %s", *id)
+		}
+
+		_, err = cs.Client.ReleaseIpamPoolAllocation(&ec2.ReleaseIpamPoolAllocationInput{
+			IpamPoolId:           &allocationIPAMPoolID,
+			IpamPoolAllocationId: id,
+			Cidr:                 cidr,
+			DryRun:               awsgo.Bool(true),
+		})
+		return err
+	})
+
 	return result, nil
 }
 
@@ -106,6 +129,11 @@ func (cs *EC2IPAMCustomAllocation) nukeAll(ids []*string) error {
 	var deletedAddresses []*string
 
 	for _, id := range ids {
+
+		if nukable, err := cs.IsNukable(awsgo.StringValue(id)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), err)
+			continue
+		}
 
 		// get the IPamPool details
 		cidr, err := cs.getPoolAllocationCIDR(id)

--- a/aws/resources/ec2_ipam_pool_test.go
+++ b/aws/resources/ec2_ipam_pool_test.go
@@ -32,9 +32,6 @@ func (m mockedIPAMPools) DeleteIpamPool(params *ec2.DeleteIpamPoolInput) (*ec2.D
 func TestIPAMPool_GetAll(t *testing.T) {
 	t.Parallel()
 
-	// Set excludeFirstSeenTag to false for testing
-	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
-
 	var (
 		now       = time.Now()
 		testId1   = "ipam-pool-0dfc56f901b2c3462"
@@ -79,17 +76,14 @@ func TestIPAMPool_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -99,7 +93,6 @@ func TestIPAMPool_GetAll(t *testing.T) {
 			expected: []string{testId2},
 		},
 		"timeAfterExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
@@ -109,7 +102,7 @@ func TestIPAMPool_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ids, err := ipam.getAll(tc.ctx, config.Config{
+			ids, err := ipam.getAll(context.Background(), config.Config{
 				EC2IPAMPool: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_ipam_resource_discovery.go
+++ b/aws/resources/ec2_ipam_resource_discovery.go
@@ -13,6 +13,39 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+func (discovery *EC2IPAMResourceDiscovery) setFirstSeenTag(ipam ec2.IpamResourceDiscovery, value time.Time) error {
+	_, err := discovery.Client.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{ipam.IpamResourceDiscoveryId},
+		Tags: []*ec2.Tag{
+			{
+				Key:   awsgo.String(util.FirstSeenTagKey),
+				Value: awsgo.String(util.FormatTimestamp(value)),
+			},
+		},
+	})
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+func (discovery *EC2IPAMResourceDiscovery) getFirstSeenTag(ipam ec2.IpamResourceDiscovery) (*time.Time, error) {
+	tags := ipam.Tags
+	for _, tag := range tags {
+		if util.IsFirstSeenTag(tag.Key) {
+			firstSeenTime, err := util.ParseTimestamp(tag.Value)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			return firstSeenTime, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func shouldIncludeIpamResourceID(ipam *ec2.IpamResourceDiscovery, firstSeenTime *time.Time, configObj config.Config) bool {
 	var ipamResourceName string
 	// get the tags as map
@@ -31,16 +64,27 @@ func shouldIncludeIpamResourceID(ipam *ec2.IpamResourceDiscovery, firstSeenTime 
 // Returns a formatted string of IPAM Resource discovery
 func (discovery *EC2IPAMResourceDiscovery) getAll(c context.Context, configObj config.Config) ([]*string, error) {
 	result := []*string{}
-	var firstSeenTime *time.Time
-	var err error
-
 	paginator := func(output *ec2.DescribeIpamResourceDiscoveriesOutput, lastPage bool) bool {
 		for _, d := range output.IpamResourceDiscoveries {
-			firstSeenTime, err = util.GetOrCreateFirstSeen(c, discovery.Client, d.IpamResourceDiscoveryId, util.ConvertEC2TagsToMap(d.Tags))
+			// check first seen tag
+			firstSeenTime, err := discovery.getFirstSeenTag(*d)
 			if err != nil {
-				logging.Error("unable to retrieve firstseen tag")
+				logging.Errorf(
+					"Unable to retrieve tags for IPAM: %s, with error: %s", *d.IpamResourceDiscoveryId, err)
 				continue
 			}
+
+			// if the first seen tag is not there, then create one
+			if firstSeenTime == nil {
+				now := time.Now().UTC()
+				firstSeenTime = &now
+				if err := discovery.setFirstSeenTag(*d, time.Now().UTC()); err != nil {
+					logging.Errorf(
+						"Unable to apply first seen tag IPAM: %s, with error: %s", *d.IpamResourceDiscoveryId, err)
+					continue
+				}
+			}
+			// Check for include this ipam resource ID
 			if shouldIncludeIpamResourceID(d, firstSeenTime, configObj) {
 				result = append(result, d.IpamResourceDiscoveryId)
 			}
@@ -58,10 +102,19 @@ func (discovery *EC2IPAMResourceDiscovery) getAll(c context.Context, configObj c
 		},
 	}
 
-	err = discovery.Client.DescribeIpamResourceDiscoveriesPages(params, paginator)
+	err := discovery.Client.DescribeIpamResourceDiscoveriesPages(params, paginator)
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
 	}
+
+	// checking the nukable permissions
+	discovery.VerifyNukablePermissions(result, func(id *string) error {
+		_, err := discovery.Client.DeleteIpamResourceDiscovery(&ec2.DeleteIpamResourceDiscoveryInput{
+			IpamResourceDiscoveryId: id,
+			DryRun:                  awsgo.Bool(true),
+		})
+		return err
+	})
 
 	return result, nil
 }
@@ -77,11 +130,15 @@ func (discovery *EC2IPAMResourceDiscovery) nukeAll(ids []*string) error {
 	var deletedAddresses []*string
 
 	for _, id := range ids {
-		params := &ec2.DeleteIpamResourceDiscoveryInput{
-			IpamResourceDiscoveryId: id,
+
+		if nukable, err := discovery.IsNukable(awsgo.StringValue(id)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), err)
+			continue
 		}
 
-		_, err := discovery.Client.DeleteIpamResourceDiscovery(params)
+		_, err := discovery.Client.DeleteIpamResourceDiscovery(&ec2.DeleteIpamResourceDiscoveryInput{
+			IpamResourceDiscoveryId: id,
+		})
 		// Record status of this resource
 		e := report.Entry{
 			Identifier:   awsgo.StringValue(id),

--- a/aws/resources/ec2_ipam_resource_discovery_test.go
+++ b/aws/resources/ec2_ipam_resource_discovery_test.go
@@ -32,9 +32,6 @@ func (m mockedIPAMResourceDiscovery) DeleteIpamResourceDiscovery(params *ec2.Del
 func TestIPAMRDiscovery_GetAll(t *testing.T) {
 	t.Parallel()
 
-	// Set excludeFirstSeenTag to false for testing
-	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
-
 	var (
 		now       = time.Now()
 		testId1   = "ipam-res-disco-0dfc56f901b2c3462"
@@ -79,17 +76,14 @@ func TestIPAMRDiscovery_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -99,7 +93,6 @@ func TestIPAMRDiscovery_GetAll(t *testing.T) {
 			expected: []string{testId2},
 		},
 		"timeAfterExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
@@ -109,7 +102,7 @@ func TestIPAMRDiscovery_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ids, err := ipam.getAll(tc.ctx, config.Config{
+			ids, err := ipam.getAll(context.Background(), config.Config{
 				EC2IPAMResourceDiscovery: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_ipam_scope_test.go
+++ b/aws/resources/ec2_ipam_scope_test.go
@@ -32,9 +32,6 @@ func (m mockedIPAMScope) DeleteIpamScope(params *ec2.DeleteIpamScopeInput) (*ec2
 func TestIPAMScope_GetAll(t *testing.T) {
 	t.Parallel()
 
-	// Set excludeFirstSeenTag to false for testing
-	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
-
 	var (
 		now       = time.Now()
 		testId1   = "ipam-scope-0dfc56f901b2c3462"
@@ -79,17 +76,14 @@ func TestIPAMScope_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -99,7 +93,6 @@ func TestIPAMScope_GetAll(t *testing.T) {
 			expected: []string{testId2},
 		},
 		"timeAfterExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
@@ -110,7 +103,7 @@ func TestIPAMScope_GetAll(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ids, err := ipam.getAll(tc.ctx, config.Config{
+			ids, err := ipam.getAll(context.Background(), config.Config{
 				EC2IPAMScope: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_ipam_test.go
+++ b/aws/resources/ec2_ipam_test.go
@@ -61,9 +61,6 @@ func (m mockedIPAM) DeleteIpam(params *ec2.DeleteIpamInput) (*ec2.DeleteIpamOutp
 func TestIPAM_GetAll(t *testing.T) {
 	t.Parallel()
 
-	// Set excludeFirstSeenTag to false for testing
-	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
-
 	var (
 		now       = time.Now()
 		testId1   = "ipam-0dfc56f901b2c3462"
@@ -108,17 +105,14 @@ func TestIPAM_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -128,7 +122,6 @@ func TestIPAM_GetAll(t *testing.T) {
 			expected: []string{testId2},
 		},
 		"timeAfterExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
@@ -139,7 +132,7 @@ func TestIPAM_GetAll(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ids, err := ipam.getAll(tc.ctx, config.Config{
+			ids, err := ipam.getAll(context.Background(), config.Config{
 				EC2IPAM: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_key_pair.go
+++ b/aws/resources/ec2_key_pair.go
@@ -2,6 +2,8 @@ package resources
 
 import (
 	"context"
+
+	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
@@ -27,6 +29,15 @@ func (k *EC2KeyPairs) getAll(c context.Context, configObj config.Config) ([]*str
 			ids = append(ids, keyPair.KeyPairId)
 		}
 	}
+
+	// checking the nukable permissions
+	k.VerifyNukablePermissions(ids, func(id *string) error {
+		_, err := k.Client.DeleteKeyPair(&ec2.DeleteKeyPairInput{
+			KeyPairId: id,
+			DryRun:    awsgo.Bool(true),
+		})
+		return err
+	})
 
 	return ids, nil
 }
@@ -57,6 +68,11 @@ func (k *EC2KeyPairs) nukeAll(keypairIds []*string) error {
 	deletedKeyPairs := 0
 	var multiErr *multierror.Error
 	for _, keypair := range keypairIds {
+		if nukable, err := k.IsNukable(awsgo.StringValue(keypair)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(keypair), err)
+			continue
+		}
+
 		if err := k.deleteKeyPair(keypair); err != nil {
 			logging.Errorf("[Failed] %s", err)
 			multiErr = multierror.Append(multiErr, err)

--- a/aws/resources/ec2_network_acl_test.go
+++ b/aws/resources/ec2_network_acl_test.go
@@ -37,9 +37,6 @@ func (m mockedNetworkACL) ReplaceNetworkAclAssociation(*ec2.ReplaceNetworkAclAss
 
 func TestNetworkAcl_GetAll(t *testing.T) {
 
-	// Set excludeFirstSeenTag to false for testing
-	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
-
 	var (
 		now     = time.Now()
 		testId1 = "acl-09e36c45cbdbfb001"
@@ -86,17 +83,14 @@ func TestNetworkAcl_GetAll(t *testing.T) {
 	resourceObject.BaseAwsResource.Init(nil)
 
 	tests := map[string]struct {
-		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -106,7 +100,6 @@ func TestNetworkAcl_GetAll(t *testing.T) {
 			expected: []string{testId2},
 		},
 		"nameInclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				IncludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -116,7 +109,6 @@ func TestNetworkAcl_GetAll(t *testing.T) {
 			expected: []string{testId1},
 		},
 		"timeAfterExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now),
@@ -128,7 +120,7 @@ func TestNetworkAcl_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := resourceObject.getAll(tc.ctx, config.Config{
+			names, err := resourceObject.getAll(context.Background(), config.Config{
 				NetworkACL: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_network_interface.go
+++ b/aws/resources/ec2_network_interface.go
@@ -14,6 +14,39 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+func (ni *NetworkInterface) setFirstSeenTag(networkInterface ec2.NetworkInterface, value time.Time) error {
+	_, err := ni.Client.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{networkInterface.NetworkInterfaceId},
+		Tags: []*ec2.Tag{
+			{
+				Key:   awsgo.String(util.FirstSeenTagKey),
+				Value: awsgo.String(util.FormatTimestamp(value)),
+			},
+		},
+	})
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+func (igw *NetworkInterface) getFirstSeenTag(networkInterface ec2.NetworkInterface) (*time.Time, error) {
+	tags := networkInterface.TagSet
+	for _, tag := range tags {
+		if util.IsFirstSeenTag(tag.Key) {
+			firstSeenTime, err := util.ParseTimestamp(tag.Value)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			return firstSeenTime, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func shouldIncludeNetworkInterface(networkInterface *ec2.NetworkInterface, firstSeenTime *time.Time, configObj config.Config) bool {
 	var interfaceName string
 	// get the tags as map
@@ -28,11 +61,8 @@ func shouldIncludeNetworkInterface(networkInterface *ec2.NetworkInterface, first
 	})
 }
 
-func (ni *NetworkInterface) getAll(c context.Context, configObj config.Config) ([]*string, error) {
+func (ni *NetworkInterface) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
 	var identifiers []*string
-	var firstSeenTime *time.Time
-	var err error
-
 	resp, err := ni.Client.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{})
 	if err != nil {
 		logging.Debugf("[Internet Gateway] Failed to list internet gateways: %s", err)
@@ -40,10 +70,23 @@ func (ni *NetworkInterface) getAll(c context.Context, configObj config.Config) (
 	}
 
 	for _, networkInterface := range resp.NetworkInterfaces {
-		firstSeenTime, err = util.GetOrCreateFirstSeen(c, ni.Client, networkInterface.NetworkInterfaceId, util.ConvertEC2TagsToMap(networkInterface.TagSet))
+		// check first seen tag
+		firstSeenTime, err := ni.getFirstSeenTag(*networkInterface)
 		if err != nil {
-			logging.Error("unable to retrieve first seen tag")
+			logging.Errorf(
+				"Unable to retrieve tags for Internet gateway: %s, with error: %s", *networkInterface.NetworkInterfaceId, err)
 			continue
+		}
+
+		// if the first seen tag is not there, then create one
+		if firstSeenTime == nil {
+			now := time.Now().UTC()
+			firstSeenTime = &now
+			if err := ni.setFirstSeenTag(*networkInterface, time.Now().UTC()); err != nil {
+				logging.Errorf(
+					"Unable to apply first seen tag Internet gateway: %s, with error: %s", *networkInterface.NetworkInterfaceId, err)
+				continue
+			}
 		}
 
 		if shouldIncludeNetworkInterface(networkInterface, firstSeenTime, configObj) {

--- a/aws/resources/ec2_network_interface_test.go
+++ b/aws/resources/ec2_network_interface_test.go
@@ -50,9 +50,6 @@ func (m mockedNetworkInterface) WaitUntilInstanceTerminated(*ec2.DescribeInstanc
 
 func TestNetworkInterface_GetAll(t *testing.T) {
 
-	// Set excludeFirstSeenTag to false for testing
-	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
-
 	var (
 		now     = time.Now()
 		testId1 = "eni-09e36c45cbdbfb001"
@@ -99,17 +96,14 @@ func TestNetworkInterface_GetAll(t *testing.T) {
 	resourceObject.BaseAwsResource.Init(nil)
 
 	tests := map[string]struct {
-		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -119,7 +113,6 @@ func TestNetworkInterface_GetAll(t *testing.T) {
 			expected: []string{testId2},
 		},
 		"nameInclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				IncludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -129,7 +122,6 @@ func TestNetworkInterface_GetAll(t *testing.T) {
 			expected: []string{testId1},
 		},
 		"timeAfterExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: awsgo.Time(now),
@@ -141,7 +133,7 @@ func TestNetworkInterface_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := resourceObject.getAll(tc.ctx, config.Config{
+			names, err := resourceObject.getAll(context.Background(), config.Config{
 				NetworkInterface: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_subnet.go
+++ b/aws/resources/ec2_subnet.go
@@ -16,6 +16,39 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+func (ec2subnet *EC2Subnet) setFirstSeenTag(sb ec2.Subnet, value time.Time) error {
+	_, err := ec2subnet.Client.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{sb.SubnetId},
+		Tags: []*ec2.Tag{
+			{
+				Key:   awsgo.String(util.FirstSeenTagKey),
+				Value: awsgo.String(util.FormatTimestamp(value)),
+			},
+		},
+	})
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+func (ec2subnet *EC2Subnet) getFirstSeenTag(sb ec2.Subnet) (*time.Time, error) {
+	tags := sb.Tags
+	for _, tag := range tags {
+		if util.IsFirstSeenTag(tag.Key) {
+			firstSeenTime, err := util.ParseTimestamp(tag.Value)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			return firstSeenTime, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func shouldIncludeEc2Subnet(subnet *ec2.Subnet, firstSeenTime *time.Time, configObj config.Config) bool {
 	var subnetName string
 	tagMap := util.ConvertEC2TagsToMap(subnet.Tags)
@@ -31,17 +64,14 @@ func shouldIncludeEc2Subnet(subnet *ec2.Subnet, firstSeenTime *time.Time, config
 }
 
 // Returns a formatted string of EC2 subnets
-func (ec2subnet *EC2Subnet) getAll(c context.Context, configObj config.Config) ([]*string, error) {
+func (ec2subnet *EC2Subnet) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
 	result := []*string{}
-	var firstSeenTime *time.Time
-	var err error
-
 	// Note: This filter initially handles non-default resources and can be overridden by passing the only-default filter to choose default subnets.
 	if configObj.EC2Subnet.DefaultOnly {
 		logging.Debugf("[default only] Retrieving the default subnets")
 	}
 
-	err = ec2subnet.Client.DescribeSubnetsPages(&ec2.DescribeSubnetsInput{
+	err := ec2subnet.Client.DescribeSubnetsPages(&ec2.DescribeSubnetsInput{
 		Filters: []*ec2.Filter{
 			{
 				Name: awsgo.String("default-for-az"),
@@ -52,11 +82,26 @@ func (ec2subnet *EC2Subnet) getAll(c context.Context, configObj config.Config) (
 		},
 	}, func(pages *ec2.DescribeSubnetsOutput, lastPage bool) bool {
 		for _, subnet := range pages.Subnets {
-			firstSeenTime, err = util.GetOrCreateFirstSeen(c, ec2subnet.Client, subnet.SubnetId, util.ConvertEC2TagsToMap(subnet.Tags))
+
+			// check first seen tag
+			firstSeenTime, err := ec2subnet.getFirstSeenTag(*subnet)
 			if err != nil {
-				logging.Error("unable to retrieve first seen tag")
+				logging.Errorf(
+					"Unable to retrieve tags for Subnet: %s, with error: %s", *subnet.SubnetId, err)
 				continue
 			}
+
+			// if the first seen tag is not there, then create one
+			if firstSeenTime == nil {
+				now := time.Now().UTC()
+				firstSeenTime = &now
+				if err := ec2subnet.setFirstSeenTag(*subnet, time.Now().UTC()); err != nil {
+					logging.Errorf(
+						"Unable to apply first seen tag Subnet: %s, with error: %s", *subnet.SubnetId, err)
+					continue
+				}
+			}
+
 			if shouldIncludeEc2Subnet(subnet, firstSeenTime, configObj) {
 				result = append(result, subnet.SubnetId)
 			}

--- a/aws/resources/ec2_subnet_test.go
+++ b/aws/resources/ec2_subnet_test.go
@@ -32,9 +32,6 @@ func TestEc2Subnets_GetAll(t *testing.T) {
 
 	t.Parallel()
 
-	// Set excludeFirstSeenTag to false for testing
-	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
-
 	var (
 		now       = time.Now()
 		subnet1   = "subnet-0631b58700ba3db41"
@@ -78,12 +75,10 @@ func TestEc2Subnets_GetAll(t *testing.T) {
 	ec2subnet.BaseAwsResource.Init(nil)
 
 	tests := map[string]struct {
-		ctx       context.Context
 		configObj config.EC2ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			ctx:       ctx,
 			configObj: config.EC2ResourceType{},
 			expected:  []string{subnet1, subnet2},
 		},
@@ -100,7 +95,6 @@ func TestEc2Subnets_GetAll(t *testing.T) {
 			expected: []string{subnet2},
 		},
 		"timeAfterExclusionFilter": {
-			ctx: ctx,
 			configObj: config.EC2ResourceType{
 				ResourceType: config.ResourceType{
 					ExcludeRule: config.FilterRule{
@@ -112,7 +106,7 @@ func TestEc2Subnets_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := ec2subnet.getAll(tc.ctx, config.Config{
+			names, err := ec2subnet.getAll(context.Background(), config.Config{
 				EC2Subnet: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ec2_vpc.go
+++ b/aws/resources/ec2_vpc.go
@@ -26,9 +26,41 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-func (v *EC2VPCs) getAll(c context.Context, configObj config.Config) ([]*string, error) {
-	var firstSeenTime *time.Time
-	var err error
+func (v *EC2VPCs) setFirstSeenTag(vpc ec2.Vpc, value time.Time) error {
+	// We set a first seen tag because an Elastic IP doesn't contain an attribute that gives us it's creation time
+	_, err := v.Client.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{vpc.VpcId},
+		Tags: []*ec2.Tag{
+			{
+				Key:   awsgo.String(util.FirstSeenTagKey),
+				Value: awsgo.String(util.FormatTimestamp(value)),
+			},
+		},
+	})
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+func (v *EC2VPCs) getFirstSeenTag(vpc ec2.Vpc) (*time.Time, error) {
+	tags := vpc.Tags
+	for _, tag := range tags {
+		if util.IsFirstSeenTag(tag.Key) {
+			firstSeenTime, err := util.ParseTimestamp(tag.Value)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			return firstSeenTime, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (v *EC2VPCs) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
 	// Note: This filter initially handles non-default resources and can be overridden by passing the only-default filter to choose default VPCs.
 	result, err := v.Client.DescribeVpcs(&ec2.DescribeVpcsInput{
 		Filters: []*ec2.Filter{
@@ -46,10 +78,18 @@ func (v *EC2VPCs) getAll(c context.Context, configObj config.Config) ([]*string,
 
 	var ids []*string
 	for _, vpc := range result.Vpcs {
-		firstSeenTime, err = util.GetOrCreateFirstSeen(c, v.Client, vpc.VpcId, util.ConvertEC2TagsToMap(vpc.Tags))
+		firstSeenTime, err := v.getFirstSeenTag(*vpc)
 		if err != nil {
 			logging.Error("Unable to retrieve tags")
 			return nil, errors.WithStackTrace(err)
+		}
+
+		if firstSeenTime == nil {
+			now := time.Now().UTC()
+			firstSeenTime = &now
+			if err := v.setFirstSeenTag(*vpc, time.Now().UTC()); err != nil {
+				return nil, err
+			}
 		}
 
 		if configObj.VPC.ShouldInclude(config.ResourceValue{
@@ -59,6 +99,15 @@ func (v *EC2VPCs) getAll(c context.Context, configObj config.Config) ([]*string,
 			ids = append(ids, vpc.VpcId)
 		}
 	}
+
+	// checking the nukable permissions
+	v.VerifyNukablePermissions(ids, func(id *string) error {
+		_, err := v.Client.DeleteVpc(&ec2.DeleteVpcInput{
+			VpcId:  id,
+			DryRun: awsgo.Bool(true),
+		})
+		return err
+	})
 
 	return ids, nil
 }
@@ -75,6 +124,11 @@ func (v *EC2VPCs) nukeAll(vpcIds []string) error {
 	multiErr := new(multierror.Error)
 
 	for _, id := range vpcIds {
+		if nukable, err := v.IsNukable(id); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", id, err)
+			continue
+		}
+
 		var err error
 		err = nuke(v.Client, v.ELBClient, id)
 

--- a/aws/resources/ec2_vpc_test.go
+++ b/aws/resources/ec2_vpc_test.go
@@ -60,9 +60,6 @@ func TestEC2VPC_GetAll(t *testing.T) {
 
 	t.Parallel()
 
-	// Set excludeFirstSeenTag to false for testing
-	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
-
 	testName1 := "test-vpc-name1"
 	testName2 := "test-vpc-name2"
 	now := time.Now()
@@ -104,17 +101,14 @@ func TestEC2VPC_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		ctx       context.Context
 		configObj config.EC2ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			ctx:       ctx,
 			configObj: config.EC2ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
-			ctx: ctx,
 			configObj: config.EC2ResourceType{
 				ResourceType: config.ResourceType{
 					ExcludeRule: config.FilterRule{
@@ -127,7 +121,6 @@ func TestEC2VPC_GetAll(t *testing.T) {
 			expected: []string{testId2},
 		},
 		"timeAfterExclusionFilter": {
-			ctx: ctx,
 			configObj: config.EC2ResourceType{
 				ResourceType: config.ResourceType{
 					ExcludeRule: config.FilterRule{
@@ -139,7 +132,7 @@ func TestEC2VPC_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := vpc.getAll(tc.ctx, config.Config{
+			names, err := vpc.getAll(context.Background(), config.Config{
 				VPC: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/ecs_cluster_test.go
+++ b/aws/resources/ecs_cluster_test.go
@@ -56,9 +56,6 @@ func TestEC2Cluster_GetAll(t *testing.T) {
 
 	t.Parallel()
 
-	// Set excludeFirstSeenTag to false for testing
-	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
-
 	testArn1 := "arn:aws:ecs:us-east-1:123456789012:cluster/cluster1"
 	testArn2 := "arn:aws:ecs:us-east-1:123456789012:cluster/cluster2"
 	testName1 := "cluster1"
@@ -106,17 +103,14 @@ func TestEC2Cluster_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{testArn1, testArn2},
 		},
 		"nameExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -126,7 +120,6 @@ func TestEC2Cluster_GetAll(t *testing.T) {
 			expected: []string{testArn2},
 		},
 		"timeAfterExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
@@ -136,7 +129,7 @@ func TestEC2Cluster_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := ec.getAll(tc.ctx, config.Config{
+			names, err := ec.getAll(context.Background(), config.Config{
 				ECSCluster: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/eip.go
+++ b/aws/resources/eip.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
@@ -14,10 +15,42 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+func (ea *EIPAddresses) setFirstSeenTag(address ec2.Address, value time.Time) error {
+	// We set a first seen tag because an Elastic IP doesn't contain an attribute that gives us it's creation time
+	_, err := ea.Client.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{address.AllocationId},
+		Tags: []*ec2.Tag{
+			{
+				Key:   awsgo.String(util.FirstSeenTagKey),
+				Value: awsgo.String(util.FormatTimestamp(value)),
+			},
+		},
+	})
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+func (ea *EIPAddresses) getFirstSeenTag(address ec2.Address) (*time.Time, error) {
+	tags := address.Tags
+	for _, tag := range tags {
+		if util.IsFirstSeenTag(tag.Key) {
+			firstSeenTime, err := util.ParseTimestamp(tag.Value)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			return firstSeenTime, nil
+		}
+	}
+
+	return nil, nil
+}
+
 // Returns a formatted string of EIP allocation ids
 func (ea *EIPAddresses) getAll(c context.Context, configObj config.Config) ([]*string, error) {
-	var firstSeenTime *time.Time
-	var err error
 	result, err := ea.Client.DescribeAddresses(&ec2.DescribeAddressesInput{})
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
@@ -25,16 +58,31 @@ func (ea *EIPAddresses) getAll(c context.Context, configObj config.Config) ([]*s
 
 	var allocationIds []*string
 	for _, address := range result.Addresses {
-		firstSeenTime, err = util.GetOrCreateFirstSeen(c, ea.Client, address.AllocationId, util.ConvertEC2TagsToMap(address.Tags))
+		firstSeenTime, err := ea.getFirstSeenTag(*address)
 		if err != nil {
-			logging.Error("unable to retrieve first seen tag")
 			return nil, errors.WithStackTrace(err)
 		}
 
+		if firstSeenTime == nil {
+			now := time.Now().UTC()
+			firstSeenTime = &now
+			if err := ea.setFirstSeenTag(*address, *firstSeenTime); err != nil {
+				return nil, err
+			}
+		}
 		if ea.shouldInclude(address, *firstSeenTime, configObj) {
 			allocationIds = append(allocationIds, address.AllocationId)
 		}
 	}
+
+	// checking the nukable permissions
+	ea.VerifyNukablePermissions(allocationIds, func(id *string) error {
+		_, err := ea.Client.ReleaseAddress(&ec2.ReleaseAddressInput{
+			AllocationId: id,
+			DryRun:       awsgo.Bool(true),
+		})
+		return err
+	})
 
 	return allocationIds, nil
 }
@@ -61,11 +109,15 @@ func (ea *EIPAddresses) nukeAll(allocationIds []*string) error {
 	var deletedAllocationIDs []*string
 
 	for _, allocationID := range allocationIds {
-		params := &ec2.ReleaseAddressInput{
-			AllocationId: allocationID,
+
+		if nukable, err := ea.IsNukable(awsgo.StringValue(allocationID)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(allocationID), err)
+			continue
 		}
 
-		_, err := ea.Client.ReleaseAddress(params)
+		_, err := ea.Client.ReleaseAddress(&ec2.ReleaseAddressInput{
+			AllocationId: allocationID,
+		})
 
 		// Record status of this resource
 		e := report.Entry{

--- a/aws/resources/eip_test.go
+++ b/aws/resources/eip_test.go
@@ -32,9 +32,6 @@ func TestEIPAddress_GetAll(t *testing.T) {
 
 	t.Parallel()
 
-	// Set excludeFirstSeenTag to false for testing
-	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
-
 	now := time.Now()
 	testName1 := "test-eip1"
 	testAllocId1 := "alloc1"
@@ -76,17 +73,14 @@ func TestEIPAddress_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{testAllocId1, testAllocId2},
 		},
 		"nameExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -96,7 +90,6 @@ func TestEIPAddress_GetAll(t *testing.T) {
 			expected: []string{testAllocId2},
 		},
 		"timeAfterExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
@@ -106,7 +99,7 @@ func TestEIPAddress_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := ea.getAll(tc.ctx, config.Config{
+			names, err := ea.getAll(context.Background(), config.Config{
 				ElasticIP: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/launch_template.go
+++ b/aws/resources/launch_template.go
@@ -2,7 +2,9 @@ package resources
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
@@ -27,6 +29,15 @@ func (lt *LaunchTemplates) getAll(c context.Context, configObj config.Config) ([
 		}
 	}
 
+	// checking the nukable permissions
+	lt.VerifyNukablePermissions(templateNames, func(id *string) error {
+		_, err := lt.Client.DeleteLaunchTemplate(&ec2.DeleteLaunchTemplateInput{
+			LaunchTemplateName: id,
+			DryRun:             awsgo.Bool(true),
+		})
+		return err
+	})
+
 	return templateNames, nil
 }
 
@@ -41,11 +52,15 @@ func (lt *LaunchTemplates) nukeAll(templateNames []*string) error {
 	var deletedTemplateNames []*string
 
 	for _, templateName := range templateNames {
-		params := &ec2.DeleteLaunchTemplateInput{
-			LaunchTemplateName: templateName,
+
+		if nukable, err := lt.IsNukable(awsgo.StringValue(templateName)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(templateName), err)
+			continue
 		}
 
-		_, err := lt.Client.DeleteLaunchTemplate(params)
+		_, err := lt.Client.DeleteLaunchTemplate(&ec2.DeleteLaunchTemplateInput{
+			LaunchTemplateName: templateName,
+		})
 
 		// Record status of this resource
 		e := report.Entry{

--- a/aws/resources/nat_gateway.go
+++ b/aws/resources/nat_gateway.go
@@ -33,6 +33,16 @@ func (ngw *NatGateways) getAll(_ context.Context, configObj config.Config) ([]*s
 			return !lastPage
 		},
 	)
+
+	// checking the nukable permissions
+	ngw.VerifyNukablePermissions(allNatGateways, func(id *string) error {
+		_, err := ngw.Client.DeleteNatGateway(&ec2.DeleteNatGatewayInput{
+			NatGatewayId: id,
+			DryRun:       awsgo.Bool(true),
+		})
+		return err
+	})
+
 	return allNatGateways, errors.WithStackTrace(err)
 }
 
@@ -161,6 +171,12 @@ func (ngw *NatGateways) areAllNatGatewaysDeleted(identifiers []*string) (bool, e
 // concurrency control and a return channel for errors.
 func (ngw *NatGateways) deleteAsync(wg *sync.WaitGroup, errChan chan error, ngwID *string) {
 	defer wg.Done()
+
+	if nukable, err := ngw.IsNukable(awsgo.StringValue(ngwID)); !nukable {
+		logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(ngwID), err)
+		errChan <- nil
+		return
+	}
 
 	err := nukeNATGateway(ngw.Client, ngwID)
 	// Record status of this resource

--- a/aws/resources/network_firewall_policy.go
+++ b/aws/resources/network_firewall_policy.go
@@ -13,6 +13,34 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+func (nfw *NetworkFirewallPolicy) setFirstSeenTag(resource *networkfirewall.FirewallPolicyResponse, value time.Time) error {
+	_, err := nfw.Client.TagResource(&networkfirewall.TagResourceInput{
+		ResourceArn: resource.FirewallPolicyArn,
+		Tags: []*networkfirewall.Tag{
+			{
+				Key:   awsgo.String(util.FirstSeenTagKey),
+				Value: awsgo.String(util.FormatTimestamp(value)),
+			},
+		},
+	})
+	return errors.WithStackTrace(err)
+}
+
+func (nfw *NetworkFirewallPolicy) getFirstSeenTag(resource *networkfirewall.FirewallPolicyResponse) (*time.Time, error) {
+	for _, tag := range resource.Tags {
+		if util.IsFirstSeenTag(tag.Key) {
+			firstSeenTime, err := util.ParseTimestamp(tag.Value)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			return firstSeenTime, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func shouldIncludeNetworkFirewallPolicy(firewall *networkfirewall.FirewallPolicyResponse, firstSeenTime *time.Time, configObj config.Config) bool {
 	// if the firewall policy has any attachments, then we can't remove that policy
 	if awsgo.Int64Value(firewall.NumberOfAssociations) > 0 {
@@ -33,12 +61,8 @@ func shouldIncludeNetworkFirewallPolicy(firewall *networkfirewall.FirewallPolicy
 	})
 }
 
-func (nfw *NetworkFirewallPolicy) getAll(c context.Context, configObj config.Config) ([]*string, error) {
-	var (
-		identifiers   []*string
-		firstSeenTime *time.Time
-		err           error
-	)
+func (nfw *NetworkFirewallPolicy) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
+	var identifiers []*string
 
 	metaOutput, err := nfw.Client.ListFirewallPolicies(nil)
 	if err != nil {
@@ -60,10 +84,23 @@ func (nfw *NetworkFirewallPolicy) getAll(c context.Context, configObj config.Con
 			continue
 		}
 
-		firstSeenTime, err = util.GetOrCreateFirstSeen(c, nfw.Client, policy.Arn, util.ConvertNetworkFirewallTagsToMap(output.FirewallPolicyResponse.Tags))
+		// check first seen tag
+		firstSeenTime, err := nfw.getFirstSeenTag(output.FirewallPolicyResponse)
 		if err != nil {
-			logging.Error("Unable to retrieve tags")
-			return nil, errors.WithStackTrace(err)
+			logging.Errorf(
+				"Unable to retrieve tags for Rule group: %s, with error: %s", awsgo.StringValue(policy.Name), err)
+			continue
+		}
+
+		// if the first seen tag is not there, then create one
+		if firstSeenTime == nil {
+			now := time.Now().UTC()
+			firstSeenTime = &now
+			if err := nfw.setFirstSeenTag(output.FirewallPolicyResponse, time.Now().UTC()); err != nil {
+				logging.Errorf(
+					"Unable to apply first seen tag Rule group: %s, with error: %s", awsgo.StringValue(policy.Name), err)
+				continue
+			}
 		}
 
 		if shouldIncludeNetworkFirewallPolicy(output.FirewallPolicyResponse, firstSeenTime, configObj) {

--- a/aws/resources/network_firewall_policy_test.go
+++ b/aws/resources/network_firewall_policy_test.go
@@ -56,7 +56,6 @@ func TestNetworkFirewallPolicy_GetAll(t *testing.T) {
 		testId2   = "test-network-firewall-id2"
 		testName1 = "test-network-firewall-1"
 		testName2 = "test-network-firewall-2"
-		ctx       = context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
 	)
 
 	nfw := NetworkFirewallPolicy{
@@ -135,7 +134,7 @@ func TestNetworkFirewallPolicy_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := nfw.getAll(ctx, config.Config{
+			names, err := nfw.getAll(context.Background(), config.Config{
 				NetworkFirewallPolicy: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/network_firewall_rule_group_test.go
+++ b/aws/resources/network_firewall_rule_group_test.go
@@ -56,7 +56,6 @@ func TestNetworkFirewallRuleGroup_GetAll(t *testing.T) {
 		testId2   = "test-network-firewall-id2"
 		testName1 = "test-network-firewall-1"
 		testName2 = "test-network-firewall-2"
-		ctx       = context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
 	)
 
 	nfw := NetworkFirewallRuleGroup{
@@ -136,7 +135,7 @@ func TestNetworkFirewallRuleGroup_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := nfw.getAll(ctx, config.Config{
+			names, err := nfw.getAll(context.Background(), config.Config{
 				NetworkFirewallRuleGroup: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/network_firewall_test.go
+++ b/aws/resources/network_firewall_test.go
@@ -56,7 +56,6 @@ func TestNetworkFirewall_GetAll(t *testing.T) {
 		testId2   = "test-network-firewall-id2"
 		testName1 = "test-network-firewall-1"
 		testName2 = "test-network-firewall-2"
-		ctx       = context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
 	)
 
 	nfw := NetworkFirewall{
@@ -135,7 +134,7 @@ func TestNetworkFirewall_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := nfw.getAll(ctx, config.Config{
+			names, err := nfw.getAll(context.Background(), config.Config{
 				NetworkFirewall: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/network_firewall_tls_config_test.go
+++ b/aws/resources/network_firewall_tls_config_test.go
@@ -56,7 +56,6 @@ func TestNetworkFirewallTLSConfig_GetAll(t *testing.T) {
 		testId2   = "test-network-firewall-id2"
 		testName1 = "test-network-firewall-1"
 		testName2 = "test-network-firewall-2"
-		ctx       = context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
 	)
 
 	nfw := NetworkFirewallTLSConfig{
@@ -135,7 +134,7 @@ func TestNetworkFirewallTLSConfig_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := nfw.getAll(ctx, config.Config{
+			names, err := nfw.getAll(context.Background(), config.Config{
 				NetworkFirewallTLSConfig: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/opensearch.go
+++ b/aws/resources/opensearch.go
@@ -3,10 +3,9 @@ package resources
 import (
 	"context"
 	"fmt"
+	"github.com/gruntwork-io/cloud-nuke/util"
 	"sync"
 	"time"
-
-	"github.com/gruntwork-io/cloud-nuke/util"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
@@ -23,34 +22,27 @@ import (
 // use the first-seen tagging pattern to track which OpenSearch Domains should be nuked based on time. This routine will
 // tag resources with the first-seen tag if it does not have one.
 func (osd *OpenSearchDomains) getAll(c context.Context, configObj config.Config) ([]*string, error) {
-	var firstSeenTime *time.Time
-	var err error
 	domains, err := osd.getAllActiveOpenSearchDomains()
-	if err != nil {
-		return nil, errors.WithStackTrace(err)
-	}
-
-	excludeFirstSeenTag, err := util.GetBoolFromContext(c, util.ExcludeFirstSeenTagKey)
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
 	}
 
 	domainsToNuke := []*string{}
 	for _, domain := range domains {
-		if !excludeFirstSeenTag {
-			firstSeenTime, err = osd.getFirstSeenTag(domain.ARN)
+
+		firstSeenTime, err := osd.getFirstSeenTag(domain.ARN)
+		if err != nil {
+			return nil, errors.WithStackTrace(err)
+		}
+
+		if firstSeenTime == nil {
+			err := osd.setFirstSeenTag(domain.ARN, time.Now().UTC())
 			if err != nil {
+				logging.Errorf("Error tagging the OpenSearch Domain with ARN %s with error: %s", aws.StringValue(domain.ARN), err.Error())
 				return nil, errors.WithStackTrace(err)
 			}
-
-			if firstSeenTime == nil {
-				err := osd.setFirstSeenTag(domain.ARN, time.Now().UTC())
-				if err != nil {
-					logging.Errorf("Error tagging the OpenSearch Domain with ARN %s with error: %s", aws.StringValue(domain.ARN), err.Error())
-					return nil, errors.WithStackTrace(err)
-				}
-			}
 		}
+
 		if configObj.OpenSearchDomain.ShouldInclude(config.ResourceValue{
 			Name: domain.DomainName,
 			Time: firstSeenTime,

--- a/aws/resources/opensearch_test.go
+++ b/aws/resources/opensearch_test.go
@@ -42,9 +42,6 @@ func TestOpenSearch_GetAll(t *testing.T) {
 
 	t.Parallel()
 
-	// Set excludeFirstSeenTag to false for testing
-	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
-
 	testName1 := "test-domain1"
 	testName2 := "test-domain2"
 	now := time.Now()
@@ -88,17 +85,14 @@ func TestOpenSearch_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		ctx       context.Context
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			ctx:       ctx,
 			configObj: config.ResourceType{},
 			expected:  []string{testName1, testName2},
 		},
 		"nameExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{
@@ -108,7 +102,6 @@ func TestOpenSearch_GetAll(t *testing.T) {
 			expected: []string{testName2},
 		},
 		"timeAfterExclusionFilter": {
-			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
@@ -118,7 +111,7 @@ func TestOpenSearch_GetAll(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			names, err := osd.getAll(tc.ctx, config.Config{
+			names, err := osd.getAll(context.Background(), config.Config{
 				OpenSearchDomain: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/rds_cluster.go
+++ b/aws/resources/rds_cluster.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"github.com/gruntwork-io/cloud-nuke/util"
 	"time"
+
+	"github.com/gruntwork-io/cloud-nuke/util"
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
 
@@ -90,7 +91,6 @@ func (instance *DBClusters) nukeAll(names []*string) error {
 
 	if len(deletedNames) > 0 {
 		for _, name := range deletedNames {
-
 			err := instance.waitUntilRdsClusterDeleted(&rds.DescribeDBClustersInput{
 				DBClusterIdentifier: name,
 			})

--- a/aws/resources/security_group_test.go
+++ b/aws/resources/security_group_test.go
@@ -44,9 +44,6 @@ func TestSecurityGroup_GetAll(t *testing.T) {
 		now       = time.Now()
 	)
 
-	// Set excludeFirstSeenTag to false for testing
-	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
-
 	sg := SecurityGroup{
 		BaseAwsResource: BaseAwsResource{
 			Nukables: map[string]error{
@@ -91,17 +88,14 @@ func TestSecurityGroup_GetAll(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		ctx       context.Context
 		configObj config.EC2ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
-			ctx:ctx,
 			configObj: config.EC2ResourceType{},
 			expected:  []string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
-			ctx:ctx,
 			configObj: config.EC2ResourceType{
 				ResourceType: config.ResourceType{
 					ExcludeRule: config.FilterRule{
@@ -113,7 +107,6 @@ func TestSecurityGroup_GetAll(t *testing.T) {
 			expected: []string{testId2},
 		},
 		"timeAfterExclusionFilter": {
-			ctx:ctx,
 			configObj: config.EC2ResourceType{
 				ResourceType: config.ResourceType{
 					ExcludeRule: config.FilterRule{
@@ -127,7 +120,7 @@ func TestSecurityGroup_GetAll(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			names, err := sg.getAll(tc.ctx, config.Config{
+			names, err := sg.getAll(context.Background(), config.Config{
 				SecurityGroup: tc.configObj,
 			})
 			require.NoError(t, err)

--- a/aws/resources/sqs.go
+++ b/aws/resources/sqs.go
@@ -2,9 +2,6 @@ package resources
 
 import (
 	"context"
-	"strconv"
-	"time"
-
 	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sqs"
@@ -12,6 +9,8 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
 	"github.com/gruntwork-io/go-commons/errors"
+	"strconv"
+	"time"
 )
 
 // Returns a formatted string of SQS Queue URLs

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -173,10 +173,6 @@ func CreateCli(version string) *cli.App {
 					Usage:   "Set log level",
 					EnvVars: []string{"LOG_LEVEL"},
 				},
-				&cli.BoolFlag{
-					Name:  "exclude-first-seen",
-					Usage: "Set a flag for excluding first-seen-tag",
-				},
 			},
 		},
 	}
@@ -400,7 +396,6 @@ func generateQuery(c *cli.Context, includeUnaliasedKmsKeys bool, overridingResou
 		includeUnaliasedKmsKeys,
 		timeout,
 		onlyDefault,
-		c.Bool("exclude-first-seen"),
 	)
 }
 

--- a/util/time.go
+++ b/util/time.go
@@ -1,16 +1,9 @@
 package util
 
 import (
-	"context"
-	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/aws/aws-sdk-go/service/networkfirewall"
-	"github.com/aws/aws-sdk-go/service/networkfirewall/networkfirewalliface"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/go-commons/errors"
 )
@@ -48,61 +41,4 @@ func ParseTimestamp(timestamp *string) (*time.Time, error) {
 
 func FormatTimestamp(timestamp time.Time) string {
 	return timestamp.Format(firstSeenTimeFormat)
-}
-
-func GetOrCreateFirstSeen(ctx context.Context, client interface{}, identifier *string, tags map[string]string) (*time.Time, error) {
-
-	var firstSeenTime *time.Time
-	var err error
-
-	excludeFirstSeenTag, err := GetBoolFromContext(ctx, ExcludeFirstSeenTagKey)
-	if err != nil {
-		return nil, errors.WithStackTrace(err)
-	}
-
-	if excludeFirstSeenTag {
-		return nil, nil
-	}
-
-	// check the first seen already exists in the given map
-	for key, value := range tags {
-		if IsFirstSeenTag(awsgo.String(key)) {
-			firstSeenTime, err = ParseTimestamp(awsgo.String(value))
-			if err != nil {
-				return nil, errors.WithStackTrace(err)
-			}
-		}
-	}
-
-	if firstSeenTime == nil {
-		now := time.Now().UTC()
-		firstSeenTime = &now
-
-		switch v := client.(type) {
-		case ec2iface.EC2API:
-			_, err = v.CreateTags(&ec2.CreateTagsInput{
-				Resources: []*string{identifier},
-				Tags: []*ec2.Tag{
-					{
-						Key:   awsgo.String(FirstSeenTagKey),
-						Value: awsgo.String(FormatTimestamp(now)),
-					},
-				},
-			})
-		case networkfirewalliface.NetworkFirewallAPI:
-			_, err = v.TagResource(&networkfirewall.TagResourceInput{
-				ResourceArn: identifier,
-				Tags: []*networkfirewall.Tag{
-					{
-						Key:   awsgo.String(FirstSeenTagKey),
-						Value: awsgo.String(FormatTimestamp(now)),
-					},
-				},
-			})
-		default:
-			return nil, errors.WithStackTrace(fmt.Errorf("invalid type %v for first seen tag", v))
-		}
-	}
-
-	return firstSeenTime, err
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

