### PR TITLE
Fix config rule nuking

### DIFF
--- a/aws/resources/config_service_test.go
+++ b/aws/resources/config_service_test.go
@@ -16,9 +16,10 @@ import (
 
 type mockedConfigServiceRule struct {
 	configserviceiface.ConfigServiceAPI
-	DescribeConfigRulesOutput            configservice.DescribeConfigRulesOutput
-	DeleteConfigRuleOutput               configservice.DeleteConfigRuleOutput
-	DeleteRemediationConfigurationOutput configservice.DeleteRemediationConfigurationOutput
+	DescribeConfigRulesOutput               configservice.DescribeConfigRulesOutput
+	DeleteConfigRuleOutput                  configservice.DeleteConfigRuleOutput
+	DeleteRemediationConfigurationOutput    configservice.DeleteRemediationConfigurationOutput
+	DescribeRemediationConfigurationsOutput configservice.DescribeRemediationConfigurationsOutput
 }
 
 func (m mockedConfigServiceRule) DescribeConfigRulesPagesWithContext(_ awsgo.Context, _ *configservice.DescribeConfigRulesInput, fn func(*configservice.DescribeConfigRulesOutput, bool) bool, _ ...request.Option) error {
@@ -32,6 +33,10 @@ func (m mockedConfigServiceRule) DeleteConfigRuleWithContext(_ awsgo.Context, _ 
 
 func (m mockedConfigServiceRule) DeleteRemediationConfigurationWithContext(_ awsgo.Context, _ *configservice.DeleteRemediationConfigurationInput, _ ...request.Option) (*configservice.DeleteRemediationConfigurationOutput, error) {
 	return &m.DeleteRemediationConfigurationOutput, nil
+}
+
+func (m mockedConfigServiceRule) DescribeRemediationConfigurationsWithContext(_ awsgo.Context, _ *configservice.DescribeRemediationConfigurationsInput, _ ...request.Option) (*configservice.DescribeRemediationConfigurationsOutput, error) {
+	return &m.DescribeRemediationConfigurationsOutput, nil
 }
 
 func TestConfigServiceRule_GetAll(t *testing.T) {
@@ -87,8 +92,9 @@ func TestConfigServiceRule_NukeAll(t *testing.T) {
 
 	csr := ConfigServiceRule{
 		Client: mockedConfigServiceRule{
-			DeleteConfigRuleOutput:               configservice.DeleteConfigRuleOutput{},
-			DeleteRemediationConfigurationOutput: configservice.DeleteRemediationConfigurationOutput{},
+			DeleteConfigRuleOutput:                  configservice.DeleteConfigRuleOutput{},
+			DeleteRemediationConfigurationOutput:    configservice.DeleteRemediationConfigurationOutput{},
+			DescribeRemediationConfigurationsOutput: configservice.DescribeRemediationConfigurationsOutput{},
 		},
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Nuking config rules fails if there is no remediation config. Add step to check existence of remediation configs before nuking.

```
# Found AWS Resources
┌─────────────────────────────────────────────────────────────────────────────────┐
| Resource Type    | Region         | Identifier                        | Nukable |
| ------------------------------------------------------------------------------- |
| config-rules     | ap-southeast-2 | encrypted-volumes                 | -       |
└─────────────────────────────────────────────────────────────────────────────────┘

 WARNING  THE NEXT STEPS ARE DESTRUCTIVE AND COMPLETELY IRREVERSIBLE, PROCEED WITH CAUTION!!!

Are you sure you want to nuke all listed resources? Enter 'nuke' to confirm (or exit with ^C) : nuke
  ERROR   Failed to delete remediation configuration w/ err NoSuchRemediationConfigurationException: No RemediationConfiguration for rule encrypted-volumes exists
```

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

