### PR TITLE
change port iam, iam-group, iam-policy, iam-role, iam-service-linked-role to awsSDKv2

### DIFF
--- a/aws/resources/iam_group.go
+++ b/aws/resources/iam_group.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"sync"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
@@ -15,23 +15,21 @@ import (
 
 func (ig *IAMGroups) getAll(c context.Context, configObj config.Config) ([]*string, error) {
 	var allIamGroups []*string
-	err := ig.Client.ListGroupsPagesWithContext(
-		ig.Context,
-		&iam.ListGroupsInput{},
-		func(page *iam.ListGroupsOutput, lastPage bool) bool {
-			for _, iamGroup := range page.Groups {
-				if configObj.IAMGroups.ShouldInclude(config.ResourceValue{
-					Time: iamGroup.CreateDate,
-					Name: iamGroup.GroupName,
-				}) {
-					allIamGroups = append(allIamGroups, iamGroup.GroupName)
-				}
+	paginator := iam.NewListGroupsPaginator(ig.Client, &iam.ListGroupsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(c)
+		if err != nil {
+			return nil, errors.WithStackTrace(err)
+		}
+
+		for _, iamGroup := range page.Groups {
+			if configObj.IAMGroups.ShouldInclude(config.ResourceValue{
+				Time: iamGroup.CreateDate,
+				Name: iamGroup.GroupName,
+			}) {
+				allIamGroups = append(allIamGroups, iamGroup.GroupName)
 			}
-			return !lastPage
-		},
-	)
-	if err != nil {
-		return nil, errors.WithStackTrace(err)
+		}
 	}
 
 	return allIamGroups, nil
@@ -44,13 +42,13 @@ func (ig *IAMGroups) nukeAll(groupNames []*string) error {
 		return nil
 	}
 
-	//Probably not required since pagination is handled by the caller
+	// Probably not required since pagination is handled by the caller
 	if len(groupNames) > 100 {
 		logging.Errorf("Nuking too many IAM Groups at once (100): Halting to avoid rate limits")
 		return TooManyIamGroupErr{}
 	}
 
-	//No bulk delete exists, do it with goroutines
+	// No bulk delete exists, do it with goroutines
 	logging.Debug("Deleting all IAM Groups")
 	wg := new(sync.WaitGroup)
 	wg.Add(len(groupNames))
@@ -61,7 +59,7 @@ func (ig *IAMGroups) nukeAll(groupNames []*string) error {
 	}
 	wg.Wait()
 
-	//Collapse the errors down to one
+	// Collapse the errors down to one
 	var allErrs *multierror.Error
 	for _, errChan := range errChans {
 		if err := <-errChan; err != nil {
@@ -82,71 +80,80 @@ func (ig *IAMGroups) deleteAsync(wg *sync.WaitGroup, errChan chan error, groupNa
 	defer wg.Done()
 	var multierr *multierror.Error
 
-	//Remove any users from the group
+	// Remove any users from the group
 	getGroupInput := &iam.GetGroupInput{
 		GroupName: groupName,
 	}
-	grp, err := ig.Client.GetGroupWithContext(ig.Context, getGroupInput)
+	grp, err := ig.Client.GetGroup(ig.Context, getGroupInput)
 	for _, user := range grp.Users {
 		unlinkUserInput := &iam.RemoveUserFromGroupInput{
 			UserName:  user.UserName,
 			GroupName: groupName,
 		}
-		_, err := ig.Client.RemoveUserFromGroupWithContext(ig.Context, unlinkUserInput)
+		_, err := ig.Client.RemoveUserFromGroup(ig.Context, unlinkUserInput)
 		if err != nil {
 			multierr = multierror.Append(multierr, err)
 		}
 	}
 
-	//Detach any policies on the group
-	allPolicies := []*string{}
-	err = ig.Client.ListAttachedGroupPoliciesPagesWithContext(ig.Context, &iam.ListAttachedGroupPoliciesInput{GroupName: groupName},
-		func(page *iam.ListAttachedGroupPoliciesOutput, lastPage bool) bool {
-			for _, iamPolicy := range page.AttachedPolicies {
-				allPolicies = append(allPolicies, iamPolicy.PolicyArn)
-			}
-			return !lastPage
-		},
-	)
+	// Detach any policies on the group
+	var allPolicies []*string
+	paginator := iam.NewListAttachedGroupPoliciesPaginator(ig.Client, &iam.ListAttachedGroupPoliciesInput{GroupName: groupName})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ig.Context)
+		if err != nil {
+			multierr = multierror.Append(multierr, err)
+			break
+		}
+
+		for _, iamPolicy := range page.AttachedPolicies {
+			allPolicies = append(allPolicies, iamPolicy.PolicyArn)
+		}
+	}
 
 	for _, policy := range allPolicies {
 		unlinkPolicyInput := &iam.DetachGroupPolicyInput{
 			GroupName: groupName,
 			PolicyArn: policy,
 		}
-		_, err = ig.Client.DetachGroupPolicyWithContext(ig.Context, unlinkPolicyInput)
+		_, err = ig.Client.DetachGroupPolicy(ig.Context, unlinkPolicyInput)
 	}
 
 	// Detach any inline policies on the group
-	allInlinePolicyNames := []*string{}
-	err = ig.Client.ListGroupPoliciesPagesWithContext(ig.Context, &iam.ListGroupPoliciesInput{GroupName: groupName},
-		func(page *iam.ListGroupPoliciesOutput, lastPage bool) bool {
-			for _, policyName := range page.PolicyNames {
-				allInlinePolicyNames = append(allInlinePolicyNames, policyName)
-			}
-			return !lastPage
-		},
-	)
+	var allInlinePolicyNames []*string
+
+	policiesPaginator := iam.NewListGroupPoliciesPaginator(ig.Client, &iam.ListGroupPoliciesInput{GroupName: groupName})
+	for policiesPaginator.HasMorePages() {
+		page, err := policiesPaginator.NextPage(ig.Context)
+		if err != nil {
+			multierr = multierror.Append(multierr, err)
+			break
+		}
+
+		for _, policyName := range page.PolicyNames {
+			allInlinePolicyNames = append(allInlinePolicyNames, aws.String(policyName))
+		}
+	}
 
 	for _, policyName := range allInlinePolicyNames {
-		_, err = ig.Client.DeleteGroupPolicyWithContext(ig.Context, &iam.DeleteGroupPolicyInput{
+		_, err = ig.Client.DeleteGroupPolicy(ig.Context, &iam.DeleteGroupPolicyInput{
 			GroupName:  groupName,
 			PolicyName: policyName,
 		})
 	}
 
-	//Delete the group
-	_, err = ig.Client.DeleteGroupWithContext(ig.Context, &iam.DeleteGroupInput{
+	// Delete the group
+	_, err = ig.Client.DeleteGroup(ig.Context, &iam.DeleteGroupInput{
 		GroupName: groupName,
 	})
 	if err != nil {
 		multierr = multierror.Append(multierr, err)
 	} else {
-		logging.Debugf("[OK] IAM Group %s was deleted in global", aws.StringValue(groupName))
+		logging.Debugf("[OK] IAM Group %s was deleted in global", aws.ToString(groupName))
 	}
 
 	e := report.Entry{
-		Identifier:   aws.StringValue(groupName),
+		Identifier:   aws.ToString(groupName),
 		ResourceType: "IAM Group",
 		Error:        multierr.ErrorOrNil(),
 	}

--- a/aws/resources/iam_group_test.go
+++ b/aws/resources/iam_group_test.go
@@ -6,84 +6,73 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/iam/iamiface"
-
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/stretchr/testify/require"
 )
 
 type mockedIAMGroups struct {
-	iamiface.IAMAPI
-	ListGroupsPagesOutput                iam.ListGroupsOutput
-	GetGroupOutput                       iam.GetGroupOutput
-	RemoveUserFromGroupOutput            iam.RemoveUserFromGroupOutput
-	DeleteGroupOutput                    iam.DeleteGroupOutput
-	ListAttachedGroupPoliciesPagesOutput iam.ListAttachedGroupPoliciesOutput
-	DetachGroupPolicyOutput              iam.DetachGroupPolicyOutput
-	ListGroupPoliciesOutput              iam.ListGroupPoliciesOutput
-	DeleteGroupPolicyOutput              iam.DeleteGroupPolicyOutput
+	IAMGroupsAPI
+	DetachGroupPolicyOutput         iam.DetachGroupPolicyOutput
+	DeleteGroupPolicyOutput         iam.DeleteGroupPolicyOutput
+	DeleteGroupOutput               iam.DeleteGroupOutput
+	GetGroupOutput                  iam.GetGroupOutput
+	ListAttachedGroupPoliciesOutput iam.ListAttachedGroupPoliciesOutput
+	ListGroupsOutput                iam.ListGroupsOutput
+	ListGroupPoliciesOutput         iam.ListGroupPoliciesOutput
+	RemoveUserFromGroupOutput       iam.RemoveUserFromGroupOutput
 }
 
-func (m mockedIAMGroups) ListGroupsPagesWithContext(
-	_ aws.Context, input *iam.ListGroupsInput, fn func(*iam.ListGroupsOutput, bool) bool, _ ...request.Option) error {
-	fn(&m.ListGroupsPagesOutput, true)
-	return nil
-}
-
-func (m mockedIAMGroups) DeleteGroupWithContext(_ aws.Context, input *iam.DeleteGroupInput, _ ...request.Option) (*iam.DeleteGroupOutput, error) {
-	return &m.DeleteGroupOutput, nil
-}
-
-func (m mockedIAMGroups) ListAttachedGroupPoliciesPagesWithContext(
-	_ aws.Context, input *iam.ListAttachedGroupPoliciesInput, fn func(*iam.ListAttachedGroupPoliciesOutput, bool) bool, _ ...request.Option) error {
-	fn(&m.ListAttachedGroupPoliciesPagesOutput, true)
-	return nil
-}
-
-func (m mockedIAMGroups) ListGroupPoliciesPagesWithContext(
-	_ aws.Context, input *iam.ListGroupPoliciesInput, fn func(*iam.ListGroupPoliciesOutput, bool) bool, _ ...request.Option) error {
-	fn(&m.ListGroupPoliciesOutput, true)
-	return nil
-}
-
-func (m mockedIAMGroups) DetachGroupPolicyWithContext(_ aws.Context, input *iam.DetachGroupPolicyInput, _ ...request.Option) (*iam.DetachGroupPolicyOutput, error) {
+func (m mockedIAMGroups) DetachGroupPolicy(ctx context.Context, params *iam.DetachGroupPolicyInput, optFns ...func(*iam.Options)) (*iam.DetachGroupPolicyOutput, error) {
 	return &m.DetachGroupPolicyOutput, nil
 }
 
-func (m mockedIAMGroups) DeleteGroupPolicyWithContext(_ aws.Context, input *iam.DeleteGroupPolicyInput, _ ...request.Option) (*iam.DeleteGroupPolicyOutput, error) {
+func (m mockedIAMGroups) DeleteGroupPolicy(ctx context.Context, params *iam.DeleteGroupPolicyInput, optFns ...func(*iam.Options)) (*iam.DeleteGroupPolicyOutput, error) {
 	return &m.DeleteGroupPolicyOutput, nil
 }
 
-func (m mockedIAMGroups) GetGroupWithContext(_ aws.Context, input *iam.GetGroupInput, _ ...request.Option) (*iam.GetGroupOutput, error) {
+func (m mockedIAMGroups) DeleteGroup(ctx context.Context, params *iam.DeleteGroupInput, optFns ...func(*iam.Options)) (*iam.DeleteGroupOutput, error) {
+	return &m.DeleteGroupOutput, nil
+}
+
+func (m mockedIAMGroups) GetGroup(ctx context.Context, params *iam.GetGroupInput, optFns ...func(*iam.Options)) (*iam.GetGroupOutput, error) {
 	return &m.GetGroupOutput, nil
 }
 
-func (m mockedIAMGroups) RemoveUserFromGroupWithContext(_ aws.Context, input *iam.RemoveUserFromGroupInput, _ ...request.Option) (*iam.RemoveUserFromGroupOutput, error) {
+func (m mockedIAMGroups) ListAttachedGroupPolicies(ctx context.Context, params *iam.ListAttachedGroupPoliciesInput, optFns ...func(*iam.Options)) (*iam.ListAttachedGroupPoliciesOutput, error) {
+	return &m.ListAttachedGroupPoliciesOutput, nil
+}
+
+func (m mockedIAMGroups) ListGroups(ctx context.Context, params *iam.ListGroupsInput, optFns ...func(*iam.Options)) (*iam.ListGroupsOutput, error) {
+	return &m.ListGroupsOutput, nil
+}
+
+func (m mockedIAMGroups) ListGroupPolicies(ctx context.Context, params *iam.ListGroupPoliciesInput, optFns ...func(*iam.Options)) (*iam.ListGroupPoliciesOutput, error) {
+	return &m.ListGroupPoliciesOutput, nil
+}
+
+func (m mockedIAMGroups) RemoveUserFromGroup(ctx context.Context, params *iam.RemoveUserFromGroupInput, optFns ...func(*iam.Options)) (*iam.RemoveUserFromGroupOutput, error) {
 	return &m.RemoveUserFromGroupOutput, nil
 }
 
 func TestIamGroups_GetAll(t *testing.T) {
-
 	t.Parallel()
-
 	testName1 := "group1"
 	testName2 := "group2"
 	now := time.Now()
 	ig := IAMGroups{
 		Client: mockedIAMGroups{
-			ListGroupsPagesOutput: iam.ListGroupsOutput{
-				Groups: []*iam.Group{
+			ListGroupsOutput: iam.ListGroupsOutput{
+				Groups: []types.Group{
 					{
-						GroupName:  awsgo.String(testName1),
-						CreateDate: awsgo.Time(now),
+						GroupName:  aws.String(testName1),
+						CreateDate: aws.Time(now),
 					},
 					{
-						GroupName:  awsgo.String(testName2),
-						CreateDate: awsgo.Time(now.Add(1)),
+						GroupName:  aws.String(testName2),
+						CreateDate: aws.Time(now.Add(1)),
 					},
 				},
 			},
@@ -110,7 +99,7 @@ func TestIamGroups_GetAll(t *testing.T) {
 		"timeAfterExclusionFilter": {
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
-					TimeAfter: awsgo.Time(now),
+					TimeAfter: aws.Time(now),
 				}},
 			expected: []string{testName1},
 		},
@@ -121,36 +110,34 @@ func TestIamGroups_GetAll(t *testing.T) {
 				IAMGroups: tc.configObj,
 			})
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, awsgo.StringValueSlice(names))
+			require.Equal(t, tc.expected, aws.ToStringSlice(names))
 		})
 	}
 }
 
 func TestIamGroups_NukeAll(t *testing.T) {
-
 	t.Parallel()
-
 	ig := IAMGroups{
 		Client: mockedIAMGroups{
 			GetGroupOutput: iam.GetGroupOutput{
-				Users: []*iam.User{
+				Users: []types.User{
 					{
-						UserName: awsgo.String("user1"),
+						UserName: aws.String("user1"),
 					},
 				},
 			},
 			RemoveUserFromGroupOutput: iam.RemoveUserFromGroupOutput{},
-			ListAttachedGroupPoliciesPagesOutput: iam.ListAttachedGroupPoliciesOutput{
-				AttachedPolicies: []*iam.AttachedPolicy{
+			ListAttachedGroupPoliciesOutput: iam.ListAttachedGroupPoliciesOutput{
+				AttachedPolicies: []types.AttachedPolicy{
 					{
-						PolicyName: awsgo.String("policy1"),
+						PolicyName: aws.String("policy1"),
 					},
 				},
 			},
 			DetachGroupPolicyOutput: iam.DetachGroupPolicyOutput{},
 			ListGroupPoliciesOutput: iam.ListGroupPoliciesOutput{
-				PolicyNames: []*string{
-					awsgo.String("policy2"),
+				PolicyNames: []string{
+					"policy2",
 				},
 			},
 			DeleteGroupPolicyOutput: iam.DeleteGroupPolicyOutput{},
@@ -158,6 +145,6 @@ func TestIamGroups_NukeAll(t *testing.T) {
 		},
 	}
 
-	err := ig.nukeAll([]*string{awsgo.String("group1")})
+	err := ig.nukeAll([]*string{aws.String("group1")})
 	require.NoError(t, err)
 }

--- a/aws/resources/iam_policy_test.go
+++ b/aws/resources/iam_policy_test.go
@@ -6,69 +6,59 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/stretchr/testify/require"
 )
 
 type mockedIAMPolicies struct {
-	iamiface.IAMAPI
-	ListPoliciesPagesOutput iam.ListPoliciesOutput
-
-	ListEntitiesForPolicyPagesOutput iam.ListEntitiesForPolicyOutput
-	DetachUserPolicyOutput           iam.DetachUserPolicyOutput
-	DetachGroupPolicyOutput          iam.DetachGroupPolicyOutput
-	DetachRolePolicyOutput           iam.DetachRolePolicyOutput
-	ListPolicyVersionsPagesOutput    iam.ListPolicyVersionsOutput
-	DeletePolicyVersionOutput        iam.DeletePolicyVersionOutput
-	DeletePolicyOutput               iam.DeletePolicyOutput
+	IAMPoliciesAPI
+	ListEntitiesForPolicyOutput iam.ListEntitiesForPolicyOutput
+	ListPoliciesOutput          iam.ListPoliciesOutput
+	ListPolicyVersionsOutput    iam.ListPolicyVersionsOutput
+	DeletePolicyOutput          iam.DeletePolicyOutput
+	DeletePolicyVersionOutput   iam.DeletePolicyVersionOutput
+	DetachGroupPolicyOutput     iam.DetachGroupPolicyOutput
+	DetachUserPolicyOutput      iam.DetachUserPolicyOutput
+	DetachRolePolicyOutput      iam.DetachRolePolicyOutput
 }
 
-func (m mockedIAMPolicies) ListPoliciesPagesWithContext(
-	_ aws.Context, input *iam.ListPoliciesInput, fn func(*iam.ListPoliciesOutput, bool) bool, _ ...request.Option) error {
-	fn(&m.ListPoliciesPagesOutput, true)
-	return nil
+func (m mockedIAMPolicies) ListEntitiesForPolicy(ctx context.Context, params *iam.ListEntitiesForPolicyInput, optFns ...func(*iam.Options)) (*iam.ListEntitiesForPolicyOutput, error) {
+	return &m.ListEntitiesForPolicyOutput, nil
 }
 
-func (m mockedIAMPolicies) ListEntitiesForPolicyPagesWithContext(
-	_ aws.Context, input *iam.ListEntitiesForPolicyInput, fn func(*iam.ListEntitiesForPolicyOutput, bool) bool, _ ...request.Option) error {
-	fn(&m.ListEntitiesForPolicyPagesOutput, true)
-	return nil
+func (m mockedIAMPolicies) ListPolicies(ctx context.Context, params *iam.ListPoliciesInput, optFns ...func(*iam.Options)) (*iam.ListPoliciesOutput, error) {
+	return &m.ListPoliciesOutput, nil
 }
 
-func (m mockedIAMPolicies) DetachUserPolicyWithContext(_ aws.Context, input *iam.DetachUserPolicyInput, _ ...request.Option) (*iam.DetachUserPolicyOutput, error) {
-	return &m.DetachUserPolicyOutput, nil
+func (m mockedIAMPolicies) ListPolicyVersions(ctx context.Context, params *iam.ListPolicyVersionsInput, optFns ...func(*iam.Options)) (*iam.ListPolicyVersionsOutput, error) {
+	return &m.ListPolicyVersionsOutput, nil
 }
 
-func (m mockedIAMPolicies) DetachGroupPolicyWithContext(_ aws.Context, input *iam.DetachGroupPolicyInput, _ ...request.Option) (*iam.DetachGroupPolicyOutput, error) {
-	return &m.DetachGroupPolicyOutput, nil
-}
-
-func (m mockedIAMPolicies) DetachRolePolicyWithContext(_ aws.Context, input *iam.DetachRolePolicyInput, _ ...request.Option) (*iam.DetachRolePolicyOutput, error) {
-	return &m.DetachRolePolicyOutput, nil
-}
-
-func (m mockedIAMPolicies) ListPolicyVersionsPagesWithContext(
-	_ aws.Context, input *iam.ListPolicyVersionsInput, fn func(*iam.ListPolicyVersionsOutput, bool) bool, _ ...request.Option) error {
-	fn(&m.ListPolicyVersionsPagesOutput, true)
-	return nil
-}
-
-func (m mockedIAMPolicies) DeletePolicyVersionWithContext(_ aws.Context, input *iam.DeletePolicyVersionInput, _ ...request.Option) (*iam.DeletePolicyVersionOutput, error) {
-	return &m.DeletePolicyVersionOutput, nil
-}
-
-func (m mockedIAMPolicies) DeletePolicyWithContext(_ aws.Context, input *iam.DeletePolicyInput, _ ...request.Option) (*iam.DeletePolicyOutput, error) {
+func (m mockedIAMPolicies) DeletePolicy(ctx context.Context, params *iam.DeletePolicyInput, optFns ...func(*iam.Options)) (*iam.DeletePolicyOutput, error) {
 	return &m.DeletePolicyOutput, nil
 }
 
+func (m mockedIAMPolicies) DeletePolicyVersion(ctx context.Context, params *iam.DeletePolicyVersionInput, optFns ...func(*iam.Options)) (*iam.DeletePolicyVersionOutput, error) {
+	return &m.DeletePolicyVersionOutput, nil
+}
+
+func (m mockedIAMPolicies) DetachGroupPolicy(ctx context.Context, params *iam.DetachGroupPolicyInput, optFns ...func(*iam.Options)) (*iam.DetachGroupPolicyOutput, error) {
+	return &m.DetachGroupPolicyOutput, nil
+}
+
+func (m mockedIAMPolicies) DetachUserPolicy(ctx context.Context, params *iam.DetachUserPolicyInput, optFns ...func(*iam.Options)) (*iam.DetachUserPolicyOutput, error) {
+	return &m.DetachUserPolicyOutput, nil
+}
+
+func (m mockedIAMPolicies) DetachRolePolicy(ctx context.Context, params *iam.DetachRolePolicyInput, optFns ...func(*iam.Options)) (*iam.DetachRolePolicyOutput, error) {
+	return &m.DetachRolePolicyOutput, nil
+}
+
 func TestIAMPolicy_GetAll(t *testing.T) {
-
 	t.Parallel()
-
 	testName1 := "MyPolicy1"
 	testName2 := "MyPolicy2"
 	testArn1 := "arn:aws:iam::123456789012:policy/MyPolicy1"
@@ -76,8 +66,8 @@ func TestIAMPolicy_GetAll(t *testing.T) {
 	now := time.Now()
 	ip := IAMPolicies{
 		Client: mockedIAMPolicies{
-			ListPoliciesPagesOutput: iam.ListPoliciesOutput{
-				Policies: []*iam.Policy{
+			ListPoliciesOutput: iam.ListPoliciesOutput{
+				Policies: []types.Policy{
 					{
 						Arn:        aws.String(testArn1),
 						PolicyName: aws.String(testName1),
@@ -130,30 +120,29 @@ func TestIAMPolicy_GetAll(t *testing.T) {
 }
 
 func TestIAMPolicy_NukeAll(t *testing.T) {
-
 	t.Parallel()
 
 	ip := IAMPolicies{
 		Client: mockedIAMPolicies{
-			ListEntitiesForPolicyPagesOutput: iam.ListEntitiesForPolicyOutput{
-				PolicyGroups: []*iam.PolicyGroup{
+			ListEntitiesForPolicyOutput: iam.ListEntitiesForPolicyOutput{
+				PolicyGroups: []types.PolicyGroup{
 					{GroupName: aws.String("group1")},
 				},
-				PolicyUsers: []*iam.PolicyUser{
+				PolicyUsers: []types.PolicyUser{
 					{UserName: aws.String("user1")},
 				},
-				PolicyRoles: []*iam.PolicyRole{
+				PolicyRoles: []types.PolicyRole{
 					{RoleName: aws.String("role1")},
 				},
 			},
 			DetachUserPolicyOutput:  iam.DetachUserPolicyOutput{},
 			DetachGroupPolicyOutput: iam.DetachGroupPolicyOutput{},
 			DetachRolePolicyOutput:  iam.DetachRolePolicyOutput{},
-			ListPolicyVersionsPagesOutput: iam.ListPolicyVersionsOutput{
-				Versions: []*iam.PolicyVersion{
+			ListPolicyVersionsOutput: iam.ListPolicyVersionsOutput{
+				Versions: []types.PolicyVersion{
 					{
 						VersionId:        aws.String("v1"),
-						IsDefaultVersion: aws.Bool(false),
+						IsDefaultVersion: false,
 					},
 				},
 			},

--- a/aws/resources/iam_role_test.go
+++ b/aws/resources/iam_role_test.go
@@ -6,75 +6,71 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/stretchr/testify/require"
 )
 
 type mockedIAMRoles struct {
-	iamiface.IAMAPI
-	ListRolesPagesOutput                iam.ListRolesOutput
-	ListInstanceProfilesForRoleOutput   iam.ListInstanceProfilesForRoleOutput
-	RemoveRoleFromInstanceProfileOutput iam.RemoveRoleFromInstanceProfileOutput
-	DeleteInstanceProfileOutput         iam.DeleteInstanceProfileOutput
-	ListRolePoliciesOutput              iam.ListRolePoliciesOutput
-	DeleteRolePolicyOutput              iam.DeleteRolePolicyOutput
+	IAMRolesAPI
 	ListAttachedRolePoliciesOutput      iam.ListAttachedRolePoliciesOutput
+	ListInstanceProfilesForRoleOutput   iam.ListInstanceProfilesForRoleOutput
+	ListRolePoliciesOutput              iam.ListRolePoliciesOutput
+	ListRolesOutput                     iam.ListRolesOutput
+	DeleteInstanceProfileOutput         iam.DeleteInstanceProfileOutput
 	DetachRolePolicyOutput              iam.DetachRolePolicyOutput
+	DeleteRolePolicyOutput              iam.DeleteRolePolicyOutput
 	DeleteRoleOutput                    iam.DeleteRoleOutput
+	RemoveRoleFromInstanceProfileOutput iam.RemoveRoleFromInstanceProfileOutput
 }
 
-func (m mockedIAMRoles) ListRolesPagesWithContext(_ aws.Context, input *iam.ListRolesInput, f func(*iam.ListRolesOutput, bool) bool, _ ...request.Option) error {
-	f(&m.ListRolesPagesOutput, true)
-	return nil
-}
-
-func (m mockedIAMRoles) ListInstanceProfilesForRoleWithContext(_ aws.Context, input *iam.ListInstanceProfilesForRoleInput, _ ...request.Option) (*iam.ListInstanceProfilesForRoleOutput, error) {
-	return &m.ListInstanceProfilesForRoleOutput, nil
-}
-
-func (m mockedIAMRoles) RemoveRoleFromInstanceProfileWithContext(_ aws.Context, input *iam.RemoveRoleFromInstanceProfileInput, _ ...request.Option) (*iam.RemoveRoleFromInstanceProfileOutput, error) {
-	return &m.RemoveRoleFromInstanceProfileOutput, nil
-}
-
-func (m mockedIAMRoles) DeleteInstanceProfileWithContext(_ aws.Context, input *iam.DeleteInstanceProfileInput, _ ...request.Option) (*iam.DeleteInstanceProfileOutput, error) {
-	return &m.DeleteInstanceProfileOutput, nil
-}
-
-func (m mockedIAMRoles) ListRolePoliciesWithContext(_ aws.Context, input *iam.ListRolePoliciesInput, _ ...request.Option) (*iam.ListRolePoliciesOutput, error) {
-	return &m.ListRolePoliciesOutput, nil
-}
-
-func (m mockedIAMRoles) DeleteRolePolicyWithContext(_ aws.Context, input *iam.DeleteRolePolicyInput, _ ...request.Option) (*iam.DeleteRolePolicyOutput, error) {
-	return &m.DeleteRolePolicyOutput, nil
-}
-
-func (m mockedIAMRoles) ListAttachedRolePoliciesWithContext(_ aws.Context, input *iam.ListAttachedRolePoliciesInput, _ ...request.Option) (*iam.ListAttachedRolePoliciesOutput, error) {
+func (m mockedIAMRoles) ListAttachedRolePolicies(ctx context.Context, params *iam.ListAttachedRolePoliciesInput, optFns ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error) {
 	return &m.ListAttachedRolePoliciesOutput, nil
 }
 
-func (m mockedIAMRoles) DetachRolePolicyWithContext(_ aws.Context, input *iam.DetachRolePolicyInput, _ ...request.Option) (*iam.DetachRolePolicyOutput, error) {
+func (m mockedIAMRoles) ListInstanceProfilesForRole(ctx context.Context, params *iam.ListInstanceProfilesForRoleInput, optFns ...func(*iam.Options)) (*iam.ListInstanceProfilesForRoleOutput, error) {
+	return &m.ListInstanceProfilesForRoleOutput, nil
+}
+
+func (m mockedIAMRoles) ListRolePolicies(ctx context.Context, params *iam.ListRolePoliciesInput, optFns ...func(*iam.Options)) (*iam.ListRolePoliciesOutput, error) {
+	return &m.ListRolePoliciesOutput, nil
+}
+
+func (m mockedIAMRoles) ListRoles(ctx context.Context, params *iam.ListRolesInput, optFns ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
+	return &m.ListRolesOutput, nil
+}
+
+func (m mockedIAMRoles) DeleteInstanceProfile(ctx context.Context, params *iam.DeleteInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.DeleteInstanceProfileOutput, error) {
+	return &m.DeleteInstanceProfileOutput, nil
+}
+
+func (m mockedIAMRoles) DetachRolePolicy(ctx context.Context, params *iam.DetachRolePolicyInput, optFns ...func(*iam.Options)) (*iam.DetachRolePolicyOutput, error) {
 	return &m.DetachRolePolicyOutput, nil
 }
 
-func (m mockedIAMRoles) DeleteRoleWithContext(_ aws.Context, input *iam.DeleteRoleInput, _ ...request.Option) (*iam.DeleteRoleOutput, error) {
+func (m mockedIAMRoles) DeleteRolePolicy(ctx context.Context, params *iam.DeleteRolePolicyInput, optFns ...func(*iam.Options)) (*iam.DeleteRolePolicyOutput, error) {
+	return &m.DeleteRolePolicyOutput, nil
+}
+
+func (m mockedIAMRoles) DeleteRole(ctx context.Context, params *iam.DeleteRoleInput, optFns ...func(*iam.Options)) (*iam.DeleteRoleOutput, error) {
 	return &m.DeleteRoleOutput, nil
 }
 
+func (m mockedIAMRoles) RemoveRoleFromInstanceProfile(ctx context.Context, params *iam.RemoveRoleFromInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.RemoveRoleFromInstanceProfileOutput, error) {
+	return &m.RemoveRoleFromInstanceProfileOutput, nil
+}
+
 func TestIAMRoles_GetAll(t *testing.T) {
-
 	t.Parallel()
-
 	testName1 := "test-role1"
 	testName2 := "test-role2"
 	now := time.Now()
 	ir := IAMRoles{
 		Client: mockedIAMRoles{
-			ListRolesPagesOutput: iam.ListRolesOutput{
-				Roles: []*iam.Role{
+			ListRolesOutput: iam.ListRolesOutput{
+				Roles: []types.Role{
 					{
 						RoleName:   aws.String(testName1),
 						CreateDate: aws.Time(now),
@@ -119,20 +115,18 @@ func TestIAMRoles_GetAll(t *testing.T) {
 				IAMRoles: tc.configObj,
 			})
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, aws.StringValueSlice(names))
+			require.Equal(t, tc.expected, aws.ToStringSlice(names))
 		})
 	}
 
 }
 
 func TestIAMRoles_NukeAll(t *testing.T) {
-
 	t.Parallel()
-
 	ir := IAMRoles{
 		Client: mockedIAMRoles{
 			ListInstanceProfilesForRoleOutput: iam.ListInstanceProfilesForRoleOutput{
-				InstanceProfiles: []*iam.InstanceProfile{
+				InstanceProfiles: []types.InstanceProfile{
 					{
 						InstanceProfileName: aws.String("test-instance-profile"),
 					},
@@ -141,13 +135,13 @@ func TestIAMRoles_NukeAll(t *testing.T) {
 			RemoveRoleFromInstanceProfileOutput: iam.RemoveRoleFromInstanceProfileOutput{},
 			DeleteInstanceProfileOutput:         iam.DeleteInstanceProfileOutput{},
 			ListRolePoliciesOutput: iam.ListRolePoliciesOutput{
-				PolicyNames: []*string{
-					aws.String("test-policy"),
+				PolicyNames: []string{
+					"test-policy",
 				},
 			},
 			DeleteRolePolicyOutput: iam.DeleteRolePolicyOutput{},
 			ListAttachedRolePoliciesOutput: iam.ListAttachedRolePoliciesOutput{
-				AttachedPolicies: []*iam.AttachedPolicy{
+				AttachedPolicies: []types.AttachedPolicy{
 					{
 						PolicyArn: aws.String("test-policy-arn"),
 					},

--- a/aws/resources/iam_test.go
+++ b/aws/resources/iam_test.go
@@ -6,143 +6,138 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/stretchr/testify/require"
 )
 
 type mockedIAMUsers struct {
-	iamiface.IAMAPI
-	ListUsersPagesOutput                  iam.ListUsersOutput
+	IAMUsersAPI
+	ListAccessKeysOutput                  iam.ListAccessKeysOutput
+	ListGroupsForUserOutput               iam.ListGroupsForUserOutput
+	ListUserPoliciesOutput                iam.ListUserPoliciesOutput
+	ListUserTagsOutput                    iam.ListUserTagsOutput
+	ListMFADevicesOutput                  iam.ListMFADevicesOutput
+	ListSSHPublicKeysOutput               iam.ListSSHPublicKeysOutput
+	ListServiceSpecificCredentialsOutput  iam.ListServiceSpecificCredentialsOutput
+	ListSigningCertificatesOutput         iam.ListSigningCertificatesOutput
+	ListUsersOutput                       iam.ListUsersOutput
 	ListAttachedUserPoliciesOutput        iam.ListAttachedUserPoliciesOutput
 	DetachUserPolicyOutput                iam.DetachUserPolicyOutput
-	ListUserPoliciesOutput                iam.ListUserPoliciesOutput
-	DeleteUserPolicyOutput                iam.DeleteUserPolicyOutput
-	ListGroupsForUserOutput               iam.ListGroupsForUserOutput
-	RemoveUserFromGroupOutput             iam.RemoveUserFromGroupOutput
 	DeleteLoginProfileOutput              iam.DeleteLoginProfileOutput
-	ListAccessKeysOutput                  iam.ListAccessKeysOutput
+	DeleteUserPolicyOutput                iam.DeleteUserPolicyOutput
 	DeleteAccessKeyOutput                 iam.DeleteAccessKeyOutput
-	ListSigningCertificatesOutput         iam.ListSigningCertificatesOutput
 	DeleteSigningCertificateOutput        iam.DeleteSigningCertificateOutput
-	ListSSHPublicKeysOutput               iam.ListSSHPublicKeysOutput
 	DeleteSSHPublicKeyOutput              iam.DeleteSSHPublicKeyOutput
-	ListServiceSpecificCredentialsOutput  iam.ListServiceSpecificCredentialsOutput
 	DeleteServiceSpecificCredentialOutput iam.DeleteServiceSpecificCredentialOutput
-	ListMFADevicesOutput                  iam.ListMFADevicesOutput
 	DeactivateMFADeviceOutput             iam.DeactivateMFADeviceOutput
 	DeleteVirtualMFADeviceOutput          iam.DeleteVirtualMFADeviceOutput
 	DeleteUserOutput                      iam.DeleteUserOutput
-	ListUserTagsOutput                    iam.ListUserTagsOutput
+	RemoveUserFromGroupOutput             iam.RemoveUserFromGroupOutput
 }
 
-func (m mockedIAMUsers) ListUsersPagesWithContext(_ aws.Context, input *iam.ListUsersInput, callback func(*iam.ListUsersOutput, bool) bool, _ ...request.Option) error {
-	callback(&m.ListUsersPagesOutput, true)
-	return nil
-}
-
-func (m mockedIAMUsers) ListAttachedUserPoliciesWithContext(_ aws.Context, input *iam.ListAttachedUserPoliciesInput, _ ...request.Option) (*iam.ListAttachedUserPoliciesOutput, error) {
-	return &m.ListAttachedUserPoliciesOutput, nil
-}
-
-func (m mockedIAMUsers) DetachUserPolicyWithContext(_ aws.Context, input *iam.DetachUserPolicyInput, _ ...request.Option) (*iam.DetachUserPolicyOutput, error) {
-	return &m.DetachUserPolicyOutput, nil
-}
-
-func (m mockedIAMUsers) ListUserPoliciesWithContext(_ aws.Context, input *iam.ListUserPoliciesInput, _ ...request.Option) (*iam.ListUserPoliciesOutput, error) {
-	return &m.ListUserPoliciesOutput, nil
-}
-
-func (m mockedIAMUsers) DeleteUserPolicyWithContext(_ aws.Context, input *iam.DeleteUserPolicyInput, _ ...request.Option) (*iam.DeleteUserPolicyOutput, error) {
-	return &m.DeleteUserPolicyOutput, nil
-}
-
-func (m mockedIAMUsers) ListGroupsForUserWithContext(_ aws.Context, input *iam.ListGroupsForUserInput, _ ...request.Option) (*iam.ListGroupsForUserOutput, error) {
-	return &m.ListGroupsForUserOutput, nil
-}
-
-func (m mockedIAMUsers) RemoveUserFromGroupWithContext(_ aws.Context, input *iam.RemoveUserFromGroupInput, _ ...request.Option) (*iam.RemoveUserFromGroupOutput, error) {
-	return &m.RemoveUserFromGroupOutput, nil
-}
-
-func (m mockedIAMUsers) DeleteLoginProfileWithContext(_ aws.Context, input *iam.DeleteLoginProfileInput, _ ...request.Option) (*iam.DeleteLoginProfileOutput, error) {
-	return &m.DeleteLoginProfileOutput, nil
-}
-
-func (m mockedIAMUsers) ListAccessKeysWithContext(_ aws.Context, input *iam.ListAccessKeysInput, _ ...request.Option) (*iam.ListAccessKeysOutput, error) {
+func (m mockedIAMUsers) ListAccessKeys(ctx context.Context, params *iam.ListAccessKeysInput, optFns ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error) {
 	return &m.ListAccessKeysOutput, nil
 }
 
-func (m mockedIAMUsers) DeleteAccessKeyWithContext(_ aws.Context, input *iam.DeleteAccessKeyInput, _ ...request.Option) (*iam.DeleteAccessKeyOutput, error) {
-	return &m.DeleteAccessKeyOutput, nil
+func (m mockedIAMUsers) ListGroupsForUser(ctx context.Context, params *iam.ListGroupsForUserInput, optFns ...func(*iam.Options)) (*iam.ListGroupsForUserOutput, error) {
+	return &m.ListGroupsForUserOutput, nil
 }
 
-func (m mockedIAMUsers) ListSigningCertificatesWithContext(_ aws.Context, input *iam.ListSigningCertificatesInput, _ ...request.Option) (*iam.ListSigningCertificatesOutput, error) {
-	return &m.ListSigningCertificatesOutput, nil
+func (m mockedIAMUsers) ListUserPolicies(ctx context.Context, params *iam.ListUserPoliciesInput, optFns ...func(*iam.Options)) (*iam.ListUserPoliciesOutput, error) {
+	return &m.ListUserPoliciesOutput, nil
 }
 
-func (m mockedIAMUsers) DeleteSigningCertificateWithContext(_ aws.Context, input *iam.DeleteSigningCertificateInput, _ ...request.Option) (*iam.DeleteSigningCertificateOutput, error) {
-	return &m.DeleteSigningCertificateOutput, nil
+func (m mockedIAMUsers) ListUserTags(ctx context.Context, params *iam.ListUserTagsInput, optFns ...func(*iam.Options)) (*iam.ListUserTagsOutput, error) {
+	return &m.ListUserTagsOutput, nil
 }
 
-func (m mockedIAMUsers) ListSSHPublicKeysWithContext(_ aws.Context, input *iam.ListSSHPublicKeysInput, _ ...request.Option) (*iam.ListSSHPublicKeysOutput, error) {
-	return &m.ListSSHPublicKeysOutput, nil
-}
-
-func (m mockedIAMUsers) DeleteSSHPublicKeyWithContext(_ aws.Context, input *iam.DeleteSSHPublicKeyInput, _ ...request.Option) (*iam.DeleteSSHPublicKeyOutput, error) {
-	return &m.DeleteSSHPublicKeyOutput, nil
-}
-
-func (m mockedIAMUsers) ListServiceSpecificCredentialsWithContext(_ aws.Context, input *iam.ListServiceSpecificCredentialsInput, _ ...request.Option) (*iam.ListServiceSpecificCredentialsOutput, error) {
-	return &m.ListServiceSpecificCredentialsOutput, nil
-}
-
-func (m mockedIAMUsers) DeleteServiceSpecificCredentialWithContext(_ aws.Context, input *iam.DeleteServiceSpecificCredentialInput, _ ...request.Option) (*iam.DeleteServiceSpecificCredentialOutput, error) {
-	return &m.DeleteServiceSpecificCredentialOutput, nil
-}
-
-func (m mockedIAMUsers) ListMFADevicesWithContext(_ aws.Context, input *iam.ListMFADevicesInput, _ ...request.Option) (*iam.ListMFADevicesOutput, error) {
+func (m mockedIAMUsers) ListMFADevices(ctx context.Context, params *iam.ListMFADevicesInput, optFns ...func(*iam.Options)) (*iam.ListMFADevicesOutput, error) {
 	return &m.ListMFADevicesOutput, nil
 }
 
-func (m mockedIAMUsers) DeactivateMFADeviceWithContext(_ aws.Context, input *iam.DeactivateMFADeviceInput, _ ...request.Option) (*iam.DeactivateMFADeviceOutput, error) {
+func (m mockedIAMUsers) ListSSHPublicKeys(ctx context.Context, params *iam.ListSSHPublicKeysInput, optFns ...func(*iam.Options)) (*iam.ListSSHPublicKeysOutput, error) {
+	return &m.ListSSHPublicKeysOutput, nil
+}
+
+func (m mockedIAMUsers) ListServiceSpecificCredentials(ctx context.Context, params *iam.ListServiceSpecificCredentialsInput, optFns ...func(*iam.Options)) (*iam.ListServiceSpecificCredentialsOutput, error) {
+	return &m.ListServiceSpecificCredentialsOutput, nil
+}
+
+func (m mockedIAMUsers) ListSigningCertificates(ctx context.Context, params *iam.ListSigningCertificatesInput, optFns ...func(*iam.Options)) (*iam.ListSigningCertificatesOutput, error) {
+	return &m.ListSigningCertificatesOutput, nil
+}
+
+func (m mockedIAMUsers) ListUsers(ctx context.Context, params *iam.ListUsersInput, optFns ...func(*iam.Options)) (*iam.ListUsersOutput, error) {
+	return &m.ListUsersOutput, nil
+}
+
+func (m mockedIAMUsers) ListAttachedUserPolicies(ctx context.Context, params *iam.ListAttachedUserPoliciesInput, optFns ...func(*iam.Options)) (*iam.ListAttachedUserPoliciesOutput, error) {
+	return &m.ListAttachedUserPoliciesOutput, nil
+}
+
+func (m mockedIAMUsers) DetachUserPolicy(ctx context.Context, params *iam.DetachUserPolicyInput, optFns ...func(*iam.Options)) (*iam.DetachUserPolicyOutput, error) {
+	return &m.DetachUserPolicyOutput, nil
+}
+
+func (m mockedIAMUsers) DeleteLoginProfile(ctx context.Context, params *iam.DeleteLoginProfileInput, optFns ...func(*iam.Options)) (*iam.DeleteLoginProfileOutput, error) {
+	return &m.DeleteLoginProfileOutput, nil
+}
+
+func (m mockedIAMUsers) DeleteUserPolicy(ctx context.Context, params *iam.DeleteUserPolicyInput, optFns ...func(*iam.Options)) (*iam.DeleteUserPolicyOutput, error) {
+	return &m.DeleteUserPolicyOutput, nil
+}
+
+func (m mockedIAMUsers) DeleteAccessKey(ctx context.Context, params *iam.DeleteAccessKeyInput, optFns ...func(*iam.Options)) (*iam.DeleteAccessKeyOutput, error) {
+	return &m.DeleteAccessKeyOutput, nil
+}
+
+func (m mockedIAMUsers) DeleteSigningCertificate(ctx context.Context, params *iam.DeleteSigningCertificateInput, optFns ...func(*iam.Options)) (*iam.DeleteSigningCertificateOutput, error) {
+	return &m.DeleteSigningCertificateOutput, nil
+}
+
+func (m mockedIAMUsers) DeleteSSHPublicKey(ctx context.Context, params *iam.DeleteSSHPublicKeyInput, optFns ...func(*iam.Options)) (*iam.DeleteSSHPublicKeyOutput, error) {
+	return &m.DeleteSSHPublicKeyOutput, nil
+}
+
+func (m mockedIAMUsers) DeleteServiceSpecificCredential(ctx context.Context, params *iam.DeleteServiceSpecificCredentialInput, optFns ...func(*iam.Options)) (*iam.DeleteServiceSpecificCredentialOutput, error) {
+	return &m.DeleteServiceSpecificCredentialOutput, nil
+}
+
+func (m mockedIAMUsers) DeactivateMFADevice(ctx context.Context, params *iam.DeactivateMFADeviceInput, optFns ...func(*iam.Options)) (*iam.DeactivateMFADeviceOutput, error) {
 	return &m.DeactivateMFADeviceOutput, nil
 }
 
-func (m mockedIAMUsers) DeleteVirtualMFADeviceWithContext(_ aws.Context, input *iam.DeleteVirtualMFADeviceInput, _ ...request.Option) (*iam.DeleteVirtualMFADeviceOutput, error) {
+func (m mockedIAMUsers) DeleteVirtualMFADevice(ctx context.Context, params *iam.DeleteVirtualMFADeviceInput, optFns ...func(*iam.Options)) (*iam.DeleteVirtualMFADeviceOutput, error) {
 	return &m.DeleteVirtualMFADeviceOutput, nil
 }
 
-func (m mockedIAMUsers) DeleteUserWithContext(_ aws.Context, input *iam.DeleteUserInput, _ ...request.Option) (*iam.DeleteUserOutput, error) {
+func (m mockedIAMUsers) DeleteUser(ctx context.Context, params *iam.DeleteUserInput, optFns ...func(*iam.Options)) (*iam.DeleteUserOutput, error) {
 	return &m.DeleteUserOutput, nil
 }
-func (m mockedIAMUsers) ListUserTagsPagesWithContext(_ aws.Context, input *iam.ListUserTagsInput, callback func(*iam.ListUserTagsOutput, bool) bool, _ ...request.Option) error {
-	callback(&m.ListUserTagsOutput, true)
-	return nil
+
+func (m mockedIAMUsers) RemoveUserFromGroup(ctx context.Context, params *iam.RemoveUserFromGroupInput, optFns ...func(*iam.Options)) (*iam.RemoveUserFromGroupOutput, error) {
+	return &m.RemoveUserFromGroupOutput, nil
 }
 
 func TestIAMUsers_GetAll(t *testing.T) {
-
 	t.Parallel()
-
 	now := time.Now()
 	testName1 := "test-user1"
 	testName2 := "test-user2"
 	iu := IAMUsers{
 		Client: mockedIAMUsers{
-			ListUsersPagesOutput: iam.ListUsersOutput{
-				Users: []*iam.User{
+			ListUsersOutput: iam.ListUsersOutput{
+				Users: []types.User{
 					{
-						UserName:   awsgo.String(testName1),
-						CreateDate: awsgo.Time(now),
+						UserName:   aws.String(testName1),
+						CreateDate: aws.Time(now),
 					},
 					{
-						UserName:   awsgo.String(testName2),
-						CreateDate: awsgo.Time(now.Add(1)),
+						UserName:   aws.String(testName2),
+						CreateDate: aws.Time(now.Add(1)),
 					},
 				},
 			},
@@ -180,77 +175,75 @@ func TestIAMUsers_GetAll(t *testing.T) {
 				IAMUsers: tc.configObj,
 			})
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, awsgo.StringValueSlice(names))
+			require.Equal(t, tc.expected, aws.ToStringSlice(names))
 		})
 	}
 
 }
 
 func TestIAMUsers_NukeAll(t *testing.T) {
-
 	t.Parallel()
-
 	iu := IAMUsers{
 		Client: mockedIAMUsers{
 			ListAttachedUserPoliciesOutput: iam.ListAttachedUserPoliciesOutput{
-				AttachedPolicies: []*iam.AttachedPolicy{
+				AttachedPolicies: []types.AttachedPolicy{
 					{
-						PolicyName: awsgo.String("test-policy"),
+						PolicyName: aws.String("test-policy"),
 					},
 				},
 			},
 			DetachUserPolicyOutput: iam.DetachUserPolicyOutput{},
 			ListUserPoliciesOutput: iam.ListUserPoliciesOutput{
-				PolicyNames: []*string{
-					awsgo.String("test-policy"),
+				PolicyNames: []string{
+					"test-policy",
 				},
 			},
 			DeleteUserPolicyOutput: iam.DeleteUserPolicyOutput{},
 			ListGroupsForUserOutput: iam.ListGroupsForUserOutput{
-				Groups: []*iam.Group{
+				Groups: []types.Group{
 					{
-						GroupName: awsgo.String("test-group"),
+						GroupName: aws.String("test-group"),
 					},
 				},
 			},
 			RemoveUserFromGroupOutput: iam.RemoveUserFromGroupOutput{},
 			DeleteLoginProfileOutput:  iam.DeleteLoginProfileOutput{},
 			ListAccessKeysOutput: iam.ListAccessKeysOutput{
-				AccessKeyMetadata: []*iam.AccessKeyMetadata{
+				AccessKeyMetadata: []types.AccessKeyMetadata{
 					{
-						AccessKeyId: awsgo.String("test-key"),
+						AccessKeyId: aws.String("test-key"),
 					},
 				},
 			},
 			DeleteAccessKeyOutput: iam.DeleteAccessKeyOutput{},
 			ListSigningCertificatesOutput: iam.ListSigningCertificatesOutput{
-				Certificates: []*iam.SigningCertificate{
+				Certificates: []types.SigningCertificate{
 					{
-						CertificateId: awsgo.String("test-certificate"),
+						CertificateId: aws.String("test-certificate"),
 					},
 				},
 			},
 			DeleteSigningCertificateOutput: iam.DeleteSigningCertificateOutput{},
 			ListSSHPublicKeysOutput: iam.ListSSHPublicKeysOutput{
-				SSHPublicKeys: []*iam.SSHPublicKeyMetadata{
+				SSHPublicKeys: []types.SSHPublicKeyMetadata{
 					{
-						SSHPublicKeyId: awsgo.String("test-ssh-key"),
+						SSHPublicKeyId: aws.String("test-ssh-key"),
 					},
 				},
 			},
 			DeleteSSHPublicKeyOutput: iam.DeleteSSHPublicKeyOutput{},
 			ListServiceSpecificCredentialsOutput: iam.ListServiceSpecificCredentialsOutput{
-				ServiceSpecificCredentials: []*iam.ServiceSpecificCredentialMetadata{
+				ServiceSpecificCredentials: []types.ServiceSpecificCredentialMetadata{
 					{
-						ServiceSpecificCredentialId: awsgo.String("test-service-credential"),
+						ServiceSpecificCredentialId: aws.String("test-service-credential"),
 					},
 				},
 			},
 			DeleteServiceSpecificCredentialOutput: iam.DeleteServiceSpecificCredentialOutput{},
 			ListMFADevicesOutput: iam.ListMFADevicesOutput{
-				MFADevices: []*iam.MFADevice{
+				MFADevices: []types.MFADevice{
 					{
-						SerialNumber: awsgo.String("test-mfa-device"),
+						SerialNumber: aws.String("test-mfa-device"),
 					},
 				},
 			},
@@ -260,6 +253,6 @@ func TestIAMUsers_NukeAll(t *testing.T) {
 		},
 	}
 
-	err := iu.nukeAll([]*string{awsgo.String("test-user")})
+	err := iu.nukeAll([]*string{aws.String("test-user")})
 	require.NoError(t, err)
 }

--- a/aws/resources/iam_types.go
+++ b/aws/resources/iam_types.go
@@ -3,24 +3,48 @@ package resources
 import (
 	"context"
 
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+type IAMUsersAPI interface {
+	ListAccessKeys(ctx context.Context, params *iam.ListAccessKeysInput, optFns ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error)
+	ListGroupsForUser(ctx context.Context, params *iam.ListGroupsForUserInput, optFns ...func(*iam.Options)) (*iam.ListGroupsForUserOutput, error)
+	ListUserPolicies(ctx context.Context, params *iam.ListUserPoliciesInput, optFns ...func(*iam.Options)) (*iam.ListUserPoliciesOutput, error)
+	ListUserTags(ctx context.Context, params *iam.ListUserTagsInput, optFns ...func(*iam.Options)) (*iam.ListUserTagsOutput, error)
+	ListMFADevices(ctx context.Context, params *iam.ListMFADevicesInput, optFns ...func(*iam.Options)) (*iam.ListMFADevicesOutput, error)
+	ListSSHPublicKeys(ctx context.Context, params *iam.ListSSHPublicKeysInput, optFns ...func(*iam.Options)) (*iam.ListSSHPublicKeysOutput, error)
+	ListServiceSpecificCredentials(ctx context.Context, params *iam.ListServiceSpecificCredentialsInput, optFns ...func(*iam.Options)) (*iam.ListServiceSpecificCredentialsOutput, error)
+	ListSigningCertificates(ctx context.Context, params *iam.ListSigningCertificatesInput, optFns ...func(*iam.Options)) (*iam.ListSigningCertificatesOutput, error)
+	ListUsers(ctx context.Context, params *iam.ListUsersInput, optFns ...func(*iam.Options)) (*iam.ListUsersOutput, error)
+	ListAttachedUserPolicies(ctx context.Context, params *iam.ListAttachedUserPoliciesInput, optFns ...func(*iam.Options)) (*iam.ListAttachedUserPoliciesOutput, error)
+	DetachUserPolicy(ctx context.Context, params *iam.DetachUserPolicyInput, optFns ...func(*iam.Options)) (*iam.DetachUserPolicyOutput, error)
+	DeleteLoginProfile(ctx context.Context, params *iam.DeleteLoginProfileInput, optFns ...func(*iam.Options)) (*iam.DeleteLoginProfileOutput, error)
+	DeleteUserPolicy(ctx context.Context, params *iam.DeleteUserPolicyInput, optFns ...func(*iam.Options)) (*iam.DeleteUserPolicyOutput, error)
+	DeleteAccessKey(ctx context.Context, params *iam.DeleteAccessKeyInput, optFns ...func(*iam.Options)) (*iam.DeleteAccessKeyOutput, error)
+	DeleteSigningCertificate(ctx context.Context, params *iam.DeleteSigningCertificateInput, optFns ...func(*iam.Options)) (*iam.DeleteSigningCertificateOutput, error)
+	DeleteSSHPublicKey(ctx context.Context, params *iam.DeleteSSHPublicKeyInput, optFns ...func(*iam.Options)) (*iam.DeleteSSHPublicKeyOutput, error)
+	DeleteServiceSpecificCredential(ctx context.Context, params *iam.DeleteServiceSpecificCredentialInput, optFns ...func(*iam.Options)) (*iam.DeleteServiceSpecificCredentialOutput, error)
+	DeactivateMFADevice(ctx context.Context, params *iam.DeactivateMFADeviceInput, optFns ...func(*iam.Options)) (*iam.DeactivateMFADeviceOutput, error)
+	DeleteVirtualMFADevice(ctx context.Context, params *iam.DeleteVirtualMFADeviceInput, optFns ...func(*iam.Options)) (*iam.DeleteVirtualMFADeviceOutput, error)
+	DeleteUser(ctx context.Context, params *iam.DeleteUserInput, optFns ...func(*iam.Options)) (*iam.DeleteUserOutput, error)
+	RemoveUserFromGroup(ctx context.Context, params *iam.RemoveUserFromGroupInput, optFns ...func(*iam.Options)) (*iam.RemoveUserFromGroupOutput, error)
+}
+
 // IAMUsers - represents all IAMUsers on the AWS Account
 type IAMUsers struct {
 	BaseAwsResource
-	Client    iamiface.IAMAPI
+	Client    IAMUsersAPI
 	UserNames []string
 }
 
-func (iu *IAMUsers) Init(session *session.Session) {
-	iu.Client = iam.New(session)
+func (iu *IAMUsers) InitV2(cfg aws.Config) {
+	iu.Client = iam.NewFromConfig(cfg)
 }
+
+func (iu *IAMUsers) IsUsingV2() bool { return true }
 
 // ResourceName - the simple name of the aws resource
 func (iu *IAMUsers) ResourceName() string {
@@ -47,13 +71,13 @@ func (iu *IAMUsers) GetAndSetIdentifiers(c context.Context, configObj config.Con
 		return nil, err
 	}
 
-	iu.UserNames = awsgo.StringValueSlice(identifiers)
+	iu.UserNames = aws.ToStringSlice(identifiers)
 	return iu.UserNames, nil
 }
 
 // Nuke - nuke 'em all!!!
 func (iu *IAMUsers) Nuke(users []string) error {
-	if err := iu.nukeAll(awsgo.StringSlice(users)); err != nil {
+	if err := iu.nukeAll(aws.StringSlice(users)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.35.3
 	github.com/aws/aws-sdk-go-v2/service/guardduty v1.50.1
+	github.com/aws/aws-sdk-go-v2/service/iam v1.37.3
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.3
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.4
 	github.com/aws/aws-sdk-go-v2/service/ses v1.28.3

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/aws/aws-sdk-go-v2/service/eventbridge v1.35.3 h1:e/jGXEQi+lyTIhc3s+jb
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.35.3/go.mod h1:607CryyDS58whuaVno9CCg3L/nnWOqorxiyAS2f9leY=
 github.com/aws/aws-sdk-go-v2/service/guardduty v1.50.1 h1:0A05jzCVA6W/UFqdtpKm8KXE8QhcEn/Fn01Zxsq2Owg=
 github.com/aws/aws-sdk-go-v2/service/guardduty v1.50.1/go.mod h1:tfpIzAIeMtSUucGN87ZUA2u5Lqnc04ManYSk3smJpGc=
+github.com/aws/aws-sdk-go-v2/service/iam v1.37.3 h1:uuoXyOwX2ReYgHJW0W84cKDUrvQNQA2l9KhkXUgT+R4=
+github.com/aws/aws-sdk-go-v2/service/iam v1.37.3/go.mod h1:RCrjvkN/ZpVAzW3ZmIlyflv7MUM45YlWx3v+6MaVX2w=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.0 h1:TToQNkvGguu209puTojY/ozlqy2d/SFNcoLIqTFi42g=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.0/go.mod h1:0jp+ltwkf+SwG2fm/PKo8t4y8pJSgOCO4D8Lz3k0aHQ=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.3 h1:wudRPcZMKytcywXERkR6PLqD8gPx754ZyIOo0iVg488=

--- a/util/tag.go
+++ b/util/tag.go
@@ -3,8 +3,8 @@ package util
 import (
 	autoscaling "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	iam "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/networkfirewall"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -55,7 +55,7 @@ func ConvertStringPtrTagsToMap(tags map[string]*string) map[string]string {
 	return tagMap
 }
 
-func ConvertIAMTagsToMap(tags []*iam.Tag) map[string]string {
+func ConvertIAMTagsToMap(tags []iam.Tag) map[string]string {
 	tagMap := make(map[string]string)
 	for _, tag := range tags {
 		tagMap[*tag.Key] = *tag.Value

--- a/v2_migration_report/output.md
+++ b/v2_migration_report/output.md
@@ -52,11 +52,11 @@ run `go generate ./...` to refresh this report.
 | event-bridge-schedule            | :white_check_mark: |
 | event-bridge-schedule-group      | :white_check_mark: |
 | guardduty                        | :white_check_mark: |
-| iam                              |                    |
-| iam-group                        |                    |
-| iam-policy                       |                    |
-| iam-role                         |                    |
-| iam-service-linked-role          |                    |
+| iam                              | :white_check_mark: |
+| iam-group                        | :white_check_mark: |
+| iam-policy                       | :white_check_mark: |
+| iam-role                         | :white_check_mark: |
+| iam-service-linked-role          | :white_check_mark: |
 | internet-gateway                 |                    |
 | ipam                             |                    |
 | ipam-byoasn                      |                    |


### PR DESCRIPTION
## Description
change port resources to aws SDK v2
- iam
- iam-group
- iam-policy
- iam-role
- iam-service-linked-role

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

- [x] Updated iam, iam-group, iam-policy, iam-role, iam-service-linked-role resources to awsSDKv2 

### Migration Guide
n/a
