### PR TITLE
Migrate LC / LT to AWS SDK v2

### DIFF
--- a/aws/resources/launch_config.go
+++ b/aws/resources/launch_config.go
@@ -1,10 +1,9 @@
 package resources
 
 import (
-	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
@@ -12,8 +11,8 @@ import (
 )
 
 // Returns a formatted string of Launch config Names
-func (lc *LaunchConfigs) getAll(c context.Context, configObj config.Config) ([]*string, error) {
-	result, err := lc.Client.DescribeLaunchConfigurationsWithContext(lc.Context, &autoscaling.DescribeLaunchConfigurationsInput{})
+func (lc *LaunchConfigs) getAll(configObj config.Config) ([]*string, error) {
+	result, err := lc.Client.DescribeLaunchConfigurations(lc.Context, &autoscaling.DescribeLaunchConfigurationsInput{})
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
 	}
@@ -47,11 +46,11 @@ func (lc *LaunchConfigs) nukeAll(configNames []*string) error {
 			LaunchConfigurationName: configName,
 		}
 
-		_, err := lc.Client.DeleteLaunchConfigurationWithContext(lc.Context, params)
+		_, err := lc.Client.DeleteLaunchConfiguration(lc.Context, params)
 
 		// Record status of this resource
 		e := report.Entry{
-			Identifier:   aws.StringValue(configName),
+			Identifier:   aws.ToString(configName),
 			ResourceType: "Launch configuration",
 			Error:        err,
 		}

--- a/aws/resources/launch_template_test.go
+++ b/aws/resources/launch_template_test.go
@@ -6,26 +6,25 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/stretchr/testify/require"
 )
 
 type mockedLaunchTemplate struct {
-	ec2iface.EC2API
+	LaunchTemplatesAPI
 	DescribeLaunchTemplatesOutput ec2.DescribeLaunchTemplatesOutput
 	DeleteLaunchTemplateOutput    ec2.DeleteLaunchTemplateOutput
 }
 
-func (m mockedLaunchTemplate) DescribeLaunchTemplatesWithContext(_ aws.Context, input *ec2.DescribeLaunchTemplatesInput, _ ...request.Option) (*ec2.DescribeLaunchTemplatesOutput, error) {
+func (m mockedLaunchTemplate) DescribeLaunchTemplates(ctx context.Context, params *ec2.DescribeLaunchTemplatesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeLaunchTemplatesOutput, error) {
 	return &m.DescribeLaunchTemplatesOutput, nil
 }
 
-func (m mockedLaunchTemplate) DeleteLaunchTemplateWithContext(_ aws.Context, input *ec2.DeleteLaunchTemplateInput, _ ...request.Option) (*ec2.DeleteLaunchTemplateOutput, error) {
+func (m mockedLaunchTemplate) DeleteLaunchTemplate(ctx context.Context, params *ec2.DeleteLaunchTemplateInput, optFns ...func(*ec2.Options)) (*ec2.DeleteLaunchTemplateOutput, error) {
 	return &m.DeleteLaunchTemplateOutput, nil
 }
 
@@ -39,14 +38,14 @@ func TestLaunchTemplate_GetAll(t *testing.T) {
 	lt := LaunchTemplates{
 		Client: mockedLaunchTemplate{
 			DescribeLaunchTemplatesOutput: ec2.DescribeLaunchTemplatesOutput{
-				LaunchTemplates: []*ec2.LaunchTemplate{
+				LaunchTemplates: []types.LaunchTemplate{
 					{
-						LaunchTemplateName: awsgo.String(testName1),
-						CreateTime:         awsgo.Time(now),
+						LaunchTemplateName: aws.String(testName1),
+						CreateTime:         aws.Time(now),
 					},
 					{
-						LaunchTemplateName: awsgo.String(testName2),
-						CreateTime:         awsgo.Time(now.Add(1)),
+						LaunchTemplateName: aws.String(testName2),
+						CreateTime:         aws.Time(now.Add(1)),
 					},
 				},
 			},
@@ -73,7 +72,7 @@ func TestLaunchTemplate_GetAll(t *testing.T) {
 		"timeAfterExclusionFilter": {
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
-					TimeAfter: awsgo.Time(now),
+					TimeAfter: aws.Time(now),
 				}},
 			expected: []string{testName1},
 		},
@@ -84,7 +83,7 @@ func TestLaunchTemplate_GetAll(t *testing.T) {
 				LaunchTemplate: tc.configObj,
 			})
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, awsgo.StringValueSlice(names))
+			require.Equal(t, tc.expected, aws.ToStringSlice(names))
 		})
 	}
 }
