### PR TITLE
fix: active ruleset wont able to nuke

### DIFF
--- a/aws/resources/ses_email_receiving_test.go
+++ b/aws/resources/ses_email_receiving_test.go
@@ -19,6 +19,7 @@ type mockedSesReceiptRule struct {
 	sesiface.SESAPI
 	DeleteReceiptRuleSetOutput ses.DeleteReceiptRuleSetOutput
 	ListReceiptRuleSetsOutput  ses.ListReceiptRuleSetsOutput
+	DescribeActiveReceiptRuleSetOutput  ses.DescribeActiveReceiptRuleSetOutput
 }
 
 func (m mockedSesReceiptRule) ListReceiptRuleSetsWithContext(_ awsgo.Context, _ *ses.ListReceiptRuleSetsInput, _ ...request.Option) (*ses.ListReceiptRuleSetsOutput, error) {
@@ -27,6 +28,10 @@ func (m mockedSesReceiptRule) ListReceiptRuleSetsWithContext(_ awsgo.Context, _ 
 
 func (m mockedSesReceiptRule) DeleteReceiptRuleSetWithContext(_ awsgo.Context, _ *ses.DeleteReceiptRuleSetInput, _ ...request.Option) (*ses.DeleteReceiptRuleSetOutput, error) {
 	return &m.DeleteReceiptRuleSetOutput, nil
+}
+
+func (m mockedSesReceiptRule) DescribeActiveReceiptRuleSetWithContext(_ awsgo.Context, _ *ses.DescribeActiveReceiptRuleSetInput, _ ...request.Option) (*ses.DescribeActiveReceiptRuleSetOutput, error) {
+	return &m.DescribeActiveReceiptRuleSetOutput, nil
 }
 
 func TestSesReceiptRule_GetAll(t *testing.T) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

