### PR TITLE
[fix] skip API GW stage certyficates when `ClientCertificateId` is ni…

### DIFF
--- a/aws/resources/apigateway.go
+++ b/aws/resources/apigateway.go
@@ -82,6 +82,10 @@ func (gateway *ApiGateway) getAttachedStageClientCerts(apigwID *string) ([]*stri
 	}
 	// get the stages attached client certificates
 	for _, stage := range stages.Item {
+		if stage.ClientCertificateId == nil {
+			logging.Debugf("Skipping certyficate for stage %s, certyficate ID is nil", *stage.StageName)
+			continue
+		}
 		clientCerts = append(clientCerts, stage.ClientCertificateId)
 	}
 	return clientCerts, nil


### PR DESCRIPTION
## Description

Fixes #739 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

Fix **panic** when deleting `API GW stage` **certificate**  for AWS mng domains.

### Migration Guide

n/a

