### PR TITLE
fix issue nuking route53

### DIFF
--- a/aws/resources/route53_hostedzone.go
+++ b/aws/resources/route53_hostedzone.go
@@ -29,6 +29,99 @@ func (r *Route53HostedZone) getAll(c context.Context, configObj config.Config) (
 	return ids, nil
 }
 
+// IMPORTANT:
+// (https://docs.aws.amazon.com/Route53/latest/APIReference/API_DeleteTrafficPolicyInstance.html).
+// Amazon Route 53 will delete the resource record set automatically. If you delete the resource record set by using ChangeResourceRecordSets,
+// Route 53 doesn't automatically delete the traffic policy instance, and you'll continue to be charged for it even though it's no longer in use.
+func (r *Route53HostedZone) nukeTrafficPolicy(id *string) (err error) {
+	logging.Debugf("[Traffic Policy] nuking the traffic policy attached with the hosted zone")
+
+	_, err = r.Client.DeleteTrafficPolicyInstance(&route53.DeleteTrafficPolicyInstanceInput{
+		Id: id,
+	})
+	return err
+}
+
+func (r *Route53HostedZone) nukeHostedZone(id *string) (err error) {
+
+	_, err = r.Client.DeleteHostedZoneWithContext(r.Context, &route53.DeleteHostedZoneInput{
+		Id: id,
+	})
+
+	return err
+}
+
+func (r *Route53HostedZone) nukeRecordSet(id *string) (err error) {
+
+	// get the resource records
+	output, err := r.Client.ListResourceRecordSets(&route53.ListResourceRecordSetsInput{
+		HostedZoneId: id,
+	})
+	if err != nil {
+		logging.Errorf("[Failed] unable to list resource record set: %s", err)
+		return err
+	}
+
+	var changes []*route53.Change
+	for _, record := range output.ResourceRecordSets {
+		if aws.StringValue(record.Type) == "NS" || aws.StringValue(record.Type) == "SOA" {
+			logging.Infof("[Skipping] resource record set type is : %s", aws.StringValue(record.Type))
+			continue
+		}
+
+		// Note : the request shoud contain exactly one of [AliasTarget, all of [TTL, and ResourceRecords], or TrafficPolicyInstanceId]
+		if record.TrafficPolicyInstanceId != nil {
+			// nuke the traffic policy
+			err := r.nukeTrafficPolicy(record.TrafficPolicyInstanceId)
+			if err != nil {
+				logging.Errorf("[Failed] unable to nuke traffic policy: %s", err)
+				return err
+			}
+
+			record.ResourceRecords = nil
+		}
+
+		// set the changes slice
+		changes = append(changes, &route53.Change{
+			Action:            aws.String("DELETE"),
+			ResourceRecordSet: record,
+		})
+	}
+
+	if len(changes) > 0 {
+		_, err = r.Client.ChangeResourceRecordSets(&route53.ChangeResourceRecordSetsInput{
+			HostedZoneId: id,
+			ChangeBatch: &route53.ChangeBatch{
+				Changes: changes,
+			},
+		})
+
+		if err != nil {
+			logging.Errorf("[Failed] unable to nuke resource record set: %s", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *Route53HostedZone) nuke(id *string) (err error) {
+
+	err = r.nukeRecordSet(id)
+	if err != nil {
+		logging.Errorf("[Failed] unable to nuke record sets: %s", err)
+		return err
+	}
+
+	err = r.nukeHostedZone(id)
+	if err != nil {
+		logging.Errorf("[Failed] unable to nuke hosted zone: %s", err)
+		return err
+	}
+
+	return nil
+}
+
 func (r *Route53HostedZone) nukeAll(identifiers []*string) (err error) {
 	if len(identifiers) == 0 {
 		logging.Debugf("No Route53 Hosted Zones to nuke in region %s", r.Region)
@@ -38,10 +131,8 @@ func (r *Route53HostedZone) nukeAll(identifiers []*string) (err error) {
 
 	var deletedIds []*string
 	for _, id := range identifiers {
-		_, err := r.Client.DeleteHostedZoneWithContext(r.Context, &route53.DeleteHostedZoneInput{
-			Id: id,
-		})
 
+		err = r.nuke(id)
 		// Record status of this resource
 		e := report.Entry{
 			Identifier:   aws.StringValue(id),

--- a/aws/resources/route53_hostedzone_test.go
+++ b/aws/resources/route53_hostedzone_test.go
@@ -16,16 +16,30 @@ import (
 
 type mockedR53HostedZone struct {
 	route53iface.Route53API
-	ListHostedZonesOutput  route53.ListHostedZonesOutput
-	DeleteHostedZoneOutput route53.DeleteHostedZoneOutput
+	ListResourceRecordSetsOutput      route53.ListResourceRecordSetsOutput
+	ChangeResourceRecordSetsOutput    route53.ChangeResourceRecordSetsOutput
+	ListHostedZonesOutput             route53.ListHostedZonesOutput
+	DeleteHostedZoneOutput            route53.DeleteHostedZoneOutput
+	DeleteTrafficPolicyInstanceOutput route53.DeleteTrafficPolicyInstanceOutput
 }
 
 func (mock mockedR53HostedZone) ListHostedZonesWithContext(_ awsgo.Context, _ *route53.ListHostedZonesInput, _ ...request.Option) (*route53.ListHostedZonesOutput, error) {
 	return &mock.ListHostedZonesOutput, nil
 }
 
+func (mock mockedR53HostedZone) ListResourceRecordSets(*route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error) {
+	return &mock.ListResourceRecordSetsOutput, nil
+}
+func (mock mockedR53HostedZone) ChangeResourceRecordSets(*route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+	return &mock.ChangeResourceRecordSetsOutput, nil
+}
+
 func (mock mockedR53HostedZone) DeleteHostedZoneWithContext(_ awsgo.Context, _ *route53.DeleteHostedZoneInput, _ ...request.Option) (*route53.DeleteHostedZoneOutput, error) {
 	return &mock.DeleteHostedZoneOutput, nil
+}
+
+func (mock mockedR53HostedZone) DeleteTrafficPolicyInstance(*route53.DeleteTrafficPolicyInstanceInput) (*route53.DeleteTrafficPolicyInstanceOutput, error) {
+	return &mock.DeleteTrafficPolicyInstanceOutput, nil
 }
 
 func TestR53HostedZone_GetAll(t *testing.T) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/704.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

