### PR TITLE
Legacy checks removal

### DIFF
--- a/aws/resources/kms_customer_key.go
+++ b/aws/resources/kms_customer_key.go
@@ -61,11 +61,6 @@ func (kck *KmsCustomerKeys) getAll(c context.Context, configObj config.Config) (
 	for _, keyId := range keys {
 		resultsChan[id] = make(chan *KmsCheckIncludeResult, 1)
 
-		if err != nil {
-			logging.Debugf("Can't read KMS key %s", err.Error())
-			continue
-		}
-
 		// If the keyId isn't found in the map, this returns an empty array
 		aliasesForKey := keyAliases[keyId]
 

--- a/aws/resources/lambda_layer.go
+++ b/aws/resources/lambda_layer.go
@@ -119,10 +119,6 @@ func (ll *LambdaLayers) nukeAll(names []*string) error {
 
 		_, err := ll.Client.DeleteLayerVersionWithContext(ll.Context, params)
 
-		if err != nil {
-			return err
-		}
-
 		// Record status of this resource
 		e := report.Entry{
 			Identifier:   aws.StringValue(params.LayerName),

--- a/aws/resources/security_hub.go
+++ b/aws/resources/security_hub.go
@@ -105,7 +105,7 @@ func (sh *SecurityHub) nukeAll(securityHubArns []string) error {
 	}
 
 	// Remove any member accounts if they exist
-	if err == nil && len(memberAccountIds) > 0 {
+	if len(memberAccountIds) > 0 {
 		err = sh.removeMembersFromHub(memberAccountIds)
 		if err != nil {
 			logging.Errorf("[Failed] Failed to disassociate members from security hub")


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
Noticed a couple of invalid checks:
```
aws/resources/kms_customer_key.go:64:10: impossible condition: nil != nil
aws/resources/lambda_layer.go:134:10: impossible condition: nil != nil
aws/resources/security_hub.go:108:9: tautological condition: nil == nil
```



<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Removed legacy code

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

