### PR TITLE
fix: nuke failure when route53 record NS exists with subdomain

### DIFF
--- a/aws/resources/route53_hostedzone_test.go
+++ b/aws/resources/route53_hostedzone_test.go
@@ -52,6 +52,14 @@ func TestR53HostedZone_GetAll(t *testing.T) {
 	testName1 := "Test name 01"
 	testName2 := "Test name 02"
 	rc := Route53HostedZone{
+		HostedZonesDomains : map[string]*route53.HostedZone{
+			testId1 : &route53.HostedZone{
+				Name : awsgo.String(testName1),
+			},
+			testId2 : &route53.HostedZone{
+				Name : awsgo.String(testName2),
+			},
+		},
 		Client: mockedR53HostedZone{
 			ListHostedZonesOutput: route53.ListHostedZonesOutput{
 				HostedZones: []*route53.HostedZone{
@@ -103,6 +111,11 @@ func TestR53HostedZone_Nuke(t *testing.T) {
 	t.Parallel()
 
 	rc := Route53HostedZone{
+		HostedZonesDomains : map[string]*route53.HostedZone{
+			"collection-id-01" : &route53.HostedZone{
+				Name : awsgo.String("domain.com"),
+			},
+		},
 		Client: mockedR53HostedZone{
 			DeleteHostedZoneOutput: route53.DeleteHostedZoneOutput{},
 		},

--- a/aws/resources/route53_hostedzone_types.go
+++ b/aws/resources/route53_hostedzone_types.go
@@ -17,10 +17,12 @@ type Route53HostedZone struct {
 	Client route53iface.Route53API
 	Region string
 	Ids    []string
+	HostedZonesDomains map[string]*route53.HostedZone
 }
 
 func (r *Route53HostedZone) Init(session *session.Session) {
 	r.Client = route53.New(session)
+	r.HostedZonesDomains = make(map[string]*route53.HostedZone,0)
 }
 
 // ResourceName - the simple name of the aws resource


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

