### PR TITLE
fix: Adding all regions to cloud nuke invocation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,24 @@ jobs:
               --older-than 2h \
               --force \
               --config ./.circleci/nuke_config.yml \
+              --region ap-northeast-1 \
+              --region ap-northeast-2 \
+              --region ap-northeast-3 \
+              --region ap-south-1 \
+              --region ap-southeast-1 \
+              --region ap-southeast-2 \
+              --region ca-central-1 \
+              --region eu-central-1 \
+              --region eu-north-1 \
+              --region eu-west-1 \
+              --region eu-west-2 \
+              --region eu-west-3 \
+              --region me-central-1 \
+              --region sa-east-1 \
+              --region us-east-1 \
+              --region us-east-2 \
+              --region us-west-1 \
+              --region us-west-2 \
               --exclude-resource-type iam \
               --exclude-resource-type iam-service-linked-role \
               --exclude-resource-type ecr \
@@ -102,6 +120,24 @@ jobs:
               --older-than 24h \
               --force \
               --config ./.circleci/nuke_config.yml \
+              --region ap-northeast-1 \
+              --region ap-northeast-2 \
+              --region ap-northeast-3 \
+              --region ap-south-1 \
+              --region ap-southeast-1 \
+              --region ap-southeast-2 \
+              --region ca-central-1 \
+              --region eu-central-1 \
+              --region eu-north-1 \
+              --region eu-west-1 \
+              --region eu-west-2 \
+              --region eu-west-3 \
+              --region me-central-1 \
+              --region sa-east-1 \
+              --region us-east-1 \
+              --region us-east-2 \
+              --region us-west-1 \
+              --region us-west-2 \
               --exclude-resource-type iam \
               --exclude-resource-type iam-service-linked-role \
               --exclude-resource-type ecr \


### PR DESCRIPTION
## Description

Fixes CI issue where all regions aren't being flushed.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

Updated the CI to flush all regions.

