### PR TITLE
fix #782 elasticache crash on `address or nil pointer dereference` in case we have a single node cluster.

### DIFF
--- a/aws/resources/elasticache.go
+++ b/aws/resources/elasticache.go
@@ -81,7 +81,7 @@ func (cache *Elasticaches) determineCacheClusterType(clusterId *string) (*string
 		}
 	}
 
-	if len(replicationGroupOutput.ReplicationGroups) > 0 {
+	if replicationGroupOutput != nil && len(replicationGroupOutput.ReplicationGroups) > 0 {
 		return replicationGroupOutput.ReplicationGroups[0].ReplicationGroupId, Replication, nil
 	}
 


### PR DESCRIPTION
## Description
running nuke on single node elasticache cluster fails with `address or nil pointer dereference`

Fixes #782

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.

## Release Notes (draft)
[x] Fixes #782 single node elasticache cluster fails with `address or nil pointer dereference`

### Migration Guide

n/a
