### PR TITLE
Nuke only interface type ec2 network

### DIFF
--- a/aws/resources/ec2_network_interface_test.go
+++ b/aws/resources/ec2_network_interface_test.go
@@ -72,6 +72,7 @@ func TestNetworkInterface_GetAll(t *testing.T) {
 				NetworkInterfaces: []*ec2.NetworkInterface{
 					{
 						NetworkInterfaceId: awsgo.String(testId1),
+						InterfaceType:      awsgo.String(NetworkInterfaceTypeInterface),
 						TagSet: []*ec2.Tag{
 							{
 								Key:   awsgo.String("Name"),
@@ -85,6 +86,7 @@ func TestNetworkInterface_GetAll(t *testing.T) {
 					},
 					{
 						NetworkInterfaceId: awsgo.String(testId2),
+						InterfaceType:      awsgo.String(NetworkInterfaceTypeInterface),
 						TagSet: []*ec2.Tag{
 							{
 								Key:   awsgo.String("Name"),
@@ -180,6 +182,7 @@ func TestNetworkInterface_NukeAll(t *testing.T) {
 				NetworkInterfaces: []*ec2.NetworkInterface{
 					{
 						NetworkInterfaceId: awsgo.String(testId1),
+						InterfaceType:      awsgo.String(NetworkInterfaceTypeInterface),
 						TagSet: []*ec2.Tag{
 							{
 								Key:   awsgo.String("Name"),
@@ -193,6 +196,7 @@ func TestNetworkInterface_NukeAll(t *testing.T) {
 					},
 					{
 						NetworkInterfaceId: awsgo.String(testId2),
+						InterfaceType:      awsgo.String(NetworkInterfaceTypeInterface),
 						TagSet: []*ec2.Tag{
 							{
 								Key:   awsgo.String("Name"),

--- a/aws/resources/ec2_network_interface_types.go
+++ b/aws/resources/ec2_network_interface_types.go
@@ -11,6 +11,10 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+const (
+	NetworkInterfaceTypeInterface = "interface"
+)
+
 type NetworkInterface struct {
 	BaseAwsResource
 	Client       ec2iface.EC2API


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/731.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

