### PR TITLE
Fixing transit gateway nuke failure

### DIFF
--- a/aws/resources/transit_gateway_test.go
+++ b/aws/resources/transit_gateway_test.go
@@ -16,8 +16,10 @@ import (
 
 type mockedTransitGateway struct {
 	ec2iface.EC2API
-	DescribeTransitGatewaysOutput ec2.DescribeTransitGatewaysOutput
-	DeleteTransitGatewayOutput    ec2.DeleteTransitGatewayOutput
+	DescribeTransitGatewaysOutput               ec2.DescribeTransitGatewaysOutput
+	DeleteTransitGatewayOutput                  ec2.DeleteTransitGatewayOutput
+	DescribeTransitGatewayAttachmentsOutput     ec2.DescribeTransitGatewayAttachmentsOutput
+	DeleteTransitGatewayPeeringAttachmentOutput ec2.DeleteTransitGatewayPeeringAttachmentOutput
 }
 
 func (m mockedTransitGateway) DescribeTransitGatewaysWithContext(_ awsgo.Context, _ *ec2.DescribeTransitGatewaysInput, _ ...request.Option) (*ec2.DescribeTransitGatewaysOutput, error) {
@@ -26,6 +28,17 @@ func (m mockedTransitGateway) DescribeTransitGatewaysWithContext(_ awsgo.Context
 
 func (m mockedTransitGateway) DeleteTransitGatewayWithContext(_ awsgo.Context, _ *ec2.DeleteTransitGatewayInput, _ ...request.Option) (*ec2.DeleteTransitGatewayOutput, error) {
 	return &m.DeleteTransitGatewayOutput, nil
+}
+
+func (m mockedTransitGateway) DescribeTransitGatewayAttachmentsWithContext(awsgo.Context, *ec2.DescribeTransitGatewayAttachmentsInput, ...request.Option) (*ec2.DescribeTransitGatewayAttachmentsOutput, error) {
+	return &m.DescribeTransitGatewayAttachmentsOutput, nil
+}
+
+func (m mockedTransitGateway) DeleteTransitGatewayPeeringAttachmentWithContext(aws.Context, *ec2.DeleteTransitGatewayPeeringAttachmentInput, ...request.Option) (*ec2.DeleteTransitGatewayPeeringAttachmentOutput, error) {
+	return &m.DeleteTransitGatewayPeeringAttachmentOutput, nil
+}
+func (m mockedTransitGateway) WaitUntilTransitGatewayAttachmentDeleted(*string, string) error {
+	return nil
 }
 
 func TestTransitGateways_GetAll(t *testing.T) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/744

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

