### PR TITLE
Migrate Snapshot to AWS SDK v2

### DIFF
--- a/v2_migration_report/output.md
+++ b/v2_migration_report/output.md
@@ -111,7 +111,7 @@ run `go generate ./...` to refresh this report.
 | ses-identity                     | :white_check_mark: |
 | ses-receipt-filter               | :white_check_mark: |
 | ses-receipt-rule-set             | :white_check_mark: |
-| snap                             |                    |
+| snap                             | :white_check_mark: |
 | snstopic                         | :white_check_mark: |
 | sqs                              | :white_check_mark: |
 | transit-gateway                  | :white_check_mark: |


### PR DESCRIPTION
## Description

Fixes #770.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

Updated `snapshot` to AWS SDK v2