@@ -99,6 +98,6 @@ func TestLaunchTemplate_NukeAll(t *testing.T) {
 		},
 	}
 
-	err := lt.nukeAll([]*string{awsgo.String("test")})
+	err := lt.nukeAll([]*string{aws.String("test")})
 	require.NoError(t, err)
 }

--- a/aws/resources/launch_template_types.go
+++ b/aws/resources/launch_template_types.go
@@ -2,26 +2,30 @@ package resources
 
 import (
 	"context"
-
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+type LaunchTemplatesAPI interface {
+	DeleteLaunchTemplate(ctx context.Context, params *ec2.DeleteLaunchTemplateInput, optFns ...func(*ec2.Options)) (*ec2.DeleteLaunchTemplateOutput, error)
+	DescribeLaunchTemplates(ctx context.Context, params *ec2.DescribeLaunchTemplatesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeLaunchTemplatesOutput, error)
+}
+
 // LaunchTemplates - represents all launch templates
 type LaunchTemplates struct {
 	BaseAwsResource
-	Client              ec2iface.EC2API
+	Client              LaunchTemplatesAPI
 	Region              string
 	LaunchTemplateNames []string
 }
 
-func (lt *LaunchTemplates) Init(session *session.Session) {
-	lt.Client = ec2.New(session)
+func (lt *LaunchTemplates) InitV2(cfg aws.Config) {
+	lt.Client = ec2.NewFromConfig(cfg)
 }
+
+func (lt *LaunchTemplates) IsUsingV2() bool { return true }
 
 // ResourceName - the simple name of the aws resource
 func (lt *LaunchTemplates) ResourceName() string {
@@ -48,13 +52,13 @@ func (lt *LaunchTemplates) GetAndSetIdentifiers(c context.Context, configObj con
 		return nil, err
 	}
 
-	lt.LaunchTemplateNames = awsgo.StringValueSlice(identifiers)
+	lt.LaunchTemplateNames = aws.ToStringSlice(identifiers)
 	return lt.LaunchTemplateNames, nil
 }
 
 // Nuke - nuke 'em all!!!
 func (lt *LaunchTemplates) Nuke(identifiers []string) error {
-	if err := lt.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
+	if err := lt.nukeAll(aws.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/v2_migration_report/output.md
+++ b/v2_migration_report/output.md
@@ -71,7 +71,7 @@ run `go generate ./...` to refresh this report.
 | kmscustomerkeys                  | :white_check_mark: |
 | lambda                           | :white_check_mark: |
 | lambda_layer                     | :white_check_mark: |
-| lc                               |                    |
+| lc                               | :white_check_mark: |
 | lt                               | :white_check_mark: |
 | macie-member                     | :white_check_mark: |
 | managed-prometheus               | :white_check_mark: |

--- a/v2_migration_report/output.md
+++ b/v2_migration_report/output.md
@@ -72,7 +72,7 @@ run `go generate ./...` to refresh this report.
 | lambda                           | :white_check_mark: |
 | lambda_layer                     | :white_check_mark: |
 | lc                               |                    |
-| lt                               |                    |
+| lt                               | :white_check_mark: |
 | macie-member                     | :white_check_mark: |
 | managed-prometheus               | :white_check_mark: |
 | msk-cluster                      |                    |


### PR DESCRIPTION
## Description

Fixes #770.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

Updated `launch_template` and `launch_config` to AWS SDK v2