### PR TITLE
Feature/nukable permission check for resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,40 @@ of the file that are supported are listed here.
 | network-firewall-resource-policy | NetworkFirewallResourcePolicy     | ✅ (Firewall Resource Policy ARN)   			  |  ❌             |  ❌    |    ❌   |
 
 
+### Resource Deletion and 'IsNukable' Check Option
+#### Supported Resources for 'IsNukable' Check
+For certain resources, such as `AMI`, `EBS`, `DHCP Option`, and others listed below, we support an option to verify whether the user has sufficient permissions to nuke the resources. If not, it will raise `error: INSUFFICIENT_PERMISSION` error.
+
+Supported resources:
+- AMI
+- EBS
+- DHCP Option
+- Egress only Internet Gateway
+- Endpoints
+- Internet Gatway
+- IPAM
+- IPAM BYOASN
+- IPAM Custom Allocation
+- IPAM Pool
+- IPAM Resource Discovery
+- IPAM Scope
+- Key Pair
+- Network ACL
+- Network Interface
+- Subnet
+- VPC
+- Elastic IP
+- Launch Template
+- NAT Gateway
+- Network Firewall
+- Security Group
+- SnapShot
+- Transit Gateway
+
+#### Unsupported Resources
+Please note that the eligibility check for nukability relies on the `DryRun` feature provided by AWS. Regrettably, this feature is not available for all delete APIs of resource types. Hence, the 'eligibility check for nukability' option may not be accessible for all resource types
+
+
 ### How to Use
 
 Once you created your config file, you can run a command like this to nuke resources with your config file:

--- a/aws/resources/ami.go
+++ b/aws/resources/ami.go
@@ -79,8 +79,8 @@ func (ami *AMIs) nukeAll(imageIds []*string) error {
 
 	deletedCount := 0
 	for _, imageID := range imageIds {
-		if nukable, err := ami.IsNukable(awsgo.StringValue(imageID)); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(imageID), err)
+		if nukable, reason := ami.IsNukable(awsgo.StringValue(imageID)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(imageID), reason)
 			continue
 		}
 

--- a/aws/resources/ami.go
+++ b/aws/resources/ami.go
@@ -2,9 +2,10 @@ package resources
 
 import (
 	"context"
+	"strings"
+
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/gruntwork-io/cloud-nuke/util"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -54,6 +55,15 @@ func (ami *AMIs) getAll(c context.Context, configObj config.Config) ([]*string, 
 		}
 	}
 
+	// checking the nukable permissions
+	ami.VerifyNukablePermissions(imageIds, func(id *string) error {
+		_, err := ami.Client.DeregisterImage(&ec2.DeregisterImageInput{
+			ImageId: id,
+			DryRun:  awsgo.Bool(true),
+		})
+		return err
+	})
+
 	return imageIds, nil
 }
 
