### PR TITLE
Migrate OpenSearch to AWS SDK v2

### DIFF
--- a/aws/resources/opensearch.go
+++ b/aws/resources/opensearch.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/gruntwork-io/cloud-nuke/util"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/opensearchservice"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/opensearch"
+	"github.com/aws/aws-sdk-go-v2/service/opensearch/types"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
@@ -46,7 +47,7 @@ func (osd *OpenSearchDomains) getAll(c context.Context, configObj config.Config)
 			if firstSeenTime == nil {
 				err := osd.setFirstSeenTag(domain.ARN, time.Now().UTC())
 				if err != nil {
-					logging.Errorf("Error tagging the OpenSearch Domain with ARN %s with error: %s", aws.StringValue(domain.ARN), err.Error())
+					logging.Errorf("Error tagging the OpenSearch Domain with ARN %s with error: %s", aws.ToString(domain.ARN), err.Error())
 					return nil, errors.WithStackTrace(err)
 				}
 			}
@@ -63,9 +64,9 @@ func (osd *OpenSearchDomains) getAll(c context.Context, configObj config.Config)
 }
 
 // getAllActiveOpenSearchDomains filters all active OpenSearch domains, which are those that have the `Created` flag true and `Deleted` flag false.
-func (osd *OpenSearchDomains) getAllActiveOpenSearchDomains() ([]*opensearchservice.DomainStatus, error) {
+func (osd *OpenSearchDomains) getAllActiveOpenSearchDomains() ([]types.DomainStatus, error) {
 	allDomains := []*string{}
-	resp, err := osd.Client.ListDomainNamesWithContext(osd.Context, &opensearchservice.ListDomainNamesInput{})
+	resp, err := osd.Client.ListDomainNames(osd.Context, &opensearch.ListDomainNamesInput{})
 	if err != nil {
 		logging.Errorf("Error getting all OpenSearch domains")
 		return nil, errors.WithStackTrace(err)
@@ -74,16 +75,16 @@ func (osd *OpenSearchDomains) getAllActiveOpenSearchDomains() ([]*opensearchserv
 		allDomains = append(allDomains, domain.DomainName)
 	}
 
-	input := &opensearchservice.DescribeDomainsInput{DomainNames: allDomains}
-	describedDomains, describeErr := osd.Client.DescribeDomainsWithContext(osd.Context, input)
+	input := &opensearch.DescribeDomainsInput{DomainNames: aws.ToStringSlice(allDomains)}
+	describedDomains, describeErr := osd.Client.DescribeDomains(osd.Context, input)
 	if describeErr != nil {
 		logging.Errorf("Error describing Domains from input %s: ", input)
 		return nil, errors.WithStackTrace(describeErr)
 	}
 
-	filteredDomains := []*opensearchservice.DomainStatus{}
+	filteredDomains := []types.DomainStatus{}
 	for _, domain := range describedDomains.DomainStatusList {
-		if aws.BoolValue(domain.Created) && aws.BoolValue(domain.Deleted) == false {
+		if aws.ToBool(domain.Created) && aws.ToBool(domain.Deleted) == false {
 			filteredDomains = append(filteredDomains, domain)
 		}
 	}
@@ -92,12 +93,12 @@ func (osd *OpenSearchDomains) getAllActiveOpenSearchDomains() ([]*opensearchserv
 
 // Tag an OpenSearch Domain identified by the given ARN when it's first seen by cloud-nuke
 func (osd *OpenSearchDomains) setFirstSeenTag(domainARN *string, timestamp time.Time) error {
-	logging.Debugf("Tagging the OpenSearch Domain with ARN %s with first seen timestamp", aws.StringValue(domainARN))
+	logging.Debugf("Tagging the OpenSearch Domain with ARN %s with first seen timestamp", aws.ToString(domainARN))
 	firstSeenTime := util.FormatTimestamp(timestamp)
 
-	input := &opensearchservice.AddTagsInput{
+	input := &opensearch.AddTagsInput{
 		ARN: domainARN,
-		TagList: []*opensearchservice.Tag{
+		TagList: []types.Tag{
 			{
 				Key:   aws.String(firstSeenTagKey),
 				Value: aws.String(firstSeenTime),
@@ -105,7 +106,7 @@ func (osd *OpenSearchDomains) setFirstSeenTag(domainARN *string, timestamp time.
 		},
 	}
 
-	_, err := osd.Client.AddTags(input)
+	_, err := osd.Client.AddTags(osd.Context, input)
 	if err != nil {
 		return errors.WithStackTrace(err)
 	}
@@ -117,10 +118,10 @@ func (osd *OpenSearchDomains) setFirstSeenTag(domainARN *string, timestamp time.
 func (osd *OpenSearchDomains) getFirstSeenTag(domainARN *string) (*time.Time, error) {
 	var firstSeenTime *time.Time
 
-	input := &opensearchservice.ListTagsInput{ARN: domainARN}
-	domainTags, err := osd.Client.ListTags(input)
+	input := &opensearch.ListTagsInput{ARN: domainARN}
+	domainTags, err := osd.Client.ListTags(osd.Context, input)
 	if err != nil {
-		logging.Errorf("Error getting the tags for OpenSearch Domain with ARN %s", aws.StringValue(domainARN))
+		logging.Errorf("Error getting the tags for OpenSearch Domain with ARN %s", aws.ToString(domainARN))
 		return firstSeenTime, errors.WithStackTrace(err)
 	}
 
@@ -128,7 +129,7 @@ func (osd *OpenSearchDomains) getFirstSeenTag(domainARN *string) (*time.Time, er
 		if util.IsFirstSeenTag(tag.Key) {
 			firstSeenTime, err := util.ParseTimestamp(tag.Value)
 			if err != nil {
-				logging.Errorf("Error parsing the `cloud-nuke-first-seen` tag for OpenSearch Domain with ARN %s", aws.StringValue(domainARN))
+				logging.Errorf("Error parsing the `cloud-nuke-first-seen` tag for OpenSearch Domain with ARN %s", aws.ToString(domainARN))
 				return firstSeenTime, errors.WithStackTrace(err)
 			}
 
@@ -139,7 +140,7 @@ func (osd *OpenSearchDomains) getFirstSeenTag(domainARN *string) (*time.Time, er
 	return firstSeenTime, nil
 }
 
-// nukeAll nukes the given list of OpenSearch domains concurrently. Note that the opensearchservice API
+// nukeAll nukes the given list of OpenSearch domains concurrently. Note that the opensearch API
 // does not support bulk delete, so this routine will spawn a goroutine for each domain that needs to be nuked so that
 // they can be issued concurrently.
 func (osd *OpenSearchDomains) nukeAll(identifiers []*string) error {
@@ -148,8 +149,8 @@ func (osd *OpenSearchDomains) nukeAll(identifiers []*string) error {
 		return nil
 	}
 
-	// NOTE: we don't need to do pagination here, because the pagination is handled by the caller to this function,
-	// based on OpenSearchDomains.MaxBatchSize, however we add a guard here to warn users when the batching fails and has a
+	// NOTE: we don't need to do pagination here, because the caller handles the pagination to this function,
+	// based on OpenSearchDomains.MaxBatchSize, however, we add a guard here to warn users when the batching fails and has a
 	// chance of throttling AWS. Since we concurrently make one call for each identifier, we pick 100 for the limit here
 	// because many APIs in AWS have a limit of 100 requests per second.
 	if len(identifiers) > 100 {
@@ -187,7 +188,7 @@ func (osd *OpenSearchDomains) nukeAll(identifiers []*string) error {
 		// Wait a maximum of 5 minutes: 10 seconds in between, up to 30 times
 		30, 10*time.Second,
 		func() error {
-			resp, err := osd.Client.DescribeDomainsWithContext(osd.Context, &opensearchservice.DescribeDomainsInput{DomainNames: identifiers})
+			resp, err := osd.Client.DescribeDomains(osd.Context, &opensearch.DescribeDomainsInput{DomainNames: aws.ToStringSlice(identifiers)})
 			if err != nil {
 				return errors.WithStackTrace(retry.FatalError{Underlying: err})
 			}
@@ -201,7 +202,7 @@ func (osd *OpenSearchDomains) nukeAll(identifiers []*string) error {
 		return errors.WithStackTrace(err)
 	}
 	for _, domainName := range identifiers {
-		logging.Debugf("[OK] OpenSearch Domain %s was deleted in %s", aws.StringValue(domainName), osd.Region)
+		logging.Debugf("[OK] OpenSearch Domain %s was deleted in %s", aws.ToString(domainName), osd.Region)
 	}
 	return nil
 }
@@ -211,12 +212,12 @@ func (osd *OpenSearchDomains) nukeAll(identifiers []*string) error {
 func (osd *OpenSearchDomains) deleteAsync(wg *sync.WaitGroup, errChan chan error, domainName *string) {
 	defer wg.Done()
 
-	input := &opensearchservice.DeleteDomainInput{DomainName: domainName}
-	_, err := osd.Client.DeleteDomainWithContext(osd.Context, input)
+	input := &opensearch.DeleteDomainInput{DomainName: domainName}
+	_, err := osd.Client.DeleteDomain(osd.Context, input)
 
 	// Record status of this resource
 	e := report.Entry{
-		Identifier:   aws.StringValue(domainName),
+		Identifier:   aws.ToString(domainName),
 		ResourceType: "OpenSearch Domain",
 		Error:        err,
 	}

--- a/aws/resources/opensearch.go
+++ b/aws/resources/opensearch.go
@@ -6,14 +6,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gruntwork-io/cloud-nuke/util"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/opensearch"
 	"github.com/aws/aws-sdk-go-v2/service/opensearch/types"
+
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/go-commons/retry"
 	"github.com/hashicorp/go-multierror"

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kms v1.37.5
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.66.0
 	github.com/aws/aws-sdk-go-v2/service/macie2 v1.43.5
+	github.com/aws/aws-sdk-go-v2/service/opensearch v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.5
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.6
 	github.com/aws/aws-sdk-go-v2/service/ses v1.28.4

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/aws/aws-sdk-go-v2/service/lambda v1.66.0 h1:jMqMB8t/xbJnDdr11kH5rKdAh
 github.com/aws/aws-sdk-go-v2/service/lambda v1.66.0/go.mod h1:4L6vIpiChdahncljlDFzKWGiZsLgszGwDoYqMDhb6T4=
 github.com/aws/aws-sdk-go-v2/service/macie2 v1.43.5 h1:WJZG9ajCzS93t5qgG3NqVJqJqvpab9frc+2OhEszF/s=
 github.com/aws/aws-sdk-go-v2/service/macie2 v1.43.5/go.mod h1:uAeVP7yiKq1iECAGBsHgMzlUH77OIrmsA1CBmIIeCe4=
+github.com/aws/aws-sdk-go-v2/service/opensearch v1.44.0 h1:5U5Y6tWzqoP2Dr9APxkElg3tdMBsZd6PVWAq6NMYBbs=
+github.com/aws/aws-sdk-go-v2/service/opensearch v1.44.0/go.mod h1:JbyxgIAzR9wXnvVAqITjrpKRCcktIC+UWtPJ2meWZbg=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.5 h1:iitjgZ+/+ICxhA4EBvT5sqKchDcTiKBSOy+Ow0N8M+U=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.5/go.mod h1:xbnM3QuSlc52qQjTdDK3GptxYgDnGaonugLFdv5opq4=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.6 h1:EXJOAcfyr0atxiQdrHTnrVTCwO9udESAcQ96sWiJ8es=

--- a/v2_migration_report/output.md
+++ b/v2_migration_report/output.md
@@ -85,7 +85,7 @@ run `go generate ./...` to refresh this report.
 | network-firewall-tls-config      |                    |
 | network-interface                |                    |
 | oidcprovider                     |                    |
-| opensearchdomain                 |                    |
+| opensearchdomain                 | :white_check_mark: |
 | rds                              |                    |
 | rds-cluster                      |                    |
 | rds-global-cluster               |                    |


### PR DESCRIPTION
## Description

Fixes #770.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

Updated `opensearchservice` to AWS SDK v2