### PR TITLE
Fixing dhcp nuke failing

### DIFF
--- a/aws/resources/ec2_dhcp_option.go
+++ b/aws/resources/ec2_dhcp_option.go
@@ -17,10 +17,44 @@ func (v *EC2DhcpOption) getAll(_ context.Context, configObj config.Config) ([]*s
 	var dhcpOptionIds []*string
 	err := v.Client.DescribeDhcpOptionsPagesWithContext(v.Context, &ec2.DescribeDhcpOptionsInput{}, func(page *ec2.DescribeDhcpOptionsOutput, lastPage bool) bool {
 		for _, dhcpOption := range page.DhcpOptions {
-			// No specific filters to apply at this point, we can think about introducing
-			// filtering with name tag in the future. In the initial version, we just getAll
-			// without filtering.
-			dhcpOptionIds = append(dhcpOptionIds, dhcpOption.DhcpOptionsId)
+			var isEligibleForNuke = true
+
+			// check the dhcp is attached with any vpc
+			// if the vpc is default one, then omit the dhcp option id from result
+			vpcs, err := v.Client.DescribeVpcsWithContext(v.Context, &ec2.DescribeVpcsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   awsgo.String("dhcp-options-id"),
+						Values: []*string{dhcpOption.DhcpOptionsId},
+					},
+				},
+			})
+			if err != nil {
+				logging.Debugf("[Failed] %s", err)
+				continue
+			}
+
+			for _, vpc := range vpcs.Vpcs {
+				// check the vpc is the default one then set isEligible false as we dont need to remove the dhcp option of default vpc
+				if awsgo.BoolValue(vpc.IsDefault) {
+					logging.Debugf("[Skipping] %s is attached with a default vpc %s", awsgo.StringValue(dhcpOption.DhcpOptionsId), awsgo.StringValue(vpc.VpcId))
+					isEligibleForNuke = false
+				}
+
+				v.DhcpOptions[awsgo.StringValue(dhcpOption.DhcpOptionsId)] = DHCPOption{
+					Id:    dhcpOption.DhcpOptionsId,
+					VpcId: vpc.VpcId,
+				}
+
+			}
+
+			if isEligibleForNuke {
+				// No specific filters to apply at this point, we can think about introducing
+				// filtering with name tag in the future. In the initial version, we just getAll
+				// without filtering.
+				dhcpOptionIds = append(dhcpOptionIds, dhcpOption.DhcpOptionsId)
+
+			}
 		}
 
 		return !lastPage
@@ -42,6 +76,40 @@ func (v *EC2DhcpOption) getAll(_ context.Context, configObj config.Config) ([]*s
 	return dhcpOptionIds, nil
 }
 
