### PR TITLE
Change Route53 resources to global resource

### DIFF
--- a/aws/resource_registry.go
+++ b/aws/resource_registry.go
@@ -40,6 +40,9 @@ func getRegisteredGlobalResources() []AwsResource {
 		&resources.IAMRoles{},
 		&resources.IAMServiceLinkedRoles{},
 		&resources.OIDCProviders{},
+		&resources.Route53HostedZone{},
+		&resources.Route53CidrCollection{},
+		&resources.Route53TrafficPolicy{},
 	}
 }
 
@@ -129,9 +132,6 @@ func getRegisteredRegionalResources() []AwsResource {
 		&resources.EC2IPAMByoasn{},
 		&resources.EC2IPAMCustomAllocation{},
 		&resources.EC2Subnet{},
-		&resources.Route53HostedZone{},
-		&resources.Route53CidrCollection{},
-		&resources.Route53TrafficPolicy{},
 		&resources.InternetGateway{},
 		&resources.NetworkInterface{},
 		&resources.SecurityGroup{},

--- a/aws/resources/route53_cidr_collection.go
+++ b/aws/resources/route53_cidr_collection.go
@@ -48,13 +48,15 @@ func (r *Route53CidrCollection) nukeCidrLocations(id *string) (err error) {
 		})
 	}
 
-	_, err = r.Client.ChangeCidrCollectionWithContext(r.Context, &route53.ChangeCidrCollectionInput{
-		Id:      id,
-		Changes: changes,
-	})
-	if err != nil {
-		logging.Errorf("[Failed] unable to list cidr collections: %v", err)
-		return err
+	if len(changes) > 0 {
+		_, err = r.Client.ChangeCidrCollectionWithContext(r.Context, &route53.ChangeCidrCollectionInput{
+			Id:      id,
+			Changes: changes,
+		})
+		if err != nil {
+			logging.Errorf("[Failed] unable to list cidr collections: %v", err)
+			return err
+		}
 	}
 
 	logging.Debugf("[Route53 CIDR location] Successfully nuked cidr location(s)")
@@ -63,10 +65,10 @@ func (r *Route53CidrCollection) nukeCidrLocations(id *string) (err error) {
 
 func (r *Route53CidrCollection) nukeAll(identifiers []*string) (err error) {
 	if len(identifiers) == 0 {
-		logging.Debugf("No Route53 Cidr collection to nuke in region %s", r.Region)
+		logging.Debugf("No Route53 Cidr collection to nuke")
 		return nil
 	}
-	logging.Debugf("Deleting all Route53 Cidr collection in region %s", r.Region)
+	logging.Debugf("Deleting all Route53 Cidr collection")
 
 	var deletedIds []*string
 	for _, id := range identifiers {
@@ -105,7 +107,7 @@ func (r *Route53CidrCollection) nukeAll(identifiers []*string) (err error) {
 		}
 	}
 
-	logging.Debugf("[OK] %d Route53 cidr collection(s) deleted in %s", len(deletedIds), r.Region)
+	logging.Debugf("[OK] %d Route53 cidr collection(s) deleted", len(deletedIds))
 
 	return nil
 }

--- a/aws/resources/route53_hostedzone.go
+++ b/aws/resources/route53_hostedzone.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/report"
 )
 
-func (r *Route53HostedZone) getAll(c context.Context, configObj config.Config) ([]*string, error) {
+func (r *Route53HostedZone) getAll(_ context.Context, configObj config.Config) ([]*string, error) {
 	var ids []*string
 
 	result, err := r.Client.ListHostedZonesWithContext(r.Context, &route53.ListHostedZonesInput{})


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/705.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