@@ -62,17 +72,21 @@ func (ami *AMIs) nukeAll(imageIds []*string) error {
 	if len(imageIds) == 0 {
 		logging.Debugf("No AMI to nuke in region %s", ami.Region)
 		return nil
+
 	}
 
 	logging.Debugf("Deleting all AMI in region %s", ami.Region)
 
 	deletedCount := 0
 	for _, imageID := range imageIds {
-		params := &ec2.DeregisterImageInput{
-			ImageId: imageID,
+		if nukable, err := ami.IsNukable(awsgo.StringValue(imageID)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(imageID), err)
+			continue
 		}
 
-		_, err := ami.Client.DeregisterImage(params)
+		_, err := ami.Client.DeregisterImage(&ec2.DeregisterImageInput{
+			ImageId: imageID,
+		})
 
 		// Record status of this resource
 		e := report.Entry{

--- a/aws/resources/base_resource.go
+++ b/aws/resources/base_resource.go
@@ -74,6 +74,11 @@ func (br *BaseAwsResource) PrepareContext(parentContext context.Context, resourc
 // executed, and the result (error or success) is recorded using the SetNukableStatus method, indicating whether
 // the specified action is nukable
 func (br *BaseAwsResource) VerifyNukablePermissions(ids []*string, nukableCheckfn func(id *string) error) {
+	// check if the 'Nukables' map is initialized, and if it's not, initialize it
+	if br.Nukables == nil {
+		br.Nukables = make(map[string]error)
+	}
+
 	for _, id := range ids {
 		// skip if the id is already exists
 		if _, ok := br.GetNukableStatus(*id); ok {

--- a/aws/resources/ebs.go
+++ b/aws/resources/ebs.go
@@ -75,8 +75,8 @@ func (ev *EBSVolumes) nukeAll(volumeIds []*string) error {
 
 	for _, volumeID := range volumeIds {
 
-		if nukable, err := ev.IsNukable(awsgo.StringValue(volumeID)); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(volumeID), err)
+		if nukable, reason := ev.IsNukable(awsgo.StringValue(volumeID)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(volumeID), reason)
 			continue
 		}
 

--- a/aws/resources/ec2_dhcp_option.go
+++ b/aws/resources/ec2_dhcp_option.go
@@ -44,8 +44,8 @@ func (v *EC2DhcpOption) getAll(_ context.Context, configObj config.Config) ([]*s
 
 func (v *EC2DhcpOption) nukeAll(identifiers []*string) error {
 	for _, identifier := range identifiers {
-		if nukable, err := v.IsNukable(awsgo.StringValue(identifier)); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(identifier), err)
+		if nukable, reason := v.IsNukable(awsgo.StringValue(identifier)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(identifier), reason)
 			continue
 		}
 

--- a/aws/resources/ec2_dhcp_option.go
+++ b/aws/resources/ec2_dhcp_option.go
@@ -30,11 +30,24 @@ func (v *EC2DhcpOption) getAll(_ context.Context, configObj config.Config) ([]*s
 		return nil, errors.WithStackTrace(err)
 	}
 
+	// checking the nukable permissions
+	v.VerifyNukablePermissions(dhcpOptionIds, func(id *string) error {
+		_, err := v.Client.DeleteDhcpOptions(&ec2.DeleteDhcpOptionsInput{
+			DhcpOptionsId: id,
+			DryRun:        awsgo.Bool(true),
+		})
+		return err
+	})
+
 	return dhcpOptionIds, nil
 }
 
 func (v *EC2DhcpOption) nukeAll(identifiers []*string) error {
 	for _, identifier := range identifiers {
+		if nukable, err := v.IsNukable(awsgo.StringValue(identifier)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(identifier), err)
+			continue
+		}
 
 		err := nukeDhcpOption(v.Client, identifier)
 		if err != nil {

--- a/aws/resources/ec2_egress_only_igw.go
+++ b/aws/resources/ec2_egress_only_igw.go
@@ -73,8 +73,8 @@ func (egigw *EgressOnlyInternetGateway) nukeAll(ids []*string) error {
 		// NOTE : We can skip the error checking and return it here, since it is already being checked while displaying the identifiers with the Nukable  field.
 		// Here, `err` refers to the error indicating whether the identifier is eligible for nuke or not (an error which we got from aws when tried to delete the resource with dryRun),
 		// and it is not a programming error. (edited)
-		if nukable, err := egigw.IsNukable(*id); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", *id, err)
+		if nukable, reason := egigw.IsNukable(*id); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", *id, reason)
 			continue
 		}
 

--- a/aws/resources/ec2_endpoints.go
+++ b/aws/resources/ec2_endpoints.go
@@ -74,8 +74,8 @@ func (e *EC2Endpoints) nukeAll(identifiers []*string) error {
 	var deletedAddresses []*string
 
 	for _, id := range identifiers {
-		if nukable, err := e.IsNukable(*id); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", *id, err)
+		if nukable, reason := e.IsNukable(*id); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", *id, reason)
 			continue
 		}
 

--- a/aws/resources/ec2_internet_gateway.go
+++ b/aws/resources/ec2_internet_gateway.go
@@ -81,8 +81,8 @@ func (igw *InternetGateway) nukeAll(identifiers []*string) error {
 	var deletedGateways []*string
 
 	for _, id := range identifiers {
-		if nukable, err := igw.IsNukable(*id); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", *id, err)
+		if nukable, reason := igw.IsNukable(*id); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", *id, reason)
 			continue
 		}
 

--- a/aws/resources/ec2_ipam.go
+++ b/aws/resources/ec2_ipam.go
@@ -256,8 +256,8 @@ func (ec2Ipam *EC2IPAMs) nukeAll(ids []*string) error {
 
 	for _, id := range ids {
 
-		if nukable, err := ec2Ipam.IsNukable(awsgo.StringValue(id)); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), err)
+		if nukable, reason := ec2Ipam.IsNukable(awsgo.StringValue(id)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), reason)
 			continue
 		}
 

--- a/aws/resources/ec2_ipam_byoasn.go
+++ b/aws/resources/ec2_ipam_byoasn.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
@@ -26,6 +27,15 @@ func (byoasn *EC2IPAMByoasn) getAll(c context.Context, configObj config.Config) 
 	for _, out := range output.Byoasns {
 		result = append(result, out.Asn)
 	}
+
+	// checking the nukable permissions
+	byoasn.VerifyNukablePermissions(result, func(id *string) error {
+		_, err := byoasn.Client.DisassociateIpamByoasn(&ec2.DisassociateIpamByoasnInput{
+			Asn:    id,
+			DryRun: awsgo.Bool(true),
+		})
+		return err
+	})
 	return result, nil
 }
 
@@ -40,11 +50,14 @@ func (byoasn *EC2IPAMByoasn) nukeAll(asns []*string) error {
 	var list []*string
 
 	for _, id := range asns {
-		params := &ec2.DisassociateIpamByoasnInput{
-			Asn: id,
+		if nukable, err := byoasn.IsNukable(awsgo.StringValue(id)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), err)
+			continue
 		}
 
-		_, err := byoasn.Client.DisassociateIpamByoasn(params)
+		_, err := byoasn.Client.DisassociateIpamByoasn(&ec2.DisassociateIpamByoasnInput{
+			Asn: id,
+		})
 
 		// Record status of this resource
 		e := report.Entry{

--- a/aws/resources/ec2_ipam_byoasn.go
+++ b/aws/resources/ec2_ipam_byoasn.go
@@ -50,8 +50,8 @@ func (byoasn *EC2IPAMByoasn) nukeAll(asns []*string) error {
 	var list []*string
 
 	for _, id := range asns {
-		if nukable, err := byoasn.IsNukable(awsgo.StringValue(id)); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), err)
+		if nukable, reason := byoasn.IsNukable(awsgo.StringValue(id)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), reason)
 			continue
 		}
 

--- a/aws/resources/ec2_ipam_custom_allocation.go
+++ b/aws/resources/ec2_ipam_custom_allocation.go
@@ -92,6 +92,29 @@ func (cs *EC2IPAMCustomAllocation) getAll(c context.Context, configObj config.Co
 		}
 	}
 
+	// checking the nukable permissions
+	cs.VerifyNukablePermissions(result, func(id *string) error {
+		cidr, err := cs.getPoolAllocationCIDR(id)
+		if err != nil {
+			logging.Errorf("[Failed] %s", err)
+			return err
+		}
+
+		allocationIPAMPoolID, ok := cs.PoolAndAllocationMap[*id]
+		if !ok {
+			logging.Errorf("[Failed] %s", fmt.Errorf("unable to find the pool allocation with %s", *id))
+			return fmt.Errorf("unable to find the pool allocation with %s", *id)
+		}
+
+		_, err = cs.Client.ReleaseIpamPoolAllocation(&ec2.ReleaseIpamPoolAllocationInput{
+			IpamPoolId:           &allocationIPAMPoolID,
+			IpamPoolAllocationId: id,
+			Cidr:                 cidr,
+			DryRun:               awsgo.Bool(true),
+		})
+		return err
+	})
+
 	return result, nil
 }
 
@@ -106,6 +129,11 @@ func (cs *EC2IPAMCustomAllocation) nukeAll(ids []*string) error {
 	var deletedAddresses []*string
 
 	for _, id := range ids {
+
+		if nukable, err := cs.IsNukable(awsgo.StringValue(id)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), err)
+			continue
+		}
 
 		// get the IPamPool details
 		cidr, err := cs.getPoolAllocationCIDR(id)

--- a/aws/resources/ec2_ipam_custom_allocation.go
+++ b/aws/resources/ec2_ipam_custom_allocation.go
@@ -130,8 +130,8 @@ func (cs *EC2IPAMCustomAllocation) nukeAll(ids []*string) error {
 
 	for _, id := range ids {
 
-		if nukable, err := cs.IsNukable(awsgo.StringValue(id)); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), err)
+		if nukable, reason := cs.IsNukable(awsgo.StringValue(id)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), reason)
 			continue
 		}
 

--- a/aws/resources/ec2_ipam_pool.go
+++ b/aws/resources/ec2_ipam_pool.go
@@ -88,8 +88,8 @@ func (pool *EC2IPAMPool) nukeAll(ids []*string) error {
 
 	for _, id := range ids {
 
-		if nukable, err := pool.IsNukable(awsgo.StringValue(id)); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), err)
+		if nukable, reason := pool.IsNukable(awsgo.StringValue(id)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), reason)
 			continue
 		}
 

--- a/aws/resources/ec2_ipam_resource_discovery.go
+++ b/aws/resources/ec2_ipam_resource_discovery.go
@@ -63,6 +63,15 @@ func (discovery *EC2IPAMResourceDiscovery) getAll(c context.Context, configObj c
 		return nil, errors.WithStackTrace(err)
 	}
 
+	// checking the nukable permissions
+	discovery.VerifyNukablePermissions(result, func(id *string) error {
+		_, err := discovery.Client.DeleteIpamResourceDiscovery(&ec2.DeleteIpamResourceDiscoveryInput{
+			IpamResourceDiscoveryId: id,
+			DryRun:                  awsgo.Bool(true),
+		})
+		return err
+	})
+
 	return result, nil
 }
 
@@ -77,11 +86,15 @@ func (discovery *EC2IPAMResourceDiscovery) nukeAll(ids []*string) error {
 	var deletedAddresses []*string
 
 	for _, id := range ids {
-		params := &ec2.DeleteIpamResourceDiscoveryInput{
-			IpamResourceDiscoveryId: id,
+
+		if nukable, err := discovery.IsNukable(awsgo.StringValue(id)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), err)
+			continue
 		}
 
-		_, err := discovery.Client.DeleteIpamResourceDiscovery(params)
+		_, err := discovery.Client.DeleteIpamResourceDiscovery(&ec2.DeleteIpamResourceDiscoveryInput{
+			IpamResourceDiscoveryId: id,
+		})
 		// Record status of this resource
 		e := report.Entry{
 			Identifier:   awsgo.StringValue(id),

--- a/aws/resources/ec2_ipam_resource_discovery.go
+++ b/aws/resources/ec2_ipam_resource_discovery.go
@@ -87,8 +87,8 @@ func (discovery *EC2IPAMResourceDiscovery) nukeAll(ids []*string) error {
 
 	for _, id := range ids {
 
-		if nukable, err := discovery.IsNukable(awsgo.StringValue(id)); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), err)
+		if nukable, reason := discovery.IsNukable(awsgo.StringValue(id)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), reason)
 			continue
 		}
 

--- a/aws/resources/ec2_ipam_scope.go
+++ b/aws/resources/ec2_ipam_scope.go
@@ -90,8 +90,8 @@ func (scope *EC2IpamScopes) nukeAll(ids []*string) error {
 	var deletedList []*string
 
 	for _, id := range ids {
-		if nukable, err := scope.IsNukable(awsgo.StringValue(id)); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), err)
+		if nukable, reason := scope.IsNukable(awsgo.StringValue(id)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(id), reason)
 			continue
 		}
 

