### PR TITLE
Increase parallelism for circleCi test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,14 +44,15 @@ jobs:
       arch:
         type: string
     steps:
-      - checkout
       - run:
+          # darwin/386 is no longer supported by the newer versions of Go.
           name: Check Combination
           command: |
             if [ "<< parameters.os >>" == "darwin" ] && [ "<< parameters.arch >>" == "386" ]; then
               echo "Skipping build for darwin/386."
               circleci-agent step halt
             fi
+      - checkout
       - run:
           name: Build Binaries
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,13 +27,13 @@ jobs:
             # Find all directories containing Go test files under 'aws/resources'
             PACKAGES=$(find aws/resources -type f -name "*_test.go" | sed 's|/[^/]*$||' | sort -u)
             # Split packages by name for simpler distribution
-            SPLIT_PACKAGES=$(echo "$PACKAGES" | circleci tests split --split-by=alphabetical)
+            SPLIT_PACKAGES=$(echo "$PACKAGES" | circleci tests split --split-by=name)
             echo "Packages to test: $SPLIT_PACKAGES"
             for PACKAGE in $SPLIT_PACKAGES; do
               echo "Running tests in package: $PACKAGE"
               # Adjust the path to be correct for the `run-go-tests` script
               PACKAGE_PATH=$(echo "$PACKAGE" | sed 's|^./||') # Ensure there's no leading './'
-              DISABLE_TELEMETRY=true ./run-go-tests --path "$PACKAGE_PATH" --packages "$PACKAGE_PATH" | tee -a /tmp/logs/all.log
+              DISABLE_TELEMETRY=true run-go-tests --path "$PACKAGE_PATH" --packages "$PACKAGE_PATH" | tee -a /tmp/logs/all.log
             done
       - run:
           name: Parse Test Output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,9 @@ jobs:
             echo "Packages to test: $SPLIT_PACKAGES"
             for PACKAGE in $SPLIT_PACKAGES; do
               echo "Running tests in package: $PACKAGE"
-              DISABLE_TELEMETRY=true run-go-tests --path "$PACKAGE" --packages "./$PACKAGE" | tee -a /tmp/logs/all.log
+              # Ensuring paths are relative and removing any potential leading './' which might be causing the issue
+              REL_PACKAGE="${PACKAGE#./}"
+              DISABLE_TELEMETRY=true run-go-tests --path "$REL_PACKAGE" --packages "$REL_PACKAGE" | tee -a /tmp/logs/all.log
             done
       - run:
           name: Parse Test Output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
             echo "Packages to test: $SPLIT_PACKAGES"
             for PACKAGE in $SPLIT_PACKAGES; do
               echo "Running tests in package: $PACKAGE"
-              DISABLE_TELEMETRY=true ./run-go-tests --path "$PACKAGE" --packages "./$PACKAGE" | tee -a /tmp/logs/all.log
+              DISABLE_TELEMETRY=true run-go-tests --path "$PACKAGE" --packages "./$PACKAGE" | tee -a /tmp/logs/all.log
             done
       - run:
           name: Parse Test Output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,15 @@ jobs:
       - run:
           name: Run Tests in Parallel Across Containers
           command: |
-            PACKAGES=$(find . -type f -name "*_test.go" | sed 's|/[^/]*$||' | sort -u)
-            SPLIT_PACKAGES=$(echo "$PACKAGES" | circleci tests split --split-by=timings)
+            # Find all directories containing Go test files under 'aws/resources'
+            PACKAGES=$(find aws/resources -type f -name "*_test.go" | sed 's|/[^/]*$||' | sort -u)
+            # Split packages by name for simpler distribution
+            SPLIT_PACKAGES=$(echo "$PACKAGES" | circleci tests split --split-by=alphabetical)
             echo "Packages to test: $SPLIT_PACKAGES"
             for PACKAGE in $SPLIT_PACKAGES; do
               echo "Running tests in package: $PACKAGE"
