### PR TITLE
fix: no name tag resources are listing for nuke with include filter

### DIFF
--- a/aws/resources/kms_customer_key.go
+++ b/aws/resources/kms_customer_key.go
@@ -106,7 +106,7 @@ func (kck *KmsCustomerKeys) shouldInclude(
 	includedByName := false
 	// verify if key aliases matches configurations
 	for _, alias := range aliases {
-		if config.ShouldInclude(alias, configObj.KMSCustomerKeys.IncludeRule.NamesRegExp,
+		if config.ShouldInclude(&alias, configObj.KMSCustomerKeys.IncludeRule.NamesRegExp,
 			configObj.KMSCustomerKeys.ExcludeRule.NamesRegExp) {
 			includedByName = true
 		}

--- a/aws/resources/sns.go
+++ b/aws/resources/sns.go
@@ -127,7 +127,7 @@ func shouldIncludeSNS(topicArn string, excludeAfter, firstSeenTime time.Time, co
 		return false
 	}
 
-	return config.ShouldInclude(topicName, configObj.SNS.IncludeRule.NamesRegExp, configObj.SNS.ExcludeRule.NamesRegExp)
+	return config.ShouldInclude(&topicName, configObj.SNS.IncludeRule.NamesRegExp, configObj.SNS.ExcludeRule.NamesRegExp)
 }
 
 func (s *SNSTopic) nukeAll(identifiers []*string) error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -48,7 +48,6 @@ func emptyConfig() *Config {
 		EC2IPAMResourceDiscovery:        ResourceType{FilterRule{}, FilterRule{}, "",false},
 		EC2IPAMScope:                    ResourceType{FilterRule{}, FilterRule{}, "",false},
 		EC2Endpoint:                     ResourceType{FilterRule{}, FilterRule{}, "",false},
-		EC2PlacementGroups:              ResourceType{FilterRule{}, FilterRule{}, "",false},
 		EC2Subnet:                       EC2ResourceType{false, ResourceType{FilterRule{}, FilterRule{}, "",false}},
 		EgressOnlyInternetGateway:       ResourceType{FilterRule{}, FilterRule{}, "",false},
 		ECRRepository:                   ResourceType{FilterRule{}, FilterRule{}, "",false},
@@ -161,7 +160,7 @@ func TestShouldInclude_AllowWhenEmpty(t *testing.T) {
 	var includeREs []Expression
 	var excludeREs []Expression
 
-	assert.True(t, ShouldInclude("test-open-vpn", includeREs, excludeREs),
+	assert.True(t, ShouldInclude(aws.String("test-open-vpn"), includeREs, excludeREs),
 		"Should include when both lists are empty")
 }
 
@@ -172,9 +171,9 @@ func TestShouldInclude_ExcludeWhenMatches(t *testing.T) {
 	require.NoError(t, err)
 	excludeREs := []Expression{{RE: *exclude}}
 
-	assert.False(t, ShouldInclude("test-openvpn-123", includeREs, excludeREs),
+	assert.False(t, ShouldInclude(aws.String("test-openvpn-123"), includeREs, excludeREs),
 		"Should not include when matches from the 'exclude' list")
-	assert.True(t, ShouldInclude("tf-state-bucket", includeREs, excludeREs),
+	assert.True(t, ShouldInclude(aws.String("tf-state-bucket"), includeREs, excludeREs),
 		"Should include when doesn't matches from the 'exclude' list")
 }
 
@@ -185,9 +184,9 @@ func TestShouldInclude_IncludeWhenMatches(t *testing.T) {
 
 	var excludeREs []Expression
 
-	assert.True(t, ShouldInclude("test-openvpn-123", includeREs, excludeREs),
+	assert.True(t, ShouldInclude(aws.String("test-openvpn-123"), includeREs, excludeREs),
 		"Should include when matches the 'include' list")
-	assert.False(t, ShouldInclude("test-vpc-123", includeREs, excludeREs),
+	assert.False(t, ShouldInclude(aws.String("test-vpc-123"), includeREs, excludeREs),
 		"Should not include when doesn't matches the 'include' list")
 }
 
@@ -200,11 +199,11 @@ func TestShouldInclude_WhenMatchesIncludeAndExclude(t *testing.T) {
 	require.NoError(t, err)
 	excludeREs := []Expression{{RE: *exclude}}
 
-	assert.True(t, ShouldInclude("test-eks-cluster-123", includeREs, excludeREs),
+	assert.True(t, ShouldInclude(aws.String("test-eks-cluster-123"), includeREs, excludeREs),
 		"Should include when matches the 'include' list but not matches the 'exclude' list")
-	assert.False(t, ShouldInclude("test-openvpn-123", includeREs, excludeREs),
+	assert.False(t, ShouldInclude(aws.String("test-openvpn-123"), includeREs, excludeREs),
 		"Should not include when matches 'exclude' list")
-	assert.False(t, ShouldInclude("terraform-tf-state", includeREs, excludeREs),
+	assert.False(t, ShouldInclude(aws.String("terraform-tf-state"), includeREs, excludeREs),
 		"Should not include when doesn't matches 'include' list")
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

