### PR TITLE
Migrate to AWS SDK v2 for vpc and dependant services

### DIFF
--- a/aws/resources/ec2_egress_only_igw.go
+++ b/aws/resources/ec2_egress_only_igw.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	awsgo "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
@@ -15,10 +15,10 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-func shouldIncludeEgressOnlyInternetGateway(gateway *ec2.EgressOnlyInternetGateway, firstSeenTime *time.Time, configObj config.Config) bool {
+func shouldIncludeEgressOnlyInternetGateway(gateway types.EgressOnlyInternetGateway, firstSeenTime *time.Time, configObj config.Config) bool {
 	var gatewayName string
 	// get the tags as map
-	tagMap := util.ConvertEC2TagsToMap(gateway.Tags)
+	tagMap := util.ConvertTypesTagsToMap(gateway.Tags)
 	if name, ok := tagMap["Name"]; ok {
 		gatewayName = name
 	}
@@ -34,13 +34,13 @@ func (egigw *EgressOnlyInternetGateway) getAll(c context.Context, configObj conf
 	var firstSeenTime *time.Time
 	var err error
 
-	output, err := egigw.Client.DescribeEgressOnlyInternetGatewaysWithContext(egigw.Context, &ec2.DescribeEgressOnlyInternetGatewaysInput{})
+	output, err := egigw.Client.DescribeEgressOnlyInternetGateways(egigw.Context, &ec2.DescribeEgressOnlyInternetGatewaysInput{})
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
 	}
 
 	for _, igw := range output.EgressOnlyInternetGateways {
-		firstSeenTime, err = util.GetOrCreateFirstSeen(c, egigw.Client, igw.EgressOnlyInternetGatewayId, util.ConvertEC2TagsToMap(igw.Tags))
+		firstSeenTime, err = util.GetOrCreateFirstSeen(c, egigw.Client, igw.EgressOnlyInternetGatewayId, util.ConvertTypesTagsToMap(igw.Tags))
 		if err != nil {
 			logging.Error("Unable to retrieve tags")
 			return nil, errors.WithStackTrace(err)
@@ -51,7 +51,7 @@ func (egigw *EgressOnlyInternetGateway) getAll(c context.Context, configObj conf
 	}
 	// checking the nukable permissions
 	egigw.VerifyNukablePermissions(result, func(id *string) error {
-		_, err := egigw.Client.DeleteEgressOnlyInternetGatewayWithContext(egigw.Context, &ec2.DeleteEgressOnlyInternetGatewayInput{
+		_, err := egigw.Client.DeleteEgressOnlyInternetGateway(egigw.Context, &ec2.DeleteEgressOnlyInternetGatewayInput{
 			EgressOnlyInternetGatewayId: id,
 			DryRun:                      awsgo.Bool(true),
 		})
@@ -82,7 +82,7 @@ func (egigw *EgressOnlyInternetGateway) nukeAll(ids []*string) error {
 
 		// Record status of this resource
 		e := report.Entry{
-			Identifier:   awsgo.StringValue(id),
+			Identifier:   awsgo.ToString(id),
 			ResourceType: "Egress Only Internet Gateway",
 			Error:        err,
 		}
@@ -102,10 +102,10 @@ func (egigw *EgressOnlyInternetGateway) nukeAll(ids []*string) error {
 
 }
 
-func nukeEgressOnlyGateway(client ec2iface.EC2API, gateway *string) error {
-	logging.Debugf("[Nuke] Egress only gateway %s", awsgo.StringValue(gateway))
+func nukeEgressOnlyGateway(client EgressOnlyIGAPI, gateway *string) error {
+	logging.Debugf("[Nuke] Egress only gateway %s", awsgo.ToString(gateway))
 
-	_, err := client.DeleteEgressOnlyInternetGateway(&ec2.DeleteEgressOnlyInternetGatewayInput{
+	_, err := client.DeleteEgressOnlyInternetGateway(context.Background(), &ec2.DeleteEgressOnlyInternetGatewayInput{
 		EgressOnlyInternetGatewayId: gateway,
 	})
 	if err != nil {

--- a/aws/resources/ec2_egress_only_igw_types.go
+++ b/aws/resources/ec2_egress_only_igw_types.go
@@ -3,26 +3,31 @@ package resources
 import (
 	"context"
 
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsgo "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+type EgressOnlyIGAPI interface {
+	DescribeEgressOnlyInternetGateways(ctx context.Context, params *ec2.DescribeEgressOnlyInternetGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeEgressOnlyInternetGatewaysOutput, error)
+	DeleteEgressOnlyInternetGateway(ctx context.Context, params *ec2.DeleteEgressOnlyInternetGatewayInput, optFns ...func(*ec2.Options)) (*ec2.DeleteEgressOnlyInternetGatewayOutput, error)
+}
+
 // EgressOnlyInternetGateway represents all Egress only internet gateway
 type EgressOnlyInternetGateway struct {
 	BaseAwsResource
-	Client ec2iface.EC2API
+	Client EgressOnlyIGAPI
 	Region string
 	Pools  []string
 }
 
-func (egigw *EgressOnlyInternetGateway) Init(session *session.Session) {
-	egigw.BaseAwsResource.Init(session)
-	egigw.Client = ec2.New(session)
+func (egigw *EgressOnlyInternetGateway) InitV2(cfg aws.Config) {
+	egigw.Client = ec2.NewFromConfig(cfg)
 }
+
+func (egigw *EgressOnlyInternetGateway) IsUsingV2() bool { return true }
 
 // ResourceName - the simple name of the aws resource
 func (egigw *EgressOnlyInternetGateway) ResourceName() string {
@@ -49,7 +54,7 @@ func (egigw *EgressOnlyInternetGateway) GetAndSetIdentifiers(c context.Context, 
 		return nil, err
 	}
 
-	egigw.Pools = awsgo.StringValueSlice(identifiers)
+	egigw.Pools = awsgo.ToStringSlice(identifiers)
 	return egigw.Pools, nil
 }
 

--- a/aws/resources/ec2_endpoints.go
+++ b/aws/resources/ec2_endpoints.go
@@ -80,7 +80,7 @@ func (e *EC2Endpoints) nukeAll(identifiers []*string) error {
 			continue
 		}
 
-		err := e.nukeVpcEndpoint([]*string{id})
+		err := nukeVpcEndpoint(e.Client, []*string{id})
 
 		// Record status of this resource
 		e := report.Entry{
@@ -102,10 +102,10 @@ func (e *EC2Endpoints) nukeAll(identifiers []*string) error {
 	return nil
 }
 
-func (e *EC2Endpoints) nukeVpcEndpoint(endpointIds []*string) error {
+func nukeVpcEndpoint(client EC2EndpointsAPI, endpointIds []*string) error {
 	logging.Debugf("Deleting VPC endpoints %s", aws.ToStringSlice(endpointIds))
 
-	_, err := e.Client.DeleteVpcEndpoints(e.Context, &ec2.DeleteVpcEndpointsInput{
+	_, err := client.DeleteVpcEndpoints(context.Background(), &ec2.DeleteVpcEndpointsInput{
 		VpcEndpointIds: aws.ToStringSlice(endpointIds),
 	})
 	if err != nil {

--- a/aws/resources/ec2_internet_gateway_test.go
+++ b/aws/resources/ec2_internet_gateway_test.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 	"time"
 
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	awsgo "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
@@ -17,21 +16,21 @@ import (
 
 type mockedInternetGateway struct {
 	BaseAwsResource
-	ec2iface.EC2API
+	InternetGatewayAPI
 	DescribeInternetGatewaysOutput ec2.DescribeInternetGatewaysOutput
 	DetachInternetGatewayOutput    ec2.DetachInternetGatewayOutput
 	DeleteInternetGatewayOutput    ec2.DeleteInternetGatewayOutput
 }
 
-func (m mockedInternetGateway) DescribeInternetGatewaysWithContext(_ awsgo.Context, _ *ec2.DescribeInternetGatewaysInput, _ ...request.Option) (*ec2.DescribeInternetGatewaysOutput, error) {
+func (m mockedInternetGateway) DescribeInternetGateways(ctx context.Context, params *ec2.DescribeInternetGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInternetGatewaysOutput, error) {
 	return &m.DescribeInternetGatewaysOutput, nil
 }
 
-func (m mockedInternetGateway) DetachInternetGatewayWithContext(_ awsgo.Context, _ *ec2.DetachInternetGatewayInput, _ ...request.Option) (*ec2.DetachInternetGatewayOutput, error) {
+func (m mockedInternetGateway) DetachInternetGateway(ctx context.Context, params *ec2.DetachInternetGatewayInput, optFns ...func(*ec2.Options)) (*ec2.DetachInternetGatewayOutput, error) {
 	return &m.DetachInternetGatewayOutput, nil
 }
 
-func (m mockedInternetGateway) DeleteInternetGatewayWithContext(_ awsgo.Context, _ *ec2.DeleteInternetGatewayInput, _ ...request.Option) (*ec2.DeleteInternetGatewayOutput, error) {
+func (m mockedInternetGateway) DeleteInternetGateway(ctx context.Context, params *ec2.DeleteInternetGatewayInput, optFns ...func(*ec2.Options)) (*ec2.DeleteInternetGatewayOutput, error) {
 	return &m.DeleteInternetGatewayOutput, nil
 }
 
@@ -54,10 +53,10 @@ func TestEc2InternetGateway_GetAll(t *testing.T) {
 	igw := InternetGateway{
 		Client: mockedInternetGateway{
 			DescribeInternetGatewaysOutput: ec2.DescribeInternetGatewaysOutput{
-				InternetGateways: []*ec2.InternetGateway{
+				InternetGateways: []types.InternetGateway{
 					{
 						InternetGatewayId: awsgo.String(gateway1),
-						Tags: []*ec2.Tag{
+						Tags: []types.Tag{
 							{
 								Key:   awsgo.String("Name"),
 								Value: awsgo.String(testName1),
@@ -69,7 +68,7 @@ func TestEc2InternetGateway_GetAll(t *testing.T) {
 					},
 					{
 						InternetGatewayId: awsgo.String(gateway2),
-						Tags: []*ec2.Tag{
+						Tags: []types.Tag{
 							{
 								Key:   awsgo.String("Name"),
 								Value: awsgo.String(testName2),
@@ -120,7 +119,7 @@ func TestEc2InternetGateway_GetAll(t *testing.T) {
 				InternetGateway: tc.configObj,
 			})
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, awsgo.StringValueSlice(names))
+			require.Equal(t, tc.expected, awsgo.ToStringSlice(names))
 		})
 	}
 
@@ -143,21 +142,21 @@ func TestEc2InternetGateway_NukeAll(t *testing.T) {
 		},
 		Client: mockedInternetGateway{
 			DescribeInternetGatewaysOutput: ec2.DescribeInternetGatewaysOutput{
-				InternetGateways: []*ec2.InternetGateway{
+				InternetGateways: []types.InternetGateway{
 					{
 						InternetGatewayId: awsgo.String(gateway1),
-						Attachments: []*ec2.InternetGatewayAttachment{
+						Attachments: []types.InternetGatewayAttachment{
 							{
-								State: awsgo.String("testing-state"),
+								State: "testing-state",
 								VpcId: awsgo.String("test-gateway-vpc"),
 							},
 						},
 					},
 					{
 						InternetGatewayId: awsgo.String(gateway2),
-						Attachments: []*ec2.InternetGatewayAttachment{
+						Attachments: []types.InternetGatewayAttachment{
 							{
-								State: awsgo.String("testing-state"),
+								State: "testing-state",
 								VpcId: awsgo.String("test-gateway-vpc"),
 							},
 						},

--- a/aws/resources/ec2_internet_gateway_types.go
+++ b/aws/resources/ec2_internet_gateway_types.go
@@ -3,31 +3,35 @@ package resources
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+type InternetGatewayAPI interface {
+	DescribeInternetGateways(ctx context.Context, params *ec2.DescribeInternetGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInternetGatewaysOutput, error)
+	DeleteInternetGateway(ctx context.Context, params *ec2.DeleteInternetGatewayInput, optFns ...func(*ec2.Options)) (*ec2.DeleteInternetGatewayOutput, error)
+	DetachInternetGateway(ctx context.Context, params *ec2.DetachInternetGatewayInput, optFns ...func(*ec2.Options)) (*ec2.DetachInternetGatewayOutput, error)
+}
+
 type InternetGateway struct {
 	BaseAwsResource
-	Client        ec2iface.EC2API
+	Client        InternetGatewayAPI
 	Region        string
 	GatewayIds    []string
 	GatewayVPCMap map[string]string
 }
 
-func (igw *InternetGateway) Init(session *session.Session) {
-	igw.BaseAwsResource.Init(session)
-	igw.Client = ec2.New(session)
-
+func (igw *InternetGateway) InitV2(cfg aws.Config) {
+	igw.Client = ec2.NewFromConfig(cfg)
 	// Since the nuking of the internet gateway requires the VPC ID, and to avoid redundant API calls for this information within the nuke method,
 	// we utilize the getAll method to retrieve it.
 	// This map is used to store the information and access the value within the nuke method.
 	igw.GatewayVPCMap = make(map[string]string)
 }
+
+func (igw *InternetGateway) IsUsingV2() bool { return true }
 
 func (igw *InternetGateway) ResourceName() string {
 	return "internet-gateway"
@@ -51,7 +55,7 @@ func (igw *InternetGateway) GetAndSetIdentifiers(c context.Context, configObj co
 		return nil, err
 	}
 
-	igw.GatewayIds = aws.StringValueSlice(identifiers)
+	igw.GatewayIds = aws.ToStringSlice(identifiers)
 	return igw.GatewayIds, nil
 }
 

--- a/aws/resources/ec2_network_acl_test.go
+++ b/aws/resources/ec2_network_acl_test.go
@@ -6,82 +6,72 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	awsgo "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 )
 
 type mockedNetworkACL struct {
-	BaseAwsResource
-	ec2iface.EC2API
-
 	DescribeNetworkAclsOutput          ec2.DescribeNetworkAclsOutput
 	DeleteNetworkAclOutput             ec2.DeleteNetworkAclOutput
 	ReplaceNetworkAclAssociationOutput ec2.ReplaceNetworkAclAssociationOutput
 }
 
-func (m mockedNetworkACL) DescribeNetworkAclsWithContext(_ awsgo.Context, _ *ec2.DescribeNetworkAclsInput, _ ...request.Option) (*ec2.DescribeNetworkAclsOutput, error) {
+func (m *mockedNetworkACL) DescribeNetworkAcls(ctx context.Context, params *ec2.DescribeNetworkAclsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkAclsOutput, error) {
 	return &m.DescribeNetworkAclsOutput, nil
 }
 
-func (m mockedNetworkACL) DeleteNetworkAcl(_ *ec2.DeleteNetworkAclInput) (*ec2.DeleteNetworkAclOutput, error) {
+func (m *mockedNetworkACL) DeleteNetworkAcl(ctx context.Context, params *ec2.DeleteNetworkAclInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNetworkAclOutput, error) {
 	return &m.DeleteNetworkAclOutput, nil
 }
 
-func (m mockedNetworkACL) DeleteNetworkAclWithContext(_ awsgo.Context, _ *ec2.DeleteNetworkAclInput, _ ...request.Option) (*ec2.DeleteNetworkAclOutput, error) {
-	return &m.DeleteNetworkAclOutput, nil
-}
-
-func (m mockedNetworkACL) ReplaceNetworkAclAssociation(_ *ec2.ReplaceNetworkAclAssociationInput) (*ec2.ReplaceNetworkAclAssociationOutput, error) {
+func (m *mockedNetworkACL) ReplaceNetworkAclAssociation(ctx context.Context, params *ec2.ReplaceNetworkAclAssociationInput, optFns ...func(*ec2.Options)) (*ec2.ReplaceNetworkAclAssociationOutput, error) {
 	return &m.ReplaceNetworkAclAssociationOutput, nil
 }
 
 func TestNetworkAcl_GetAll(t *testing.T) {
 
-	// Set excludeFirstSeenTag to false for testing
 	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
 
 	var (
 		now     = time.Now()
-		testId1 = "acl-09e36c45cbdbfb001"
-		testId2 = "acl-09e36c45cbdbfb002"
+		testId1 = awsgo.String("acl-09e36c45cbdbfb001")
+		testId2 = awsgo.String("acl-09e36c45cbdbfb002")
 
 		testName1 = "cloud-nuke-acl-001"
 		testName2 = "cloud-nuke-acl-002"
 	)
 
 	resourceObject := NetworkACL{
-		Client: mockedNetworkACL{
+		Client: &mockedNetworkACL{
 			DescribeNetworkAclsOutput: ec2.DescribeNetworkAclsOutput{
-				NetworkAcls: []*ec2.NetworkAcl{
+				NetworkAcls: []types.NetworkAcl{
 					{
-						NetworkAclId: aws.String(testId1),
-						Tags: []*ec2.Tag{
+						NetworkAclId: testId1,
+						Tags: []types.Tag{
 							{
-								Key:   aws.String("Name"),
-								Value: aws.String(testName1),
+								Key:   awsgo.String("Name"),
+								Value: awsgo.String(testName1),
 							},
 							{
-								Key:   aws.String(util.FirstSeenTagKey),
-								Value: aws.String(util.FormatTimestamp(now)),
+								Key:   awsgo.String(util.FirstSeenTagKey),
+								Value: awsgo.String(util.FormatTimestamp(now)),
 							},
 						},
 					},
 					{
-						NetworkAclId: aws.String(testId2),
-						Tags: []*ec2.Tag{
+						NetworkAclId: testId2,
+						Tags: []types.Tag{
 							{
-								Key:   aws.String("Name"),
-								Value: aws.String(testName2),
+								Key:   awsgo.String("Name"),
+								Value: awsgo.String(testName2),
 							},
 							{
-								Key:   aws.String(util.FirstSeenTagKey),
-								Value: aws.String(util.FormatTimestamp(now.Add(1 * time.Hour))),
+								Key:   awsgo.String(util.FirstSeenTagKey),
+								Value: awsgo.String(util.FormatTimestamp(now.Add(1 * time.Hour))),
 							},
 						},
 					},
@@ -94,12 +84,12 @@ func TestNetworkAcl_GetAll(t *testing.T) {
 	tests := map[string]struct {
 		ctx       context.Context
 		configObj config.ResourceType
-		expected  []string
+		expected  []*string
 	}{
 		"emptyFilter": {
 			ctx:       ctx,
 			configObj: config.ResourceType{},
-			expected:  []string{testId1, testId2},
+			expected:  []*string{testId1, testId2},
 		},
 		"nameExclusionFilter": {
 			ctx: ctx,
@@ -109,7 +99,7 @@ func TestNetworkAcl_GetAll(t *testing.T) {
 						RE: *regexp.MustCompile(testName1),
 					}}},
 			},
-			expected: []string{testId2},
+			expected: []*string{testId2},
 		},
 		"nameInclusionFilter": {
 			ctx: ctx,
@@ -119,17 +109,15 @@ func TestNetworkAcl_GetAll(t *testing.T) {
 						RE: *regexp.MustCompile(testName1),
 					}}},
 			},
-			expected: []string{testId1},
+			expected: []*string{testId1},
 		},
 		"timeAfterExclusionFilter": {
 			ctx: ctx,
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
-					TimeAfter: aws.Time(now),
+					TimeAfter: awsgo.Time(now),
 				}},
-			expected: []string{
-				testId1,
-			},
+			expected: []*string{testId1},
 		},
 	}
 	for name, tc := range tests {
@@ -138,14 +126,12 @@ func TestNetworkAcl_GetAll(t *testing.T) {
 				NetworkACL: tc.configObj,
 			})
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, aws.StringValueSlice(names))
+			require.Equal(t, tc.expected, names)
 		})
 	}
-
 }
 
 func TestNetworkAcl_NukeAll(t *testing.T) {
-
 	var (
 		testId1 = "acl-09e36c45cbdbfb001"
 		testId2 = "acl-09e36c45cbdbfb002"
@@ -155,42 +141,38 @@ func TestNetworkAcl_NukeAll(t *testing.T) {
 	)
 
 	resourceObject := NetworkACL{
-		BaseAwsResource: BaseAwsResource{
-			Nukables: map[string]error{
-				testId1: nil,
-				testId2: nil,
-			},
-		},
-		Client: mockedNetworkACL{
+		Client: &mockedNetworkACL{
 			DescribeNetworkAclsOutput: ec2.DescribeNetworkAclsOutput{
-				NetworkAcls: []*ec2.NetworkAcl{
+				NetworkAcls: []types.NetworkAcl{
 					{
-						NetworkAclId: aws.String(testId1),
-						Associations: []*ec2.NetworkAclAssociation{
+						NetworkAclId: awsgo.String(testId1),
+						Associations: []types.NetworkAclAssociation{
 							{
-								NetworkAclAssociationId: aws.String("assoc-09e36c45cbdbfb001"),
-								NetworkAclId:            aws.String("acl-09e36c45cbdbfb001"),
+								NetworkAclAssociationId: awsgo.String("assoc-09e36c45cbdbfb001"),
+								NetworkAclId:            awsgo.String(testId1),
+								SubnetId:                awsgo.String("subnet-1234"),
 							},
 						},
-						Tags: []*ec2.Tag{
+						Tags: []types.Tag{
 							{
-								Key:   aws.String("Name"),
-								Value: aws.String(testName1),
+								Key:   awsgo.String("Name"),
+								Value: awsgo.String(testName1),
 							},
 						},
 					},
 					{
-						NetworkAclId: aws.String(testId2),
-						Associations: []*ec2.NetworkAclAssociation{
+						NetworkAclId: awsgo.String(testId2),
+						Associations: []types.NetworkAclAssociation{
 							{
-								NetworkAclAssociationId: aws.String("assoc-09e36c45cbdbfb002"),
-								NetworkAclId:            aws.String("acl-09e36c45cbdbfb002"),
+								NetworkAclAssociationId: awsgo.String("assoc-09e36c45cbdbfb002"),
+								NetworkAclId:            awsgo.String(testId2),
+								SubnetId:                awsgo.String("subnet-5678"),
 							},
 						},
-						Tags: []*ec2.Tag{
+						Tags: []types.Tag{
 							{
-								Key:   aws.String("Name"),
-								Value: aws.String(testName2),
+								Key:   awsgo.String("Name"),
+								Value: awsgo.String(testName2),
 							},
 						},
 					},
@@ -198,10 +180,9 @@ func TestNetworkAcl_NukeAll(t *testing.T) {
 			},
 		},
 	}
-
 	err := resourceObject.nukeAll([]*string{
-		aws.String(testId1),
-		aws.String(testId2),
+		awsgo.String(testId1),
+		awsgo.String(testId2),
 	})
 	require.NoError(t, err)
 }

--- a/aws/resources/ec2_network_acl_types.go
+++ b/aws/resources/ec2_network_acl_types.go
@@ -3,25 +3,30 @@ package resources
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+type NetworkACLAPI interface {
+	DescribeNetworkAcls(ctx context.Context, params *ec2.DescribeNetworkAclsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkAclsOutput, error)
+	DeleteNetworkAcl(ctx context.Context, params *ec2.DeleteNetworkAclInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNetworkAclOutput, error)
+	ReplaceNetworkAclAssociation(ctx context.Context, params *ec2.ReplaceNetworkAclAssociationInput, optFns ...func(*ec2.Options)) (*ec2.ReplaceNetworkAclAssociationOutput, error) // Add this line
+}
+
 type NetworkACL struct {
 	BaseAwsResource
-	Client ec2iface.EC2API
+	Client NetworkACLAPI
 	Region string
 	Ids    []string
 }
 
-func (nacl *NetworkACL) Init(session *session.Session) {
-	nacl.BaseAwsResource.Init(session)
-	nacl.Client = ec2.New(session)
+func (nacl *NetworkACL) InitV2(cfg aws.Config) {
+	nacl.Client = ec2.NewFromConfig(cfg)
 }
+
+func (nacl *NetworkACL) IsUsingV2() bool { return true }
 
 func (nacl *NetworkACL) ResourceName() string {
 	return "network-acl"
@@ -45,7 +50,7 @@ func (nacl *NetworkACL) GetAndSetIdentifiers(c context.Context, configObj config
 		return nil, err
 	}
 
-	nacl.Ids = aws.StringValueSlice(identifiers)
+	nacl.Ids = aws.ToStringSlice(identifiers)
 	return nacl.Ids, nil
 }
 

--- a/aws/resources/ec2_network_interface_test.go
+++ b/aws/resources/ec2_network_interface_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	awsgo "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
@@ -17,39 +17,33 @@ import (
 
 type mockedNetworkInterface struct {
 	BaseAwsResource
-	ec2iface.EC2API
+	NetworkInterfaceAPI
 	DescribeNetworkInterfacesOutput ec2.DescribeNetworkInterfacesOutput
 	DeleteNetworkInterfaceOutput    ec2.DeleteNetworkInterfaceOutput
 	DescribeAddressesOutput         ec2.DescribeAddressesOutput
 	TerminateInstancesOutput        ec2.TerminateInstancesOutput
 	ReleaseAddressOutput            ec2.ReleaseAddressOutput
+	DescribeNetworkInterfacesError  error
 }
 
-func (m mockedNetworkInterface) DescribeNetworkInterfacesWithContext(_ awsgo.Context, _ *ec2.DescribeNetworkInterfacesInput, _ ...request.Option) (*ec2.DescribeNetworkInterfacesOutput, error) {
-	return &m.DescribeNetworkInterfacesOutput, nil
+func (m mockedNetworkInterface) DescribeNetworkInterfaces(ctx context.Context, params *ec2.DescribeNetworkInterfacesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	return &m.DescribeNetworkInterfacesOutput, m.DescribeNetworkInterfacesError
 }
 
-func (m mockedNetworkInterface) DeleteNetworkInterface(_ *ec2.DeleteNetworkInterfaceInput) (*ec2.DeleteNetworkInterfaceOutput, error) {
+func (m mockedNetworkInterface) DeleteNetworkInterface(ctx context.Context, params *ec2.DeleteNetworkInterfaceInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNetworkInterfaceOutput, error) {
 	return &m.DeleteNetworkInterfaceOutput, nil
 }
-func (m mockedNetworkInterface) DeleteNetworkInterfaceWithContext(_ awsgo.Context, _ *ec2.DeleteNetworkInterfaceInput, _ ...request.Option) (*ec2.DeleteNetworkInterfaceOutput, error) {
-	return &m.DeleteNetworkInterfaceOutput, nil
-}
 
-func (m mockedNetworkInterface) DescribeAddressesWithContext(_ awsgo.Context, _ *ec2.DescribeAddressesInput, _ ...request.Option) (*ec2.DescribeAddressesOutput, error) {
+func (m mockedNetworkInterface) DescribeAddresses(ctx context.Context, params *ec2.DescribeAddressesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeAddressesOutput, error) {
 	return &m.DescribeAddressesOutput, nil
 }
 
-func (m mockedNetworkInterface) ReleaseAddressWithContext(_ awsgo.Context, _ *ec2.ReleaseAddressInput, _ ...request.Option) (*ec2.ReleaseAddressOutput, error) {
+func (m mockedNetworkInterface) ReleaseAddress(ctx context.Context, params *ec2.ReleaseAddressInput, optFns ...func(*ec2.Options)) (*ec2.ReleaseAddressOutput, error) {
 	return &m.ReleaseAddressOutput, nil
 }
 
-func (m mockedNetworkInterface) TerminateInstancesWithContext(_ awsgo.Context, _ *ec2.TerminateInstancesInput, _ ...request.Option) (*ec2.TerminateInstancesOutput, error) {
+func (m mockedNetworkInterface) TerminateInstances(ctx context.Context, params *ec2.TerminateInstancesInput, optFns ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error) {
 	return &m.TerminateInstancesOutput, nil
-}
-
-func (m mockedNetworkInterface) WaitUntilInstanceTerminatedWithContext(_ awsgo.Context, _ *ec2.DescribeInstancesInput, _ ...request.WaiterOption) error {
-	return nil
 }
 
 func TestNetworkInterface_GetAll(t *testing.T) {
@@ -69,11 +63,11 @@ func TestNetworkInterface_GetAll(t *testing.T) {
 	resourceObject := NetworkInterface{
 		Client: mockedNetworkInterface{
 			DescribeNetworkInterfacesOutput: ec2.DescribeNetworkInterfacesOutput{
-				NetworkInterfaces: []*ec2.NetworkInterface{
+				NetworkInterfaces: []types.NetworkInterface{
 					{
 						NetworkInterfaceId: awsgo.String(testId1),
-						InterfaceType:      awsgo.String(NetworkInterfaceTypeInterface),
-						TagSet: []*ec2.Tag{
+						InterfaceType:      NetworkInterfaceTypeInterface,
+						TagSet: []types.Tag{
 							{
 								Key:   awsgo.String("Name"),
 								Value: awsgo.String(testName1),
@@ -86,8 +80,8 @@ func TestNetworkInterface_GetAll(t *testing.T) {
 					},
 					{
 						NetworkInterfaceId: awsgo.String(testId2),
-						InterfaceType:      awsgo.String(NetworkInterfaceTypeInterface),
-						TagSet: []*ec2.Tag{
+						InterfaceType:      NetworkInterfaceTypeInterface,
+						TagSet: []types.Tag{
 							{
 								Key:   awsgo.String("Name"),
 								Value: awsgo.String(testName2),
@@ -151,7 +145,7 @@ func TestNetworkInterface_GetAll(t *testing.T) {
 				NetworkInterface: tc.configObj,
 			})
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, awsgo.StringValueSlice(names))
+			require.Equal(t, tc.expected, awsgo.ToStringSlice(names))
 		})
 	}
 
@@ -179,31 +173,31 @@ func TestNetworkInterface_NukeAll(t *testing.T) {
 		Client: mockedNetworkInterface{
 			DeleteNetworkInterfaceOutput: ec2.DeleteNetworkInterfaceOutput{},
 			DescribeNetworkInterfacesOutput: ec2.DescribeNetworkInterfacesOutput{
-				NetworkInterfaces: []*ec2.NetworkInterface{
+				NetworkInterfaces: []types.NetworkInterface{
 					{
 						NetworkInterfaceId: awsgo.String(testId1),
-						InterfaceType:      awsgo.String(NetworkInterfaceTypeInterface),
-						TagSet: []*ec2.Tag{
+						InterfaceType:      NetworkInterfaceTypeInterface,
+						TagSet: []types.Tag{
 							{
 								Key:   awsgo.String("Name"),
 								Value: awsgo.String(testName1),
 							},
 						},
-						Attachment: &ec2.NetworkInterfaceAttachment{
+						Attachment: &types.NetworkInterfaceAttachment{
 							AttachmentId: awsgo.String("network-attachment-09e36c45cbdbfb001"),
 							InstanceId:   awsgo.String("ec2-instance-09e36c45cbdbfb001"),
 						},
 					},
 					{
 						NetworkInterfaceId: awsgo.String(testId2),
-						InterfaceType:      awsgo.String(NetworkInterfaceTypeInterface),
-						TagSet: []*ec2.Tag{
+						InterfaceType:      NetworkInterfaceTypeInterface,
+						TagSet: []types.Tag{
 							{
 								Key:   awsgo.String("Name"),
 								Value: awsgo.String(testName2),
 							},
 						},
-						Attachment: &ec2.NetworkInterfaceAttachment{
+						Attachment: &types.NetworkInterfaceAttachment{
 							AttachmentId: awsgo.String("network-attachment-09e36c45cbdbfb002"),
 							InstanceId:   awsgo.String("ec2-instance-09e36c45cbdbfb002"),
 						},
@@ -211,7 +205,7 @@ func TestNetworkInterface_NukeAll(t *testing.T) {
 				},
 			},
 			DescribeAddressesOutput: ec2.DescribeAddressesOutput{
-				Addresses: []*ec2.Address{
+				Addresses: []types.Address{
 					{
 						AllocationId: awsgo.String("ec2-addr-alloc-09e36c45cbdbfb001"),
 						InstanceId:   awsgo.String("ec2-instance-09e36c45cbdbfb001"),
@@ -224,8 +218,12 @@ func TestNetworkInterface_NukeAll(t *testing.T) {
 			},
 			TerminateInstancesOutput: ec2.TerminateInstancesOutput{},
 			ReleaseAddressOutput:     ec2.ReleaseAddressOutput{},
+			DescribeNetworkInterfacesError: &smithy.GenericAPIError{
+				Code: "terminated",
+			},
 		},
 	}
+	resourceObject.Context = context.Background()
 
 	err := resourceObject.nukeAll([]*string{
 		awsgo.String(testId1),

--- a/aws/resources/ec2_subnet.go
+++ b/aws/resources/ec2_subnet.go
@@ -3,12 +3,11 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	awsgo "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
@@ -16,9 +15,9 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
-func shouldIncludeEc2Subnet(subnet *ec2.Subnet, firstSeenTime *time.Time, configObj config.Config) bool {
+func shouldIncludeEc2Subnet(subnet types.Subnet, firstSeenTime *time.Time, configObj config.Config) bool {
 	var subnetName string
-	tagMap := util.ConvertEC2TagsToMap(subnet.Tags)
+	tagMap := util.ConvertTypesTagsToMap(subnet.Tags)
 	if name, ok := tagMap["Name"]; ok {
 		subnetName = name
 	}
@@ -33,48 +32,50 @@ func shouldIncludeEc2Subnet(subnet *ec2.Subnet, firstSeenTime *time.Time, config
 // Returns a formatted string of EC2 subnets
 func (ec2subnet *EC2Subnet) getAll(c context.Context, configObj config.Config) ([]*string, error) {
 	result := []*string{}
-	var firstSeenTime *time.Time
-	var err error
 
-	// Note: This filter initially handles non-default resources and can be overridden by passing the only-default filter to choose default subnets.
+	// Configure filters
+	var filters []types.Filter
 	if configObj.EC2Subnet.DefaultOnly {
 		logging.Debugf("[default only] Retrieving the default subnets")
+		filters = append(filters, types.Filter{
+			Name:   awsgo.String("default-for-az"),
+			Values: []string{"true"},
+		})
 	}
 
-	err = ec2subnet.Client.DescribeSubnetsPagesWithContext(ec2subnet.Context, &ec2.DescribeSubnetsInput{
-		Filters: []*ec2.Filter{
-			{
-				Name: awsgo.String("default-for-az"),
-				Values: []*string{
-					awsgo.String(strconv.FormatBool(configObj.EC2Subnet.DefaultOnly)), // convert the bool status into string
-				},
-			},
-		},
-	}, func(pages *ec2.DescribeSubnetsOutput, lastPage bool) bool {
-		for _, subnet := range pages.Subnets {
-			firstSeenTime, err = util.GetOrCreateFirstSeen(c, ec2subnet.Client, subnet.SubnetId, util.ConvertEC2TagsToMap(subnet.Tags))
+	// Create paginator
+	paginator := ec2.NewDescribeSubnetsPaginator(ec2subnet.Client, &ec2.DescribeSubnetsInput{
+		Filters: filters,
+	})
+
+	// Iterate through pages
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(c)
+		if err != nil {
+			return nil, errors.WithStackTrace(err)
+		}
+
+		// Process subnets in the current page
+		for _, subnet := range page.Subnets {
+			firstSeenTime, err := util.GetOrCreateFirstSeen(c, ec2subnet.Client, subnet.SubnetId, util.ConvertTypesTagsToMap(subnet.Tags))
 			if err != nil {
 				logging.Error("unable to retrieve first seen tag")
 				continue
 			}
+
 			if shouldIncludeEc2Subnet(subnet, firstSeenTime, configObj) {
 				result = append(result, subnet.SubnetId)
 			}
 		}
-		return !lastPage
-	})
-
-	if err != nil {
-		return nil, errors.WithStackTrace(err)
 	}
 
-	// check the resources are nukable
+	// Check if resources are nukable
 	ec2subnet.VerifyNukablePermissions(result, func(id *string) error {
 		params := &ec2.DeleteSubnetInput{
 			SubnetId: id,
-			DryRun:   awsgo.Bool(true), // dry run set as true , checks permission without actually making the request
+			DryRun:   awsgo.Bool(true), // Check permissions without making the actual request
 		}
-		_, err := ec2subnet.Client.DeleteSubnetWithContext(ec2subnet.Context, params)
+		_, err := ec2subnet.Client.DeleteSubnet(c, params)
 		return err
 	})
 
@@ -105,7 +106,7 @@ func (ec2subnet *EC2Subnet) nukeAll(ids []*string) error {
 		err := nukeSubnet(ec2subnet.Client, id)
 		// Record status of this resource
 		e := report.Entry{
-			Identifier:   awsgo.StringValue(id),
+			Identifier:   awsgo.ToString(id),
 			ResourceType: "Subnet",
 			Error:        err,
 		}
@@ -124,20 +125,20 @@ func (ec2subnet *EC2Subnet) nukeAll(ids []*string) error {
 	return nil
 }
 
-func nukeSubnet(client ec2iface.EC2API, id *string) error {
+func nukeSubnet(client EC2SubnetAPI, id *string) error {
 	logging.Debug(fmt.Sprintf("Deleting subnet %s",
-		awsgo.StringValue(id)))
+		awsgo.ToString(id)))
 
-	_, err := client.DeleteSubnet(&ec2.DeleteSubnetInput{
+	_, err := client.DeleteSubnet(context.Background(), &ec2.DeleteSubnetInput{
 		SubnetId: id,
 	})
 	if err != nil {
 		logging.Debug(fmt.Sprintf("Failed to delete subnet %s",
-			awsgo.StringValue(id)))
+			awsgo.ToString(id)))
 		return errors.WithStackTrace(err)
 	}
 
 	logging.Debug(fmt.Sprintf("Successfully deleted subnet %s",
-		awsgo.StringValue(id)))
+		awsgo.ToString(id)))
 	return nil
 }

--- a/aws/resources/ec2_subnet_types.go
+++ b/aws/resources/ec2_subnet_types.go
@@ -3,26 +3,30 @@ package resources
 import (
 	"context"
 
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+type EC2SubnetAPI interface {
+	DeleteSubnet(ctx context.Context, params *ec2.DeleteSubnetInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSubnetOutput, error)
+	DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error)
+}
+
 // Ec2Subnet- represents all Subnets
 type EC2Subnet struct {
 	BaseAwsResource
-	Client  ec2iface.EC2API
+	Client  EC2SubnetAPI
 	Region  string
 	Subnets []string
 }
 
-func (es *EC2Subnet) Init(session *session.Session) {
-	es.BaseAwsResource.Init(session)
-	es.Client = ec2.New(session)
+func (es *EC2Subnet) InitV2(cfg aws.Config) {
+	es.Client = ec2.NewFromConfig(cfg)
 }
+
+func (es *EC2Subnet) IsUsingV2() bool { return true }
 
 // ResourceName - the simple name of the aws resource
 func (es *EC2Subnet) ResourceName() string {
@@ -45,13 +49,13 @@ func (es *EC2Subnet) GetAndSetIdentifiers(c context.Context, configObj config.Co
 		return nil, err
 	}
 
-	es.Subnets = awsgo.StringValueSlice(identifiers)
+	es.Subnets = aws.ToStringSlice(identifiers)
 	return es.Subnets, nil
 }
 
 // Nuke - nuke 'em all!!!
 func (es *EC2Subnet) Nuke(identifiers []string) error {
-	if err := es.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
+	if err := es.nukeAll(aws.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/resources/ec2_vpc_test.go
+++ b/aws/resources/ec2_vpc_test.go
@@ -6,20 +6,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsgo "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 )
 
 type mockedEC2VPCs struct {
-	ec2iface.EC2API
+	EC2VPCAPI
 	DescribeVpcsOutput                             ec2.DescribeVpcsOutput
 	DeleteVpcOutput                                ec2.DeleteVpcOutput
 	DescribeVpcPeeringConnectionsOutput            ec2.DescribeVpcPeeringConnectionsOutput
@@ -27,34 +26,34 @@ type mockedEC2VPCs struct {
 	TerminateInstancesOutput                       ec2.TerminateInstancesOutput
 	DescribeVpcEndpointServiceConfigurationsOutput ec2.DescribeVpcEndpointServiceConfigurationsOutput
 	DeleteVpcEndpointServiceConfigurationsOutput   ec2.DeleteVpcEndpointServiceConfigurationsOutput
+	DescribeInstancesError                         error
 }
 
-func (m mockedEC2VPCs) DescribeVpcsWithContext(_ awsgo.Context, _ *ec2.DescribeVpcsInput, _ ...request.Option) (*ec2.DescribeVpcsOutput, error) {
+func (m mockedEC2VPCs) DescribeVpcs(ctx context.Context, input *ec2.DescribeVpcsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
 	return &m.DescribeVpcsOutput, nil
 }
 
-func (m mockedEC2VPCs) DeleteVpc(_ *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error) {
+func (m mockedEC2VPCs) DeleteVpc(ctx context.Context, input *ec2.DeleteVpcInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVpcOutput, error) {
 	return &m.DeleteVpcOutput, nil
 }
-func (m mockedEC2VPCs) DescribeVpcPeeringConnectionsPages(_ *ec2.DescribeVpcPeeringConnectionsInput, callback func(*ec2.DescribeVpcPeeringConnectionsOutput, bool) bool) error {
-	callback(&m.DescribeVpcPeeringConnectionsOutput, true)
-	return nil
-}
-func (m mockedEC2VPCs) DescribeInstances(_ *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
-	return &m.DescribeInstancesOutput, nil
+
+func (m mockedEC2VPCs) DescribeVpcPeeringConnections(ctx context.Context, input *ec2.DescribeVpcPeeringConnectionsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcPeeringConnectionsOutput, error) {
+	return &m.DescribeVpcPeeringConnectionsOutput, nil
 }
 
-func (m mockedEC2VPCs) TerminateInstances(_ *ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error) {
+func (m mockedEC2VPCs) DescribeInstances(ctx context.Context, input *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	return &m.DescribeInstancesOutput, m.DescribeInstancesError
+}
+
+func (m mockedEC2VPCs) TerminateInstances(ctx context.Context, input *ec2.TerminateInstancesInput, optFns ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error) {
 	return &m.TerminateInstancesOutput, nil
 }
-func (m mockedEC2VPCs) WaitUntilInstanceTerminated(_ *ec2.DescribeInstancesInput) error {
-	return nil
-}
 
-func (m mockedEC2VPCs) DescribeVpcEndpointServiceConfigurations(_ *ec2.DescribeVpcEndpointServiceConfigurationsInput) (*ec2.DescribeVpcEndpointServiceConfigurationsOutput, error) {
+func (m mockedEC2VPCs) DescribeVpcEndpointServiceConfigurations(ctx context.Context, input *ec2.DescribeVpcEndpointServiceConfigurationsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointServiceConfigurationsOutput, error) {
 	return &m.DescribeVpcEndpointServiceConfigurationsOutput, nil
 }
-func (m mockedEC2VPCs) DeleteVpcEndpointServiceConfigurations(_ *ec2.DeleteVpcEndpointServiceConfigurationsInput) (*ec2.DeleteVpcEndpointServiceConfigurationsOutput, error) {
+
+func (m mockedEC2VPCs) DeleteVpcEndpointServiceConfigurations(ctx context.Context, input *ec2.DeleteVpcEndpointServiceConfigurationsInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVpcEndpointServiceConfigurationsOutput, error) {
 	return &m.DeleteVpcEndpointServiceConfigurationsOutput, nil
 }
 func TestEC2VPC_GetAll(t *testing.T) {
@@ -72,10 +71,10 @@ func TestEC2VPC_GetAll(t *testing.T) {
 	vpc := EC2VPCs{
 		Client: mockedEC2VPCs{
 			DescribeVpcsOutput: ec2.DescribeVpcsOutput{
-				Vpcs: []*ec2.Vpc{
+				Vpcs: []types.Vpc{
 					{
 						VpcId: awsgo.String(testId1),
-						Tags: []*ec2.Tag{
+						Tags: []types.Tag{
 							{
 								Key:   awsgo.String("Name"),
 								Value: awsgo.String(testName1),
@@ -88,7 +87,7 @@ func TestEC2VPC_GetAll(t *testing.T) {
 					},
 					{
 						VpcId: awsgo.String(testId2),
-						Tags: []*ec2.Tag{
+						Tags: []types.Tag{
 							{
 								Key:   awsgo.String("Name"),
 								Value: awsgo.String(testName2),
@@ -144,7 +143,7 @@ func TestEC2VPC_GetAll(t *testing.T) {
 				VPC: tc.configObj,
 			})
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, awsgo.StringValueSlice(names))
+			require.Equal(t, tc.expected, awsgo.ToStringSlice(names))
 		})
 	}
 }
@@ -177,7 +176,7 @@ func TestEC2VPCPeeringConnections_NukeAll(t *testing.T) {
 }
 
 type mockedEC2ELB struct {
-	elbv2iface.ELBV2API
+	ELBClientAPI
 	DescribeLoadBalancersOutput elbv2.DescribeLoadBalancersOutput
 	DeleteLoadBalancerOutput    elbv2.DeleteLoadBalancerOutput
 
@@ -185,17 +184,19 @@ type mockedEC2ELB struct {
 	DeleteTargetGroupOutput    elbv2.DeleteTargetGroupOutput
 }
 
-func (m mockedEC2ELB) DescribeLoadBalancers(*elbv2.DescribeLoadBalancersInput) (*elbv2.DescribeLoadBalancersOutput, error) {
+func (m mockedEC2ELB) DescribeLoadBalancers(ctx context.Context, input *elbv2.DescribeLoadBalancersInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeLoadBalancersOutput, error) {
 	return &m.DescribeLoadBalancersOutput, nil
 }
-func (m mockedEC2ELB) DescribeTargetGroups(*elbv2.DescribeTargetGroupsInput) (*elbv2.DescribeTargetGroupsOutput, error) {
+
+func (m mockedEC2ELB) DescribeTargetGroups(ctx context.Context, input *elbv2.DescribeTargetGroupsInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeTargetGroupsOutput, error) {
 	return &m.DescribeTargetGroupsOutput, nil
 }
 
-func (m mockedEC2ELB) DeleteLoadBalancer(*elbv2.DeleteLoadBalancerInput) (*elbv2.DeleteLoadBalancerOutput, error) {
+func (m mockedEC2ELB) DeleteLoadBalancer(ctx context.Context, input *elbv2.DeleteLoadBalancerInput, optFns ...func(*elbv2.Options)) (*elbv2.DeleteLoadBalancerOutput, error) {
 	return &m.DeleteLoadBalancerOutput, nil
 }
-func (m mockedEC2ELB) DeleteTargetGroup(*elbv2.DeleteTargetGroupInput) (*elbv2.DeleteTargetGroupOutput, error) {
+
+func (m mockedEC2ELB) DeleteTargetGroup(ctx context.Context, input *elbv2.DeleteTargetGroupInput, optFns ...func(*elbv2.Options)) (*elbv2.DeleteTargetGroupOutput, error) {
 	return &m.DeleteTargetGroupOutput, nil
 }
 
@@ -206,18 +207,17 @@ func TestAttachedLB_Nuke(t *testing.T) {
 	vpc := EC2VPCs{
 		Client: mockedEC2VPCs{
 			DescribeVpcEndpointServiceConfigurationsOutput: ec2.DescribeVpcEndpointServiceConfigurationsOutput{
-				ServiceConfigurations: []*ec2.ServiceConfiguration{
+				ServiceConfigurations: []types.ServiceConfiguration{
 					{
-						GatewayLoadBalancerArns: awsgo.StringSlice([]string{
-							"load-balancer-arn-00012",
-						}),
+						ServiceId:               aws.String("load-balancer-arn-service-id-00012"),
+						GatewayLoadBalancerArns: []string{"load-balancer-arn-00012"},
 					},
 				},
 			},
 		},
 		ELBClient: mockedEC2ELB{
 			DescribeLoadBalancersOutput: elbv2.DescribeLoadBalancersOutput{
-				LoadBalancers: []*elbv2.LoadBalancer{
+				LoadBalancers: []elbtypes.LoadBalancer{
 					{
 						VpcId:           awsgo.String(vpcID),
 						LoadBalancerArn: awsgo.String("load-balancer-arn-00012"),
@@ -227,6 +227,7 @@ func TestAttachedLB_Nuke(t *testing.T) {
 		},
 	}
 
+	vpc.Context = context.Background()
 	err := nukeAttachedLB(vpc.Client, vpc.ELBClient, vpcID)
 	require.NoError(t, err)
 }
@@ -238,7 +239,7 @@ func TestTargetGroup_Nuke(t *testing.T) {
 	vpc := EC2VPCs{
 		ELBClient: mockedEC2ELB{
 			DescribeTargetGroupsOutput: elbv2.DescribeTargetGroupsOutput{
-				TargetGroups: []*elbv2.TargetGroup{
+				TargetGroups: []elbtypes.TargetGroup{
 					{
 						VpcId:          awsgo.String(vpcID),
 						TargetGroupArn: awsgo.String("arn:aws:elasticloadbalancing:us-east-1:tg-001"),
@@ -249,29 +250,5 @@ func TestTargetGroup_Nuke(t *testing.T) {
 	}
 
 	err := nukeTargetGroups(vpc.ELBClient, vpcID)
-	require.NoError(t, err)
-}
-
-func TestEc2Instance_Nuke(t *testing.T) {
-	t.Parallel()
-	vpcID := "vpc-0e9a3e7c72d9f3a0f"
-
-	vpc := EC2VPCs{
-		Client: mockedEC2VPCs{
-			DescribeInstancesOutput: ec2.DescribeInstancesOutput{
-				Reservations: []*ec2.Reservation{
-					{
-						Instances: []*ec2.Instance{
-							{
-								InstanceId: awsgo.String("instance-001"),
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	err := nukeEc2Instances(vpc.Client, vpcID)
 	require.NoError(t, err)
 }

--- a/aws/resources/ec2_vpc_types.go
+++ b/aws/resources/ec2_vpc_types.go
@@ -3,28 +3,59 @@ package resources
 import (
 	"context"
 
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsgo "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+type EC2VPCAPI interface {
+	DescribeVpcs(ctx context.Context, params *ec2.DescribeVpcsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error)
+	DeleteVpc(ctx context.Context, params *ec2.DeleteVpcInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVpcOutput, error)
+	DescribeVpcEndpointServiceConfigurations(ctx context.Context, params *ec2.DescribeVpcEndpointServiceConfigurationsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointServiceConfigurationsOutput, error)
+	DeleteVpcEndpointServiceConfigurations(ctx context.Context, params *ec2.DeleteVpcEndpointServiceConfigurationsInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVpcEndpointServiceConfigurationsOutput, error)
+	DeleteVpcPeeringConnection(ctx context.Context, params *ec2.DeleteVpcPeeringConnectionInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVpcPeeringConnectionOutput, error)
+	DescribeVpcEndpoints(ctx context.Context, params *ec2.DescribeVpcEndpointsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointsOutput, error)
+	DescribeRouteTables(ctx context.Context, params *ec2.DescribeRouteTablesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error)
+	DisassociateRouteTable(ctx context.Context, params *ec2.DisassociateRouteTableInput, optFns ...func(*ec2.Options)) (*ec2.DisassociateRouteTableOutput, error)
+	DeleteRouteTable(ctx context.Context, params *ec2.DeleteRouteTableInput, optFns ...func(*ec2.Options)) (*ec2.DeleteRouteTableOutput, error)
+	DescribeSecurityGroupRules(ctx context.Context, params *ec2.DescribeSecurityGroupRulesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupRulesOutput, error)
+	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+	DescribeVpcPeeringConnections(ctx context.Context, params *ec2.DescribeVpcPeeringConnectionsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcPeeringConnectionsOutput, error)
+	AcceptAddressTransfer(ctx context.Context, params *ec2.AcceptAddressTransferInput, optFns ...func(*ec2.Options)) (*ec2.AcceptAddressTransferOutput, error)
+	NetworkInterfaceAPI
+	EC2DhcpOptionAPI
+	NetworkACLAPI
+	EC2EndpointsAPI
+	NetworkACLAPI
+	InternetGatewayAPI
+	EgressOnlyIGAPI
+	EC2SubnetAPI
+	NatGatewaysAPI
+	SecurityGroupAPI
+}
+type ELBClientAPI interface {
+	DescribeLoadBalancers(ctx context.Context, input *elbv2.DescribeLoadBalancersInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeLoadBalancersOutput, error)
+	DeleteLoadBalancer(ctx context.Context, input *elbv2.DeleteLoadBalancerInput, optFns ...func(*elbv2.Options)) (*elbv2.DeleteLoadBalancerOutput, error)
+	DescribeTargetGroups(ctx context.Context, input *elbv2.DescribeTargetGroupsInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeTargetGroupsOutput, error)
+	DeleteTargetGroup(ctx context.Context, input *elbv2.DeleteTargetGroupInput, optFns ...func(*elbv2.Options)) (*elbv2.DeleteTargetGroupOutput, error)
+}
 type EC2VPCs struct {
 	BaseAwsResource
-	Client    ec2iface.EC2API
-	ELBClient elbv2iface.ELBV2API
+	Client    EC2VPCAPI
+	ELBClient ELBClientAPI
 	Region    string
 	VPCIds    []string
 }
 
-func (v *EC2VPCs) Init(session *session.Session) {
-	v.Client = ec2.New(session)
-	v.ELBClient = elbv2.New(session)
+func (v *EC2VPCs) InitV2(cfg aws.Config) {
+	v.Client = ec2.NewFromConfig(cfg)
+	v.ELBClient = elbv2.NewFromConfig(cfg)
 }
+
+func (v *EC2VPCs) IsUsingV2() bool { return true }
 
 // ResourceName - the simple name of the aws resource
 func (v *EC2VPCs) ResourceName() string {
@@ -51,7 +82,7 @@ func (v *EC2VPCs) GetAndSetIdentifiers(c context.Context, configObj config.Confi
 		return nil, err
 	}
 
-	v.VPCIds = awsgo.StringValueSlice(identifiers)
+	v.VPCIds = awsgo.ToStringSlice(identifiers)
 	return v.VPCIds, nil
 }
 

--- a/aws/resources/nat_gateway_test.go
+++ b/aws/resources/nat_gateway_test.go
@@ -7,32 +7,26 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/stretchr/testify/require"
 )
 
 type mockedNatGateway struct {
-	ec2iface.EC2API
+	NatGatewaysAPI
 	DeleteNatGatewayOutput    ec2.DeleteNatGatewayOutput
 	DescribeNatGatewaysOutput ec2.DescribeNatGatewaysOutput
 	DescribeNatGatewaysError  error
 }
 
-func (m mockedNatGateway) DeleteNatGateway(input *ec2.DeleteNatGatewayInput) (*ec2.DeleteNatGatewayOutput, error) {
+func (m mockedNatGateway) DeleteNatGateway(ctx context.Context, params *ec2.DeleteNatGatewayInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNatGatewayOutput, error) {
 	return &m.DeleteNatGatewayOutput, nil
 }
 
-func (m mockedNatGateway) DescribeNatGatewaysPagesWithContext(_ aws.Context, input *ec2.DescribeNatGatewaysInput, fn func(*ec2.DescribeNatGatewaysOutput, bool) bool, _ ...request.Option) error {
-	fn(&m.DescribeNatGatewaysOutput, true)
-	return nil
-}
-
-func (m mockedNatGateway) DescribeNatGatewaysWithContext(_ aws.Context, input *ec2.DescribeNatGatewaysInput, _ ...request.Option) (*ec2.DescribeNatGatewaysOutput, error) {
+func (m mockedNatGateway) DescribeNatGateways(ctx context.Context, params *ec2.DescribeNatGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNatGatewaysOutput, error) {
 	return &m.DescribeNatGatewaysOutput, m.DescribeNatGatewaysError
 }
 
@@ -48,10 +42,10 @@ func TestNatGateway_GetAll(t *testing.T) {
 	ng := NatGateways{
 		Client: mockedNatGateway{
 			DescribeNatGatewaysOutput: ec2.DescribeNatGatewaysOutput{
-				NatGateways: []*ec2.NatGateway{
+				NatGateways: []types.NatGateway{
 					{
 						NatGatewayId: aws.String(testId1),
-						Tags: []*ec2.Tag{
+						Tags: []types.Tag{
 							{
 								Key:   aws.String("Name"),
 								Value: aws.String(testName1),
@@ -61,7 +55,7 @@ func TestNatGateway_GetAll(t *testing.T) {
 					},
 					{
 						NatGatewayId: aws.String(testId2),
-						Tags: []*ec2.Tag{
+						Tags: []types.Tag{
 							{
 								Key:   aws.String("Name"),
 								Value: aws.String(testName2),
@@ -105,7 +99,7 @@ func TestNatGateway_GetAll(t *testing.T) {
 				NatGateway: tc.configObj,
 			})
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, aws.StringValueSlice(names))
+			require.Equal(t, tc.expected, aws.ToStringSlice(names))
 		})
 	}
 }

--- a/aws/resources/nat_gateway_types.go
+++ b/aws/resources/nat_gateway_types.go
@@ -3,25 +3,30 @@ package resources
 import (
 	"context"
 
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+type NatGatewaysAPI interface {
+	DeleteNatGateway(ctx context.Context, params *ec2.DeleteNatGatewayInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNatGatewayOutput, error)
+	DescribeNatGateways(ctx context.Context, params *ec2.DescribeNatGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNatGatewaysOutput, error)
+}
+
 // NatGateways - represents all AWS secrets manager secrets that should be deleted.
 type NatGateways struct {
 	BaseAwsResource
-	Client        ec2iface.EC2API
+	Client        NatGatewaysAPI
 	Region        string
 	NatGatewayIDs []string
 }
 
-func (ngw *NatGateways) Init(session *session.Session) {
-	ngw.Client = ec2.New(session)
+func (ngw *NatGateways) InitV2(cfg aws.Config) {
+	ngw.Client = ec2.NewFromConfig(cfg)
 }
+
+func (ngw *NatGateways) IsUsingV2() bool { return true }
 
 // ResourceName - the simple name of the aws resource
 func (ngw *NatGateways) ResourceName() string {
@@ -50,13 +55,13 @@ func (ngw *NatGateways) GetAndSetIdentifiers(c context.Context, configObj config
 		return nil, err
 	}
 
-	ngw.NatGatewayIDs = awsgo.StringValueSlice(identifiers)
+	ngw.NatGatewayIDs = aws.ToStringSlice(identifiers)
 	return ngw.NatGatewayIDs, nil
 }
 
 // Nuke - nuke 'em all!!!
 func (ngw *NatGateways) Nuke(identifiers []string) error {
-	if err := ngw.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
+	if err := ngw.nukeAll(aws.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/resources/security_group_types.go
+++ b/aws/resources/security_group_types.go
@@ -3,26 +3,39 @@ package resources
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+type SecurityGroupAPI interface {
+	DescribeSecurityGroups(ctx context.Context, input *ec2.DescribeSecurityGroupsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error)
+	DeleteSecurityGroup(ctx context.Context, input *ec2.DeleteSecurityGroupInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error)
+	CreateSecurityGroup(ctx context.Context, input *ec2.CreateSecurityGroupInput, optFns ...func(*ec2.Options)) (*ec2.CreateSecurityGroupOutput, error)
+	AuthorizeSecurityGroupIngress(ctx context.Context, input *ec2.AuthorizeSecurityGroupIngressInput, optFns ...func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupIngressOutput, error)
+	RevokeSecurityGroupIngress(ctx context.Context, input *ec2.RevokeSecurityGroupIngressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error)
+	AuthorizeSecurityGroupEgress(ctx context.Context, input *ec2.AuthorizeSecurityGroupEgressInput, optFns ...func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupEgressOutput, error)
+	RevokeSecurityGroupEgress(ctx context.Context, input *ec2.RevokeSecurityGroupEgressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupEgressOutput, error)
+	DescribeInstances(ctx context.Context, input *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+	TerminateInstances(ctx context.Context, input *ec2.TerminateInstancesInput, optFns ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error)
+	DescribeAddresses(ctx context.Context, input *ec2.DescribeAddressesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeAddressesOutput, error)
+	ReleaseAddress(ctx context.Context, params *ec2.ReleaseAddressInput, optFns ...func(*ec2.Options)) (*ec2.ReleaseAddressOutput, error)
+}
+
 type SecurityGroup struct {
 	BaseAwsResource
-	Client          ec2iface.EC2API
+	Client          SecurityGroupAPI
 	Region          string
 	SecurityGroups  []string
 	NukeOnlyDefault bool
 }
 
-func (sg *SecurityGroup) Init(session *session.Session) {
-	sg.BaseAwsResource.Init(session)
-	sg.Client = ec2.New(session)
+func (sg *SecurityGroup) InitV2(cfg aws.Config) {
+	sg.Client = ec2.NewFromConfig(cfg)
 }
+
+func (sg *SecurityGroup) IsUsingV2() bool { return true }
 
 func (sg *SecurityGroup) ResourceName() string {
 	return "security-group"
@@ -42,7 +55,7 @@ func (sg *SecurityGroup) GetAndSetIdentifiers(c context.Context, configObj confi
 		return nil, err
 	}
 
-	sg.SecurityGroups = aws.StringValueSlice(identifiers)
+	sg.SecurityGroups = aws.ToStringSlice(identifiers)
 	return sg.SecurityGroups, nil
 }
 

--- a/util/error.go
+++ b/util/error.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/smithy-go"
 	commonErr "github.com/gruntwork-io/go-commons/errors"
 )
 
@@ -49,6 +50,12 @@ func TransformAWSError(err error) error {
 
 	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "DryRunOperation" && awsErr.Message() == AwsDryRunSuccess {
 		return nil
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		if apiErr.ErrorCode() == "DryRunOperation" && apiErr.ErrorMessage() == AwsDryRunSuccess {
+			return nil
+		}
 	}
 	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "InvalidPermission.NotFound" {
 		return ErrInvalidPermisionNotFound

--- a/util/time.go
+++ b/util/time.go
@@ -5,6 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	ec2v2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	nwfwall "github.com/aws/aws-sdk-go-v2/service/networkfirewall"
+	nwfTypes "github.com/aws/aws-sdk-go-v2/service/networkfirewall/types"
 	"github.com/aws/aws-sdk-go/aws"
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -96,6 +101,26 @@ func GetOrCreateFirstSeen(ctx context.Context, client interface{}, identifier *s
 					{
 						Key:   awsgo.String(FirstSeenTagKey),
 						Value: awsgo.String(FormatTimestamp(now)),
+					},
+				},
+			})
+		case *ec2v2.Client:
+			_, err = v.CreateTags(ctx, &ec2v2.CreateTagsInput{
+				Resources: []string{*identifier},
+				Tags: []ec2types.Tag{
+					{
+						Key:   awsv2.String(FirstSeenTagKey),
+						Value: awsv2.String(FormatTimestamp(now)),
+					},
+				},
+			})
+		case *nwfwall.Client:
+			_, err = v.TagResource(ctx, &nwfwall.TagResourceInput{
+				ResourceArn: identifier,
+				Tags: []nwfTypes.Tag{
+					{
+						Key:   awsv2.String(FirstSeenTagKey),
+						Value: awsv2.String(FormatTimestamp(now)),
 					},
 				},
 			})

--- a/v2_migration_report/output.md
+++ b/v2_migration_report/output.md
@@ -31,13 +31,13 @@ run `go generate ./...` to refresh this report.
 | ec2-endpoint                     | :white_check_mark: |
 | ec2-keypairs                     | :white_check_mark: |
 | ec2-placement-groups             | :white_check_mark: |
-| ec2-subnet                       |                    |
+| ec2-subnet                       | :white_check_mark: |
 | ec2_dhcp_option                  | :white_check_mark: |
 | ecr                              | :white_check_mark: |
 | ecscluster                       | :white_check_mark: |
 | ecsserv                          | :white_check_mark: |
 | efs                              | :white_check_mark: |
-| egress-only-internet-gateway     |                    |
+| egress-only-internet-gateway     | :white_check_mark: |
 | eip                              | :white_check_mark: |
 | ekscluster                       | :white_check_mark: |
 | elastic-beanstalk                | :white_check_mark: |
@@ -59,7 +59,7 @@ run `go generate ./...` to refresh this report.
 | iam-policy                       | :white_check_mark: |
 | iam-role                         | :white_check_mark: |
 | iam-service-linked-role          | :white_check_mark: |
-| internet-gateway                 |                    |
+| internet-gateway                 | :white_check_mark: |
 | ipam                             | :white_check_mark: |
 | ipam-byoasn                      | :white_check_mark: |
 | ipam-custom-allocation           | :white_check_mark: |
@@ -76,14 +76,14 @@ run `go generate ./...` to refresh this report.
 | macie-member                     | :white_check_mark: |
 | managed-prometheus               | :white_check_mark: |
 | msk-cluster                      | :white_check_mark: |
-| nat-gateway                      |                    |
-| network-acl                      |                    |
+| nat-gateway                      | :white_check_mark: |
+| network-acl                      | :white_check_mark: |
 | network-firewall                 | :white_check_mark: |
 | network-firewall-policy          | :white_check_mark: |
 | network-firewall-resource-policy | :white_check_mark: |
 | network-firewall-rule-group      | :white_check_mark: |
 | network-firewall-tls-config      | :white_check_mark: |
-| network-interface                |                    |
+| network-interface                | :white_check_mark: |
 | oidcprovider                     | :white_check_mark: |
 | opensearchdomain                 | :white_check_mark: |
 | rds                              | :white_check_mark: |
@@ -104,7 +104,7 @@ run `go generate ./...` to refresh this report.
 | s3-olap                          | :white_check_mark: |
 | sagemaker-notebook-smni          | :white_check_mark: |
 | secretsmanager                   | :white_check_mark: |
-| security-group                   |                    |
+| security-group                   | :white_check_mark: |
 | security-hub                     | :white_check_mark: |
 | ses-configuration-set            | :white_check_mark: |
 | ses-email-template               | :white_check_mark: |
@@ -117,7 +117,7 @@ run `go generate ./...` to refresh this report.
 | transit-gateway                  | :white_check_mark: |
 | transit-gateway-attachment       | :white_check_mark: |
 | transit-gateway-route-table      |                    |
-| vpc                              |                    |
+| vpc                              | :white_check_mark: |
 | vpc-lattice-service              | :white_check_mark: |
 | vpc-lattice-service-network      | :white_check_mark: |
 | vpc-lattice-target-group         | :white_check_mark: |


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