-              PACKAGE_PATH=$(echo "$PACKAGE" | sed 's|^./||') # Remove leading './' if present
+              # Adjust the path to be correct for the `run-go-tests` script
+              PACKAGE_PATH=$(echo "$PACKAGE" | sed 's|^./||') # Ensure there's no leading './'
               DISABLE_TELEMETRY=true ./run-go-tests --path "$PACKAGE_PATH" --packages "$PACKAGE_PATH" | tee -a /tmp/logs/all.log
             done
       - run:
@@ -39,7 +42,7 @@ jobs:
       - store_artifacts:
           path: /tmp/logs
       - store_test_results:
-          path: /tmp/logs
+          path: /tmp/logss
 
   build:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,19 +22,18 @@ jobs:
           name: Prepare Logs Directory
           command: mkdir -p /tmp/logs
       - run:
-          name: Run Tests in Parallel Across Containers
+          name: Discover and Split Test Files
           command: |
-            # Find all directories containing Go test files under 'aws/resources'
-            PACKAGES=$(find aws/resources -type f -name "*_test.go" | sed 's|/[^/]*$||' | sort -u)
-            # Split packages by name for simpler distribution
-            SPLIT_PACKAGES=$(echo "$PACKAGES" | circleci tests split --split-by=name)
-            echo "Packages to test: $SPLIT_PACKAGES"
-            for PACKAGE in $SPLIT_PACKAGES; do
-              echo "Running tests in package: $PACKAGE"
-              # Adjust the path to be correct for the `run-go-tests` script
-              PACKAGE_PATH=$(echo "$PACKAGE" | sed 's|^./||') # Ensure there's no leading './'
-              DISABLE_TELEMETRY=true run-go-tests --path "$PACKAGE_PATH" --packages "$PACKAGE_PATH" | tee -a /tmp/logs/all.log
-            done
+            # Find all test files under 'aws/resources' and split them by name
+            TEST_FILES=$(find aws/resources/ -type f -name "*_test.go" | sort -u)
+            SPLIT_TEST_FILES=$(echo "$TEST_FILES" | circleci tests split --split-by=name)
+            echo "Test files assigned to this container: $SPLIT_TEST_FILES"
+            for FILE in $SPLIT_TEST_FILES; do
+              # Extract the directory path from each file and run tests in those directories
+              DIR=$(dirname $FILE)
+              echo "Running tests in directory: $DIR"
+              DISABLE_TELEMETRY=true run-go-tests --path "$DIR" --packages "./$DIR"
+            done | tee /tmp/logs/all.log
       - run:
           name: Parse Test Output
           command: terratest_log_parser --testlog /tmp/logs/all.log --outputdir /tmp/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,7 @@ jobs:
         type: string
       arch:
         type: string
-    docker:
-      - image: cimg/go:1.18
     steps:
-      - checkout
       - run:
           name: Build Binaries
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,16 +15,22 @@ version: 2.1
 jobs:
   test:
     <<: *defaults
-    parallelism: 4  # Adjust based on your CI resource allocation and needs
+    parallelism: 4  # Using 4 containers
     steps:
       - checkout
       - run:
           name: Prepare Logs Directory
           command: mkdir -p /tmp/logs
       - run:
-          name: Run Tests with Parallel Execution
+          name: Run Tests in Parallel Across Containers
           command: |
-            DISABLE_TELEMETRY=true run-go-tests --extra-flags '--timeout 45m' --parallelism 4 --packages "./aws/..."
+            TESTFILES=$(circleci tests glob "**/*.go" | circleci tests split --split-by=timings)
+            if [ -z "$TESTFILES" ]; then
+              echo "No test files to run."
+              exit 0
+            fi
+            echo "Running tests on these files: $TESTFILES"
+            DISABLE_TELEMETRY=true run-go-tests --extra-flags '--timeout 45m' --parallelism 1 --path $TESTFILES
             | tee /tmp/logs/all.log
           no_output_timeout: 45m
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
       - store_test_results:
           path: /tmp/logs
 
+
   build:
     <<: *defaults
     parameters:
