### PR TITLE
Remove AMI created from the snapshot when nuking

### DIFF
--- a/aws/resources/snapshot.go
+++ b/aws/resources/snapshot.go
@@ -69,6 +69,60 @@ func SnapshotHasAWSBackupTag(tags []*ec2.Tag) bool {
 	return false
 }
 
+func (s *Snapshots) nuke(id *string) error {
+
+	if err := s.nukeAMI(id); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	if err := s.nukeSnapshot(id); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+func (s *Snapshots) nukeSnapshot(snapshotID *string) error {
+	_, err := s.Client.DeleteSnapshotWithContext(s.Context, &ec2.DeleteSnapshotInput{
+		SnapshotId: snapshotID,
+	})
+	return err
+}
+
+// nuke AMI which created from the snapshot
+func (s *Snapshots) nukeAMI(snapshotID *string) error {
+	logging.Debugf("De-registering images for snapshot: %s", awsgo.StringValue(snapshotID))
+
+	output, err := s.Client.DescribeImagesWithContext(s.Context, &ec2.DescribeImagesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   awsgo.String("block-device-mapping.snapshot-id"),
+				Values: []*string{snapshotID},
+			},
+		},
+	})
+
+	if err != nil {
+		logging.Debugf("[Describe Images] Failed to describe images for snapshot: %s", awsgo.StringValue(snapshotID))
+		return err
+	}
+
+	for _, image := range output.Images {
+		_, err := s.Client.DeregisterImageWithContext(s.Context, &ec2.DeregisterImageInput{
+			ImageId: image.ImageId,
+		})
+
+		if err != nil {
+			logging.Debugf("[Failed] de-registering image %v for snapshot: %s", awsgo.StringValue(image.ImageId), awsgo.StringValue(snapshotID))
+			return err
+		}
+	}
+
+	logging.Debugf("[Ok] De-registered all the images for snapshot: %s", awsgo.StringValue(snapshotID))
+
+	return nil
+}
+
 // Deletes all Snapshots
 func (s *Snapshots) nukeAll(snapshotIds []*string) error {
 
@@ -87,9 +141,7 @@ func (s *Snapshots) nukeAll(snapshotIds []*string) error {
 			continue
 		}
 
-		_, err := s.Client.DeleteSnapshotWithContext(s.Context, &ec2.DeleteSnapshotInput{
-			SnapshotId: snapshotID,
-		})
+		err := s.nuke(snapshotID)
 
 		// Record status of this resource
 		e := report.Entry{

--- a/aws/resources/snapshot_test.go
+++ b/aws/resources/snapshot_test.go
@@ -19,6 +19,8 @@ type mockedSnapshot struct {
 	ec2iface.EC2API
 	DeleteSnapshotOutput    ec2.DeleteSnapshotOutput
 	DescribeSnapshotsOutput ec2.DescribeSnapshotsOutput
+	DescribeImagesOutput    ec2.DescribeImagesOutput
+	DeregisterImageOutput   ec2.DeregisterImageOutput
 }
 
 func (m mockedSnapshot) DeleteSnapshotWithContext(_ awsgo.Context, _ *ec2.DeleteSnapshotInput, _ ...request.Option) (*ec2.DeleteSnapshotOutput, error) {
@@ -27,6 +29,12 @@ func (m mockedSnapshot) DeleteSnapshotWithContext(_ awsgo.Context, _ *ec2.Delete
 
 func (m mockedSnapshot) DescribeSnapshotsWithContext(_ awsgo.Context, _ *ec2.DescribeSnapshotsInput, _ ...request.Option) (*ec2.DescribeSnapshotsOutput, error) {
 	return &m.DescribeSnapshotsOutput, nil
+}
+func (m mockedSnapshot) DescribeImagesWithContext(awsgo.Context, *ec2.DescribeImagesInput, ...request.Option) (*ec2.DescribeImagesOutput, error) {
+	return &m.DescribeImagesOutput, nil
+}
+func (m mockedSnapshot) DeregisterImageWithContext(awsgo.Context, *ec2.DeregisterImageInput, ...request.Option) (*ec2.DeregisterImageOutput, error) {
+	return &m.DeregisterImageOutput, nil
 }
 
 func TestSnapshot_GetAll(t *testing.T) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/727.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

