### PR TITLE
Updated build flags to produce only requested binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,12 +52,16 @@ jobs:
               echo "Skipping build for darwin/386."
               circleci-agent step halt
             fi
+            if [ "<< parameters.os >>" == "windows" ] && [ "<< parameters.arch >>" == "arm64" ]; then
+              echo "Skipping build for windows/arm64, not valid build platform."
+              circleci-agent step halt
+            fi
       - checkout
       - run:
           name: Build Binaries
           command: |
-            build-go-binaries --parallel 1 --app-name cloud-nuke --dest-path bin \
-                                --ld-flags "-X main.VERSION=$CIRCLE_TAG" --os << parameters.os >> --arch << parameters.arch >>
+            build-go-binaries --osarch "<< parameters.os >>/<< parameters.arch >>" --os << parameters.os >> --arch << parameters.arch >> --parallel 1 --app-name cloud-nuke --dest-path bin \
+                                --ld-flags "-X main.VERSION=$CIRCLE_TAG"  --os << parameters.os >> --arch << parameters.arch >>
       - persist_to_workspace:
           root: .
           paths: bin


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updated `build-go-binaries` arguments to build only requested OS/Arch binaries
Excluded `windows/arm64` since the build is failing with "not valid build platform"

Result:

![image](https://github.com/gruntwork-io/cloud-nuke/assets/10694338/3c8b7143-d9c7-4223-8581-e4a1853d9b8f)


Fixes #707.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