@@ -43,11 +44,15 @@ jobs:
       arch:
         type: string
     steps:
+      - checkout
       - run:
           name: Build Binaries
           command: |
             build-go-binaries --parallel 1 --app-name cloud-nuke --dest-path bin \
                                 --ld-flags "-X main.VERSION=$CIRCLE_TAG" --os << parameters.os >> --arch << parameters.arch >>
+      - persist_to_workspace:
+          root: .
+          paths: bin
 
   nuke_phx_devops:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,14 +8,13 @@ env: &env
     MODULE_CI_VERSION: v0.53.3
 
 defaults: &defaults
-  resource_class: medium+
+  resource_class: large
   docker:
     - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.21-tf1.5-tg39.1-pck1.8-ci50.7
 version: 2.1
 jobs:
   test:
     <<: *defaults
-    parallelism: 4  # Adjust based on how many containers you want to use
     steps:
       - checkout
       - run:
@@ -25,9 +24,6 @@ jobs:
           name: Run Tests
           command: |
             mkdir -p /tmp/logs
-            # Run the tests. Note that we set the "-p 1" flag to tell Go to run tests in each package sequentially. Without
-            # this, Go buffers all log output until all packages are done, which with slower running tests can cause CircleCI
-            # to kill the build after more than 45 minutes without log output.
             DISABLE_TELEMETRY=true run-go-tests --parallelism 4 --timeout 45m | tee /tmp/logs/all.log
           no_output_timeout: 45m
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ version: 2.1
 jobs:
   test:
     <<: *defaults
-    parallelism: 4  # Number of containers to run tests in parallel
+    parallelism: 4  # Adjust based on your CI resource allocation and needs
     steps:
       - checkout
       - run:
@@ -24,7 +24,7 @@ jobs:
       - run:
           name: Run Tests with Splitting
           command: |
-            TESTFILES=$(circleci tests glob "tests/**/*.go")
+            TESTFILES=$(circleci tests glob "**/*.go")
             echo "Test files found: $TESTFILES"
             if [ -z "$TESTFILES" ]; then
               echo "No test files found."
@@ -35,7 +35,7 @@ jobs:
               echo "No test files after split. Possibly an issue with test timings data."
               exit 0
             fi
-            DISABLE_TELEMETRY=true run-go-tests --timeout 45m $TESTFILES | tee /tmp/logs/all.log
+            DISABLE_TELEMETRY=true run-go-tests --extra-flags '--timeout 45m' $TESTFILES | tee /tmp/logs/all.log
           no_output_timeout: 45m
       - run:
           name: Parse Test Output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,26 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Prepare Logs Directory
+          command: mkdir -p /tmp/logs
+      - run:
+          name: Run Tests with Splitting
           command: |
-            TESTFILES=$(circleci tests glob "tests/**/*.go" | circleci tests split --split-by=timings)
-            DISABLE_TELEMETRY=true run-go-tests --timeout 45m ${TESTFILES} | tee /tmp/logs/all.log
+            TESTFILES=$(circleci tests glob "tests/**/*.go")
+            echo "Test files found: $TESTFILES"
+            if [ -z "$TESTFILES" ]; then
+              echo "No test files found."
+              exit 0
+            fi
+            TESTFILES=$(echo "$TESTFILES" | circleci tests split --split-by=timings || echo "$TESTFILES" | circleci tests split --split-by=equal)
+            if [ -z "$TESTFILES" ]; then
+              echo "No test files after split. Possibly an issue with test timings data."
+              exit 0
+            fi
+            DISABLE_TELEMETRY=true run-go-tests --timeout 45m $TESTFILES | tee /tmp/logs/all.log
           no_output_timeout: 45m
       - run:
-          name: parse test output
+          name: Parse Test Output
           command: terratest_log_parser --testlog /tmp/logs/all.log --outputdir /tmp/logs
           when: always
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - run:
           name: Build Binaries
           command: |
