### PR TITLE
checking allowed regions for email-receiving

### DIFF
--- a/aws/resources/ses_email_receiving_test.go
+++ b/aws/resources/ses_email_receiving_test.go
@@ -43,6 +43,7 @@ func TestSesReceiptRule_GetAll(t *testing.T) {
 	t.Parallel()
 
 	sesRule := SesReceiptRule{
+		Region: "us-east-1",
 		Client: mockedSesReceiptRule{
 			ListReceiptRuleSetsOutput: ses.ListReceiptRuleSetsOutput{
 				RuleSets: []*ses.ReceiptRuleSetMetadata{
@@ -129,6 +130,7 @@ func TestSesReceiptFilter_GetAll(t *testing.T) {
 	t.Parallel()
 
 	sesRule := SesReceiptFilter{
+		Region: "us-east-1",
 		Client: mockedSesReceiptFilter{
 			ListReceiptFiltersOutput: ses.ListReceiptFiltersOutput{
 				Filters: []*ses.ReceiptFilter{


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/693.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