--- a/aws/resources/ec2_key_pair.go
+++ b/aws/resources/ec2_key_pair.go
@@ -68,8 +68,8 @@ func (k *EC2KeyPairs) nukeAll(keypairIds []*string) error {
 	deletedKeyPairs := 0
 	var multiErr *multierror.Error
 	for _, keypair := range keypairIds {
-		if nukable, err := k.IsNukable(awsgo.StringValue(keypair)); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(keypair), err)
+		if nukable, reason := k.IsNukable(awsgo.StringValue(keypair)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(keypair), reason)
 			continue
 		}
 

--- a/aws/resources/ec2_key_pair.go
+++ b/aws/resources/ec2_key_pair.go
@@ -2,6 +2,8 @@ package resources
 
 import (
 	"context"
+
+	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
@@ -27,6 +29,15 @@ func (k *EC2KeyPairs) getAll(c context.Context, configObj config.Config) ([]*str
 			ids = append(ids, keyPair.KeyPairId)
 		}
 	}
+
+	// checking the nukable permissions
+	k.VerifyNukablePermissions(ids, func(id *string) error {
+		_, err := k.Client.DeleteKeyPair(&ec2.DeleteKeyPairInput{
+			KeyPairId: id,
+			DryRun:    awsgo.Bool(true),
+		})
+		return err
+	})
 
 	return ids, nil
 }