+func (v *EC2DhcpOption) disAssociatedAttachedVpcs(identifier *string) error {
+	if option, ok := v.DhcpOptions[awsgo.StringValue(identifier)]; ok {
+		logging.Debugf("[disAssociatedAttachedVpcs] detaching the dhcp option %s from %v", awsgo.StringValue(identifier), awsgo.StringValue(option.VpcId))
+
+		_, err := v.Client.AssociateDhcpOptionsWithContext(v.Context, &ec2.AssociateDhcpOptionsInput{
+			VpcId: option.VpcId,
+			DhcpOptionsId: awsgo.String("default"), // The ID of the DHCP options set, or default to associate no DHCP options with the VPC.
+		})
+		if err != nil {
+			logging.Debugf("[Failed] %s", err)
+			return errors.WithStackTrace(err)
+		}
+		logging.Debugf("[disAssociatedAttachedVpcs] Success dhcp option %s detached from %v", awsgo.StringValue(identifier), awsgo.StringValue(option.VpcId))
+	}
+
+	return nil
+}
+
+func (v *EC2DhcpOption) nuke(identifier *string) error {
+
+	err := v.disAssociatedAttachedVpcs(identifier)
+	if err != nil {
+		logging.Debugf("[disAssociatedAttachedVpcs] Failed %s", err)
+		return errors.WithStackTrace(err)
+	}
+
+	err = nukeDhcpOption(v.Client, identifier)
+	if err != nil {
+		logging.Debugf("[nukeDhcpOption] Failed %s", err)
+		return errors.WithStackTrace(err)
+	}
+	return nil
+}
+
 func (v *EC2DhcpOption) nukeAll(identifiers []*string) error {
 	for _, identifier := range identifiers {
 		if nukable, reason := v.IsNukable(awsgo.StringValue(identifier)); !nukable {
@@ -49,7 +117,7 @@ func (v *EC2DhcpOption) nukeAll(identifiers []*string) error {
 			continue
 		}
 
-		err := nukeDhcpOption(v.Client, identifier)
+		err := v.nuke(identifier)
 		if err != nil {
 			logging.Debugf("Failed to delete DHCP option w/ err: %s.", err)
 		} else {

--- a/aws/resources/ec2_dhcp_option_test.go
+++ b/aws/resources/ec2_dhcp_option_test.go
@@ -16,6 +16,8 @@ type mockedEC2DhcpOption struct {
 	ec2iface.EC2API
 	DescribeDhcpOptionsOutput ec2.DescribeDhcpOptionsOutput
 	DeleteDhcpOptionsOutput   ec2.DeleteDhcpOptionsOutput
+	DescribeVpcsOutput   ec2.DescribeVpcsOutput
+	AssociateDhcpOptionsOutput   ec2.AssociateDhcpOptionsOutput
 }
 
 func (m mockedEC2DhcpOption) DescribeDhcpOptionsPagesWithContext(_ awsgo.Context, _ *ec2.DescribeDhcpOptionsInput, fn func(*ec2.DescribeDhcpOptionsOutput, bool) bool, _ ...request.Option) error {
@@ -29,6 +31,13 @@ func (m mockedEC2DhcpOption) DeleteDhcpOptions(_ *ec2.DeleteDhcpOptionsInput) (*
 
 func (m mockedEC2DhcpOption) DeleteDhcpOptionsWithContext(_ awsgo.Context, _ *ec2.DeleteDhcpOptionsInput, _ ...request.Option) (*ec2.DeleteDhcpOptionsOutput, error) {
 	return &m.DeleteDhcpOptionsOutput, nil
+}
+
+func (m mockedEC2DhcpOption) DescribeVpcsWithContext(awsgo.Context, *ec2.DescribeVpcsInput, ...request.Option) (*ec2.DescribeVpcsOutput, error) {
+	return &m.DescribeVpcsOutput, nil
+}
+func (m mockedEC2DhcpOption) AssociateDhcpOptionsWithContext(awsgo.Context, *ec2.AssociateDhcpOptionsInput, ...request.Option) (*ec2.AssociateDhcpOptionsOutput, error){
+	return &m.AssociateDhcpOptionsOutput, nil
 }
 
 func TestEC2DhcpOption_GetAll(t *testing.T) {

--- a/aws/resources/ec2_dhcp_option_types.go
+++ b/aws/resources/ec2_dhcp_option_types.go
@@ -11,15 +11,22 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+type DHCPOption struct {
+	Id    *string
+	VpcId *string
+}
+
 type EC2DhcpOption struct {
 	BaseAwsResource
 	Client ec2iface.EC2API
 	Region string
 	VPCIds []string
+	DhcpOptions map[string]DHCPOption
 }
 
 func (v *EC2DhcpOption) Init(session *session.Session) {
 	v.Client = ec2.New(session)
+	v.DhcpOptions = make(map[string]DHCPOption)
 }
 
 // ResourceName - the simple name of the aws resource


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixing DHCP nuke failing issues: 

```
Failed to delete DHCP option w/ err: DependencyViolation: The dhcpOptions 'dopt-286d8b41' has dependencies and cannot be deleted.
```

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