-            ./build-go-binaries --parallel 1 --app-name cloud-nuke --dest-path bin \
+            build-go-binaries --parallel 1 --app-name cloud-nuke --dest-path bin \
                                 --ld-flags "-X main.VERSION=$CIRCLE_TAG" --os << parameters.os >> --arch << parameters.arch >>
 
   nuke_phx_devops:
@@ -154,6 +154,10 @@ workflows:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
       - build:
+          matrix:
+            parameters:
+              os: [ "linux", "windows", "darwin" ]
+              arch: [ "386", "amd64", "arm64" ]
           filters:
             tags:
               only: /^v.*/
@@ -193,10 +197,3 @@ workflows:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
             - AWS__SANDBOX__circle-ci
-  build_all_combinations:
-    jobs:
-      - build:
-          matrix:
-            parameters:
-              os: [ "linux", "windows", "darwin" ]
-              arch: [ "386", "amd64", "arm64" ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,15 +15,13 @@ version: 2.1
 jobs:
   test:
     <<: *defaults
+    parallelism: 4  # Number of containers to run tests in parallel
     steps:
       - checkout
       - run:
           command: |
-            mkdir -p /tmp/logs
-            # Run the tests. Note that we set the "-p 1" flag to tell Go to run tests in each package sequentially. Without
-            # this, Go buffers all log output until all packages are done, which with slower running tests can cause CircleCI
-            # to kill the build after more than 45 minutes without log output.
-            DISABLE_TELEMETRY=true run-go-tests --extra-flags '-p 1' --timeout 45m | tee /tmp/logs/all.log
+            TESTFILES=$(circleci tests glob "tests/**/*.go" | circleci tests split --split-by=timings)
+            DISABLE_TELEMETRY=true run-go-tests --extra-flags '-p 1' --timeout 45m ${TESTFILES} | tee /tmp/logs/all.log
           no_output_timeout: 45m
       - run:
           name: parse test output
@@ -36,12 +34,16 @@ jobs:
 
   build:
     <<: *defaults
+    parallelism: 4  # Adjust based on your resource capacity and needs
     steps:
       - checkout
-      - run: build-go-binaries --parallel 2 --app-name cloud-nuke --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG"
+      - run:
+          command: build-go-binaries --parallel 4 --app-name cloud-nuke --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG"
       - persist_to_workspace:
           root: .
-          paths: bin
+          paths:
+            bin
+
   nuke_phx_devops:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,18 +22,14 @@ jobs:
           name: Prepare Logs Directory
           command: mkdir -p /tmp/logs
       - run:
-          name: Discover and Split Test Files
+          name: Run Tests
           command: |
-            # Finding all test files under 'aws/resources'
-            TEST_FILES=$(find aws/resources/ -type f -name "*_test.go")
-            # Splitting test files for parallel execution
-            SPLIT_TEST_FILES=$(echo "$TEST_FILES" | circleci tests split --split-by=name)
-            echo "Test files assigned to this container: $SPLIT_TEST_FILES"
-            for FILE in $SPLIT_TEST_FILES; do
-              echo "Running tests for file: $FILE"
-              # Running tests directly on the file
-              go test -v -timeout 45m -parallel 1 $FILE | tee -a /tmp/logs/all.log
-            done
+            mkdir -p /tmp/logs
+            # Run the tests. Note that we set the "-p 1" flag to tell Go to run tests in each package sequentially. Without
+            # this, Go buffers all log output until all packages are done, which with slower running tests can cause CircleCI
+            # to kill the build after more than 45 minutes without log output.
+            DISABLE_TELEMETRY=true run-go-tests --parallelism 4 --timeout 45m | tee /tmp/logs/all.log
+          no_output_timeout: 45m
       - run:
           name: Parse Test Output
           command: terratest_log_parser --testlog /tmp/logs/all.log --outputdir /tmp/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           command: |
             TESTFILES=$(circleci tests glob "tests/**/*.go" | circleci tests split --split-by=timings)
-            DISABLE_TELEMETRY=true run-go-tests --extra-flags '-p 1' --timeout 45m ${TESTFILES} | tee /tmp/logs/all.log
+            DISABLE_TELEMETRY=true run-go-tests --timeout 45m ${TESTFILES} | tee /tmp/logs/all.log
           no_output_timeout: 45m
       - run:
           name: parse test output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,20 +22,10 @@ jobs:
           name: Prepare Logs Directory
           command: mkdir -p /tmp/logs
       - run:
-          name: Run Tests with Splitting
+          name: Run Tests with Parallel Execution
           command: |
-            TESTFILES=$(circleci tests glob "**/*.go")
-            echo "Test files found: $TESTFILES"
-            if [ -z "$TESTFILES" ]; then
-              echo "No test files found."
-              exit 0
-            fi
-            TESTFILES=$(echo "$TESTFILES" | circleci tests split --split-by=timings || echo "$TESTFILES" | circleci tests split --split-by=equal)
-            if [ -z "$TESTFILES" ]; then
-              echo "No test files after split. Possibly an issue with test timings data."
-              exit 0
-            fi
-            DISABLE_TELEMETRY=true run-go-tests --extra-flags '--timeout 45m' $TESTFILES | tee /tmp/logs/all.log
+            DISABLE_TELEMETRY=true run-go-tests --extra-flags '--timeout 45m' --parallelism 4 --packages "./aws/..."
+            | tee /tmp/logs/all.log
           no_output_timeout: 45m
       - run:
           name: Parse Test Output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ env: &env
     MODULE_CI_VERSION: v0.53.3
 
 defaults: &defaults
-  resource_class: large
+  resource_class: medium+
   docker:
     - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.21-tf1.5-tg39.1-pck1.8-ci50.7
 version: 2.1
@@ -46,9 +46,16 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Check Combination
+          command: |
+            if [ "<< parameters.os >>" == "darwin" ] && [ "<< parameters.arch >>" == "386" ]; then
+              echo "Skipping build for darwin/386."
+              circleci-agent step halt
+            fi
+      - run:
           name: Build Binaries
           command: |
-            build-go-binaries --parallel 1 --app-name cloud-nuke --dest-path bin \
+            ./build-go-binaries --parallel 1 --app-name cloud-nuke --dest-path bin \
                                 --ld-flags "-X main.VERSION=$CIRCLE_TAG" --os << parameters.os >> --arch << parameters.arch >>
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,15 +24,16 @@ jobs:
       - run:
           name: Run Tests in Parallel Across Containers
           command: |
-            PACKAGES=$(circleci tests glob "aws/**/*_test.go" | circleci tests split --split-by=timings)
+            PACKAGES=$(circleci tests glob "aws/**/*.go" | grep '_test.go' | sed 's|/[^/]*$||' | sort -u)
+            echo "Unique package paths: $PACKAGES"
             if [ -z "$PACKAGES" ]; then
               echo "No test packages to run."
               exit 0
             fi
-            echo "Running tests on these packages: $PACKAGES"
-            PACKAGES=$(echo "$PACKAGES" | sed 's|/[^/]*$||' | sort -u)  # Convert file paths to package paths and remove duplicates
-            echo "Unique package paths: $PACKAGES"
-            DISABLE_TELEMETRY=true run-go-tests --extra-flags '--timeout 45m' --packages "$PACKAGES"
+            for PACKAGE in $PACKAGES; do
+              echo "Running tests in package: $PACKAGE"
+              go test -v -timeout 45m $PACKAGE
+            done
           no_output_timeout: 45m
       - run:
           name: Parse Test Output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,24 +19,18 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install Git (if necessary)
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y git
-      - run:
           name: Prepare Logs Directory
           command: mkdir -p /tmp/logs
       - run:
           name: Run Tests in Parallel Across Containers
           command: |
-            PACKAGES=$(find . -name "*_test.go" | sed 's|/[^/]*$||' | sort -u)
-            SPLIT_PACKAGES=$(echo $PACKAGES | tr ' ' '\n' | circleci tests split --split-by=timings)
+            PACKAGES=$(find . -type f -name "*_test.go" | sed 's|/[^/]*$||' | sort -u)
+            SPLIT_PACKAGES=$(echo "$PACKAGES" | circleci tests split --split-by=timings)
             echo "Packages to test: $SPLIT_PACKAGES"
             for PACKAGE in $SPLIT_PACKAGES; do
               echo "Running tests in package: $PACKAGE"
-              # Ensuring paths are relative and removing any potential leading './' which might be causing the issue
-              REL_PACKAGE="${PACKAGE#./}"
-              DISABLE_TELEMETRY=true run-go-tests --path "$REL_PACKAGE" --packages "$REL_PACKAGE" | tee -a /tmp/logs/all.log
+              PACKAGE_PATH=$(echo "$PACKAGE" | sed 's|^./||') # Remove leading './' if present
+              DISABLE_TELEMETRY=true ./run-go-tests --path "$PACKAGE_PATH" --packages "$PACKAGE_PATH" | tee -a /tmp/logs/all.log
             done
       - run:
           name: Parse Test Output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       - run:
           name: Build Binaries
           command: |
-            ./build-go-binaries --parallel 1 --app-name cloud-nuke --dest-path bin \
+            build-go-binaries --parallel 1 --app-name cloud-nuke --dest-path bin \
                                 --ld-flags "-X main.VERSION=$CIRCLE_TAG" --os << parameters.os >> --arch << parameters.arch >>
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ version: 2.1
 jobs:
   test:
     <<: *defaults
-    parallelism: 4  # Number of containers to split the tests across
+    parallelism: 4  # Adjust based on how many containers you want to use
     steps:
       - checkout
       - run:
@@ -24,16 +24,16 @@ jobs:
       - run:
           name: Discover and Split Test Files
           command: |
-            # Find all test files under 'aws/resources' and split them by name
-            TEST_FILES=$(find aws/resources/ -type f -name "*_test.go" | sort -u)
+            # Finding all test files under 'aws/resources'
+            TEST_FILES=$(find aws/resources/ -type f -name "*_test.go")
+            # Splitting test files for parallel execution
             SPLIT_TEST_FILES=$(echo "$TEST_FILES" | circleci tests split --split-by=name)
             echo "Test files assigned to this container: $SPLIT_TEST_FILES"
             for FILE in $SPLIT_TEST_FILES; do
-              # Extract the directory path from each file and run tests in those directories
-              DIR=$(dirname $FILE)
-              echo "Running tests in directory: $DIR"
-              DISABLE_TELEMETRY=true run-go-tests --path "$DIR" --packages "./$DIR"
-            done | tee /tmp/logs/all.log
+              echo "Running tests for file: $FILE"
+              # Running tests directly on the file
+              go test -v -timeout 45m -parallel 1 $FILE | tee -a /tmp/logs/all.log
+            done
       - run:
           name: Parse Test Output
           command: terratest_log_parser --testlog /tmp/logs/all.log --outputdir /tmp/logs
@@ -41,7 +41,7 @@ jobs:
       - store_artifacts:
           path: /tmp/logs
       - store_test_results:
-          path: /tmp/logss
+          path: /tmp/logs
 
   build:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,14 +24,15 @@ jobs:
       - run:
           name: Run Tests in Parallel Across Containers
           command: |
-            TESTFILES=$(circleci tests glob "**/*.go" | circleci tests split --split-by=timings)
-            if [ -z "$TESTFILES" ]; then
-              echo "No test files to run."
+            PACKAGES=$(circleci tests glob "aws/**/*_test.go" | circleci tests split --split-by=timings)
+            if [ -z "$PACKAGES" ]; then
+              echo "No test packages to run."
               exit 0
             fi
-            echo "Running tests on these files: $TESTFILES"
-            DISABLE_TELEMETRY=true run-go-tests --extra-flags '--timeout 45m' --parallelism 1 --path $TESTFILES
-            | tee /tmp/logs/all.log
+            echo "Running tests on these packages: $PACKAGES"
+            PACKAGES=$(echo "$PACKAGES" | sed 's|/[^/]*$||' | sort -u)  # Convert file paths to package paths and remove duplicates
+            echo "Unique package paths: $PACKAGES"
+            DISABLE_TELEMETRY=true run-go-tests --extra-flags '--timeout 45m' --packages "$PACKAGES"
           no_output_timeout: 45m
       - run:
           name: Parse Test Output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,15 +37,20 @@ jobs:
 
   build:
     <<: *defaults
-    parallelism: 4  # Adjust based on your resource capacity and needs
+    parameters:
+      os:
+        type: string
+      arch:
+        type: string
+    docker:
+      - image: cimg/go:1.18
     steps:
       - checkout
       - run:
-          command: build-go-binaries --parallel 4 --app-name cloud-nuke --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG"
-      - persist_to_workspace:
-          root: .
-          paths:
-            bin
+          name: Build Binaries
+          command: |
+            ./build-go-binaries --parallel 1 --app-name cloud-nuke --dest-path bin \
+                                --ld-flags "-X main.VERSION=$CIRCLE_TAG" --os << parameters.os >> --arch << parameters.arch >>
 
   nuke_phx_devops:
     <<: *defaults
@@ -188,3 +193,10 @@ workflows:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
             - AWS__SANDBOX__circle-ci
+  build_all_combinations:
+    jobs:
+      - build:
+          matrix:
+            parameters:
+              os: [ "linux", "windows", "darwin" ]
+              arch: [ "386", "amd64", "arm64" ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,26 +15,27 @@ version: 2.1
 jobs:
   test:
     <<: *defaults
-    parallelism: 4  # Using 4 containers
+    parallelism: 4  # Number of containers to split the tests across
     steps:
       - checkout
+      - run:
+          name: Install Git (if necessary)
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y git
       - run:
           name: Prepare Logs Directory
           command: mkdir -p /tmp/logs
       - run:
           name: Run Tests in Parallel Across Containers
           command: |
-            PACKAGES=$(circleci tests glob "aws/**/*.go" | grep '_test.go' | sed 's|/[^/]*$||' | sort -u)
-            echo "Unique package paths: $PACKAGES"
-            if [ -z "$PACKAGES" ]; then
-              echo "No test packages to run."
-              exit 0
-            fi
-            for PACKAGE in $PACKAGES; do
+            PACKAGES=$(find . -name "*_test.go" | sed 's|/[^/]*$||' | sort -u)
+            SPLIT_PACKAGES=$(echo $PACKAGES | tr ' ' '\n' | circleci tests split --split-by=timings)
+            echo "Packages to test: $SPLIT_PACKAGES"
+            for PACKAGE in $SPLIT_PACKAGES; do
               echo "Running tests in package: $PACKAGE"
-              go test -v -timeout 45m $PACKAGE
+              DISABLE_TELEMETRY=true ./run-go-tests --path "$PACKAGE" --packages "./$PACKAGE" | tee -a /tmp/logs/all.log
             done
-          no_output_timeout: 45m
       - run:
           name: Parse Test Output
           command: terratest_log_parser --testlog /tmp/logs/all.log --outputdir /tmp/logs

--- a/aws/resources/ec2_subnet_test.go
+++ b/aws/resources/ec2_subnet_test.go
@@ -88,6 +88,7 @@ func TestEc2Subnets_GetAll(t *testing.T) {
 			expected:  []string{subnet1, subnet2},
 		},
 		"nameExclusionFilter": {
+			ctx: ctx,
 			configObj: config.EC2ResourceType{
 				ResourceType: config.ResourceType{
 					ExcludeRule: config.FilterRule{


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
Following instruction here: https://circleci.com/docs/parallelism-faster-jobs/
Fixes https://github.com/gruntwork-io/cloud-nuke/issues/697

Previously, all tests have been migrated to use mocking. 
We no longer have slow running tests so no need to run sequentially. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