@@ -57,6 +68,11 @@ func (k *EC2KeyPairs) nukeAll(keypairIds []*string) error {
 	deletedKeyPairs := 0
 	var multiErr *multierror.Error
 	for _, keypair := range keypairIds {
+		if nukable, err := k.IsNukable(awsgo.StringValue(keypair)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(keypair), err)
+			continue
+		}
+
 		if err := k.deleteKeyPair(keypair); err != nil {
 			logging.Errorf("[Failed] %s", err)
 			multiErr = multierror.Append(multiErr, err)

--- a/aws/resources/ec2_network_acl.go
+++ b/aws/resources/ec2_network_acl.go
@@ -159,8 +159,8 @@ func (nacl *NetworkACL) nukeAll(identifiers []*string) error {
 	var deleted []*string
 
 	for _, id := range identifiers {
-		if nukable, err := nacl.IsNukable(*id); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", *id, err)
+		if nukable, reason := nacl.IsNukable(*id); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", *id, reason)
 			continue
 		}
 

--- a/aws/resources/ec2_network_interface.go
+++ b/aws/resources/ec2_network_interface.go
@@ -180,8 +180,8 @@ func (ni *NetworkInterface) nukeAll(identifiers []*string) error {
 	var deleted []*string
 
 	for _, id := range identifiers {
-		if nukable, err := ni.IsNukable(*id); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", *id, err)
+		if nukable, reason := ni.IsNukable(*id); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", *id, reason)
 			continue
 		}
 

--- a/aws/resources/ec2_subnet.go
+++ b/aws/resources/ec2_subnet.go
@@ -93,12 +93,12 @@ func (ec2subnet *EC2Subnet) nukeAll(ids []*string) error {
 
 	for _, id := range ids {
 		// check the id has the permission to nuke, if not. continue the execution
-		if nukable, err := ec2subnet.IsNukable(*id); !nukable {
+		if nukable, reason := ec2subnet.IsNukable(*id); !nukable {
 			// not adding the report on final result hence not adding a record entry here
 			// NOTE: We can skip the error checking and return it here, since it is already being checked while
 			// displaying the identifiers. Here, `err` refers to the error indicating whether the identifier is eligible for nuke or not,
 			// and it is not a programming error.
-			logging.Debugf("[Skipping] %s nuke because %v", *id, err)
+			logging.Debugf("[Skipping] %s nuke because %v", *id, reason)
 			continue
 		}
 

--- a/aws/resources/ec2_subnet_test.go
+++ b/aws/resources/ec2_subnet_test.go
@@ -88,6 +88,7 @@ func TestEc2Subnets_GetAll(t *testing.T) {
 			expected:  []string{subnet1, subnet2},
 		},
 		"nameExclusionFilter": {
+			ctx: ctx,
 			configObj: config.EC2ResourceType{
 				ResourceType: config.ResourceType{
 					ExcludeRule: config.FilterRule{

--- a/aws/resources/ec2_vpc.go
+++ b/aws/resources/ec2_vpc.go
@@ -84,8 +84,8 @@ func (v *EC2VPCs) nukeAll(vpcIds []string) error {
 	multiErr := new(multierror.Error)
 
 	for _, id := range vpcIds {
-		if nukable, err := v.IsNukable(id); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", id, err)
+		if nukable, reason := v.IsNukable(id); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", id, reason)
 			continue
 		}
 

--- a/aws/resources/ec2_vpc.go
+++ b/aws/resources/ec2_vpc.go
@@ -60,6 +60,15 @@ func (v *EC2VPCs) getAll(c context.Context, configObj config.Config) ([]*string,
 		}
 	}
 
+	// checking the nukable permissions
+	v.VerifyNukablePermissions(ids, func(id *string) error {
+		_, err := v.Client.DeleteVpc(&ec2.DeleteVpcInput{
+			VpcId:  id,
+			DryRun: awsgo.Bool(true),
+		})
+		return err
+	})
+
 	return ids, nil
 }
 
@@ -75,6 +84,11 @@ func (v *EC2VPCs) nukeAll(vpcIds []string) error {
 	multiErr := new(multierror.Error)
 
 	for _, id := range vpcIds {
+		if nukable, err := v.IsNukable(id); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", id, err)
+			continue
+		}
+
 		var err error
 		err = nuke(v.Client, v.ELBClient, id)
 

--- a/aws/resources/eip.go
+++ b/aws/resources/eip.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
@@ -71,8 +72,8 @@ func (ea *EIPAddresses) nukeAll(allocationIds []*string) error {
 
 	for _, allocationID := range allocationIds {
 
-		if nukable, err := ea.IsNukable(awsgo.StringValue(allocationID)); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(allocationID), err)
+		if nukable, reason := ea.IsNukable(awsgo.StringValue(allocationID)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(allocationID), reason)
 			continue
 		}
 

--- a/aws/resources/launch_template.go
+++ b/aws/resources/launch_template.go
@@ -53,8 +53,8 @@ func (lt *LaunchTemplates) nukeAll(templateNames []*string) error {
 
 	for _, templateName := range templateNames {
 
-		if nukable, err := lt.IsNukable(awsgo.StringValue(templateName)); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(templateName), err)
+		if nukable, reason := lt.IsNukable(awsgo.StringValue(templateName)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(templateName), reason)
 			continue
 		}
 

--- a/aws/resources/launch_template.go
+++ b/aws/resources/launch_template.go
@@ -2,7 +2,9 @@ package resources
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
+	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
@@ -27,6 +29,15 @@ func (lt *LaunchTemplates) getAll(c context.Context, configObj config.Config) ([
 		}
 	}
 
+	// checking the nukable permissions
+	lt.VerifyNukablePermissions(templateNames, func(id *string) error {
+		_, err := lt.Client.DeleteLaunchTemplate(&ec2.DeleteLaunchTemplateInput{
+			LaunchTemplateName: id,
+			DryRun:             awsgo.Bool(true),
+		})
+		return err
+	})
+
 	return templateNames, nil
 }
 
@@ -41,11 +52,15 @@ func (lt *LaunchTemplates) nukeAll(templateNames []*string) error {
 	var deletedTemplateNames []*string
 
 	for _, templateName := range templateNames {
-		params := &ec2.DeleteLaunchTemplateInput{
-			LaunchTemplateName: templateName,
+
+		if nukable, err := lt.IsNukable(awsgo.StringValue(templateName)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(templateName), err)
+			continue
 		}
 
-		_, err := lt.Client.DeleteLaunchTemplate(params)
+		_, err := lt.Client.DeleteLaunchTemplate(&ec2.DeleteLaunchTemplateInput{
+			LaunchTemplateName: templateName,
+		})
 
 		// Record status of this resource
 		e := report.Entry{

--- a/aws/resources/nat_gateway.go
+++ b/aws/resources/nat_gateway.go
@@ -33,6 +33,16 @@ func (ngw *NatGateways) getAll(_ context.Context, configObj config.Config) ([]*s
 			return !lastPage
 		},
 	)
+
+	// checking the nukable permissions
+	ngw.VerifyNukablePermissions(allNatGateways, func(id *string) error {
+		_, err := ngw.Client.DeleteNatGateway(&ec2.DeleteNatGatewayInput{
+			NatGatewayId: id,
+			DryRun:       awsgo.Bool(true),
+		})
+		return err
+	})
+
 	return allNatGateways, errors.WithStackTrace(err)
 }
 
@@ -161,6 +171,12 @@ func (ngw *NatGateways) areAllNatGatewaysDeleted(identifiers []*string) (bool, e
 // concurrency control and a return channel for errors.
 func (ngw *NatGateways) deleteAsync(wg *sync.WaitGroup, errChan chan error, ngwID *string) {
 	defer wg.Done()
+
+	if nukable, err := ngw.IsNukable(awsgo.StringValue(ngwID)); !nukable {
+		logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(ngwID), err)
+		errChan <- nil
+		return
+	}
 
 	err := nukeNATGateway(ngw.Client, ngwID)
 	// Record status of this resource

--- a/aws/resources/nat_gateway.go
+++ b/aws/resources/nat_gateway.go
@@ -172,8 +172,8 @@ func (ngw *NatGateways) areAllNatGatewaysDeleted(identifiers []*string) (bool, e
 func (ngw *NatGateways) deleteAsync(wg *sync.WaitGroup, errChan chan error, ngwID *string) {
 	defer wg.Done()
 
-	if nukable, err := ngw.IsNukable(awsgo.StringValue(ngwID)); !nukable {
-		logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(ngwID), err)
+	if nukable, reason := ngw.IsNukable(awsgo.StringValue(ngwID)); !nukable {
+		logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(ngwID), reason)
 		errChan <- nil
 		return
 	}

--- a/aws/resources/network_firewall.go
+++ b/aws/resources/network_firewall.go
@@ -93,8 +93,8 @@ func (nfw *NetworkFirewall) nukeAll(identifiers []*string) error {
 	var deleted []*string
 
 	for _, id := range identifiers {
-		if nukable, err := nfw.IsNukable(*id); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", *id, err)
+		if nukable, reason := nfw.IsNukable(*id); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", *id, reason)
 			continue
 		}
 

--- a/aws/resources/security_group.go
+++ b/aws/resources/security_group.go
@@ -305,8 +305,8 @@ func (sg *SecurityGroup) nukeAll(identifiers []*string) error {
 
 	for _, id := range identifiers {
 
-		if nukable, err := sg.IsNukable(*id); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", *id, err)
+		if nukable, reason := sg.IsNukable(*id); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", *id, reason)
 			continue
 		}
 

--- a/aws/resources/snapshot.go
+++ b/aws/resources/snapshot.go
@@ -82,8 +82,8 @@ func (s *Snapshots) nukeAll(snapshotIds []*string) error {
 
 	for _, snapshotID := range snapshotIds {
 
-		if nukable, err := s.IsNukable(awsgo.StringValue(snapshotID)); !nukable {
-			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(snapshotID), err)
+		if nukable, reason := s.IsNukable(awsgo.StringValue(snapshotID)); !nukable {
+			logging.Debugf("[Skipping] %s nuke because %v", awsgo.StringValue(snapshotID), reason)
 			continue
 		}
 

--- a/aws/resources/transit_gateway.go
+++ b/aws/resources/transit_gateway.go
@@ -73,9 +73,9 @@ func (tgw *TransitGateways) nukeAll(ids []*string) error {
 
 	for _, id := range ids {
 		//check the id has the permission to nuke, if not. continue the execution
-		if nukable, err := tgw.IsNukable(*id); !nukable {
+		if nukable, reason := tgw.IsNukable(*id); !nukable {
 			//not adding the report on final result hence not adding a record entry here
-			logging.Debugf("[Skipping] %s nuke because %v", *id, err)
+			logging.Debugf("[Skipping] %s nuke because %v", *id, reason)
 			continue
 		}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

