### PR TITLE
fix: iam user exclude not working

### DIFF
--- a/aws/resources/iam_test.go
+++ b/aws/resources/iam_test.go
@@ -37,6 +37,7 @@ type mockedIAMUsers struct {
 	DeactivateMFADeviceOutput             iam.DeactivateMFADeviceOutput
 	DeleteVirtualMFADeviceOutput          iam.DeleteVirtualMFADeviceOutput
 	DeleteUserOutput                      iam.DeleteUserOutput
+	ListUserTagsOutput                    iam.ListUserTagsOutput
 }
 
 func (m mockedIAMUsers) ListUsersPagesWithContext(_ aws.Context, input *iam.ListUsersInput, callback func(*iam.ListUsersOutput, bool) bool, _ ...request.Option) error {
@@ -118,6 +119,10 @@ func (m mockedIAMUsers) DeleteVirtualMFADeviceWithContext(_ aws.Context, input *
 
 func (m mockedIAMUsers) DeleteUserWithContext(_ aws.Context, input *iam.DeleteUserInput, _ ...request.Option) (*iam.DeleteUserOutput, error) {
 	return &m.DeleteUserOutput, nil
+}
+func (m mockedIAMUsers) ListUserTagsPagesWithContext(_ aws.Context, input *iam.ListUserTagsInput, callback func(*iam.ListUserTagsOutput, bool) bool, _ ...request.Option) error {
+	callback(&m.ListUserTagsOutput, true)
+	return nil
 }
 
 func TestIAMUsers_GetAll(t *testing.T) {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/763

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

