### PR TITLE
Improve Failure Message for Insufficient Permission

### DIFF
--- a/aws/resources/cloudtrail.go
+++ b/aws/resources/cloudtrail.go
@@ -50,7 +50,6 @@ func (ct *CloudtrailTrail) nukeAll(arns []*string) error {
 		}
 
 		_, err := ct.Client.DeleteTrailWithContext(ct.Context, params)
-
 		// Record status of this resource
 		e := report.Entry{
 			Identifier:   aws.StringValue(arn),

--- a/util/error.go
+++ b/util/error.go
@@ -18,6 +18,7 @@ var ErrDeleteProtectionEnabled = errors.New("error:DeleteProtectionEnabled")
 var ErrResourceNotFoundException = errors.New("error:ErrResourceNotFoundException")
 
 const AWsUnauthorizedError string = "UnauthorizedOperation"
+const AWSAccessDeniedException string = "AccessDeniedException"
 const AwsDryRunSuccess string = "Request would have succeeded, but DryRun flag is set."
 
 // TransformAWSError
@@ -26,7 +27,7 @@ const AwsDryRunSuccess string = "Request would have succeeded, but DryRun flag i
 // providing a more human-readable error message for certain conditions
 // ref : https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html
 func TransformAWSError(err error) error {
-	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == AWsUnauthorizedError {
+	if awsErr, ok := err.(awserr.Error); ok && (awsErr.Code() == AWsUnauthorizedError || awsErr.Code() == AWSAccessDeniedException) {
 		return ErrInSufficientPermission
 	}
 	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "RequestCanceled" {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/752.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

