### PR TITLE
Migrate to AWS SDK v2 for rds subnet group, snapshot, proxy, paramete…

### DIFF
--- a/aws/resources/rds_global_cluster_membership_types.go
+++ b/aws/resources/rds_global_cluster_membership_types.go
@@ -3,24 +3,29 @@ package resources
 import (
 	"context"
 
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+type DBGCMembershipsAPI interface {
+	DescribeGlobalClusters(ctx context.Context, params *rds.DescribeGlobalClustersInput, optFns ...func(*rds.Options)) (*rds.DescribeGlobalClustersOutput, error)
+	RemoveFromGlobalCluster(ctx context.Context, params *rds.RemoveFromGlobalClusterInput, optFns ...func(*rds.Options)) (*rds.RemoveFromGlobalClusterOutput, error)
+}
+
 type DBGlobalClusterMemberships struct {
 	BaseAwsResource
-	Client        rdsiface.RDSAPI
+	Client        DBGCMembershipsAPI
 	Region        string
 	InstanceNames []string
 }
 
-func (instance *DBGlobalClusterMemberships) Init(session *session.Session) {
-	instance.Client = rds.New(session)
+func (instance *DBGlobalClusterMemberships) InitV2(cfg aws.Config) {
+	instance.Client = rds.NewFromConfig(cfg)
 }
+
+func (instance *DBGlobalClusterMemberships) IsUsingV2() bool { return true }
 
 func (instance *DBGlobalClusterMemberships) ResourceName() string {
 	return "rds-global-cluster-membership"
@@ -46,13 +51,13 @@ func (instance *DBGlobalClusterMemberships) GetAndSetIdentifiers(c context.Conte
 		return nil, err
 	}
 
-	instance.InstanceNames = awsgo.StringValueSlice(identifiers)
+	instance.InstanceNames = aws.ToStringSlice(identifiers)
 	return instance.InstanceNames, nil
 }
 
 // Nuke - nuke 'em all!!!
 func (instance *DBGlobalClusterMemberships) Nuke(identifiers []string) error {
-	if err := instance.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
+	if err := instance.nukeAll(aws.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/resources/rds_global_cluster_types.go
+++ b/aws/resources/rds_global_cluster_types.go
@@ -3,24 +3,29 @@ package resources
 import (
 	"context"
 
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+type DBGlobalClustersAPI interface {
+	DescribeGlobalClusters(ctx context.Context, params *rds.DescribeGlobalClustersInput, optFns ...func(*rds.Options)) (*rds.DescribeGlobalClustersOutput, error)
+	DeleteGlobalCluster(ctx context.Context, params *rds.DeleteGlobalClusterInput, optFns ...func(*rds.Options)) (*rds.DeleteGlobalClusterOutput, error)
+}
+
 type DBGlobalClusters struct {
 	BaseAwsResource
-	Client        rdsiface.RDSAPI
+	Client        DBGlobalClustersAPI
 	Region        string
 	InstanceNames []string
 }
 
-func (instance *DBGlobalClusters) Init(session *session.Session) {
-	instance.Client = rds.New(session)
+func (instance *DBGlobalClusters) InitV2(cfg aws.Config) {
+	instance.Client = rds.NewFromConfig(cfg)
 }
+
+func (instance *DBGlobalClusters) IsUsingV2() bool { return true }
 
 func (instance *DBGlobalClusters) ResourceName() string {
 	return "rds-global-cluster"
@@ -46,13 +51,13 @@ func (instance *DBGlobalClusters) GetAndSetIdentifiers(c context.Context, config
 		return nil, err
 	}
 
-	instance.InstanceNames = awsgo.StringValueSlice(identifiers)
+	instance.InstanceNames = aws.ToStringSlice(identifiers)
 	return instance.InstanceNames, nil
 }
 
 // Nuke - nuke 'em all!!!
 func (instance *DBGlobalClusters) Nuke(identifiers []string) error {
-	if err := instance.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
+	if err := instance.nukeAll(aws.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/resources/rds_parameter_group_test.go
+++ b/aws/resources/rds_parameter_group_test.go
@@ -5,27 +5,25 @@ import (
 	"regexp"
 	"testing"
 
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+	awsgo "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type mockedRdsDBParameterGroup struct {
-	rdsiface.RDSAPI
+	RdsParameterGroupAPI
 	DescribeDBParameterGroupsOutput rds.DescribeDBParameterGroupsOutput
 	DeleteDBParameterGroupOutput    rds.DeleteDBParameterGroupOutput
 }
 
-func (m mockedRdsDBParameterGroup) DescribeDBParameterGroupsPagesWithContext(_ awsgo.Context, _ *rds.DescribeDBParameterGroupsInput, callback func(*rds.DescribeDBParameterGroupsOutput, bool) bool, _ ...request.Option) error {
-	callback(&m.DescribeDBParameterGroupsOutput, true)
-	return nil
+func (m mockedRdsDBParameterGroup) DescribeDBParameterGroups(ctx context.Context, params *rds.DescribeDBParameterGroupsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBParameterGroupsOutput, error) {
+	return &m.DescribeDBParameterGroupsOutput, nil
 }
 
-func (m mockedRdsDBParameterGroup) DeleteDBParameterGroupWithContext(_ awsgo.Context, _ *rds.DeleteDBParameterGroupInput, _ ...request.Option) (*rds.DeleteDBParameterGroupOutput, error) {
+func (m mockedRdsDBParameterGroup) DeleteDBParameterGroup(ctx context.Context, params *rds.DeleteDBParameterGroupInput, optFns ...func(*rds.Options)) (*rds.DeleteDBParameterGroupOutput, error) {
 	return &m.DeleteDBParameterGroupOutput, nil
 }
 
@@ -38,7 +36,7 @@ func TestRDSparameterGroupGetAll(t *testing.T) {
 	pg := RdsParameterGroup{
 		Client: mockedRdsDBParameterGroup{
 			DescribeDBParameterGroupsOutput: rds.DescribeDBParameterGroupsOutput{
-				DBParameterGroups: []*rds.DBParameterGroup{
+				DBParameterGroups: []types.DBParameterGroup{
 					{
 						DBParameterGroupName: awsgo.String(testName01),
 					},

--- a/aws/resources/rds_snapshot_types.go
+++ b/aws/resources/rds_snapshot_types.go
@@ -3,24 +3,29 @@ package resources
 import (
 	"context"
 
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+type RdsSnapshotAPI interface {
+	DescribeDBSnapshots(ctx context.Context, params *rds.DescribeDBSnapshotsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBSnapshotsOutput, error)
+	DeleteDBSnapshot(ctx context.Context, params *rds.DeleteDBSnapshotInput, optFns ...func(*rds.Options)) (*rds.DeleteDBSnapshotOutput, error)
+}
+
 type RdsSnapshot struct {
 	BaseAwsResource
-	Client      rdsiface.RDSAPI
+	Client      RdsSnapshotAPI
 	Region      string
 	Identifiers []string
 }
 
-func (snapshot *RdsSnapshot) Init(session *session.Session) {
-	snapshot.Client = rds.New(session)
+func (snapshot *RdsSnapshot) InitV2(cfg aws.Config) {
+	snapshot.Client = rds.NewFromConfig(cfg)
 }
+
+func (snapshot *RdsSnapshot) IsUsingV2() bool { return true }
 
 func (snapshot *RdsSnapshot) ResourceName() string {
 	return "rds-snapshot"
@@ -44,13 +49,13 @@ func (snapshot *RdsSnapshot) GetAndSetIdentifiers(c context.Context, configObj c
 		return nil, err
 	}
 
-	snapshot.Identifiers = awsgo.StringValueSlice(identifiers)
+	snapshot.Identifiers = aws.ToStringSlice(identifiers)
 	return snapshot.Identifiers, nil
 }
 
 // Nuke - nuke 'em all!!!
 func (snapshot *RdsSnapshot) Nuke(identifiers []string) error {
-	if err := snapshot.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
+	if err := snapshot.nukeAll(aws.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/aws/resources/rds_subnet_group_types.go
+++ b/aws/resources/rds_subnet_group_types.go
@@ -3,24 +3,29 @@ package resources
 import (
 	"context"
 
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+type DBSubnetGroupsAPI interface {
+	DescribeDBSubnetGroups(ctx context.Context, params *rds.DescribeDBSubnetGroupsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBSubnetGroupsOutput, error)
+	DeleteDBSubnetGroup(ctx context.Context, params *rds.DeleteDBSubnetGroupInput, optFns ...func(*rds.Options)) (*rds.DeleteDBSubnetGroupOutput, error)
+}
+
 type DBSubnetGroups struct {
 	BaseAwsResource
-	Client        rdsiface.RDSAPI
+	Client        DBSubnetGroupsAPI
 	Region        string
 	InstanceNames []string
 }
 
-func (dsg *DBSubnetGroups) Init(session *session.Session) {
-	dsg.Client = rds.New(session)
+func (dsg *DBSubnetGroups) InitV2(cfg aws.Config) {
+	dsg.Client = rds.NewFromConfig(cfg)
 }
+
+func (dsg *DBSubnetGroups) IsUsingV2() bool { return true }
 
 func (dsg *DBSubnetGroups) ResourceName() string {
 	return "rds-subnet-group"
@@ -46,13 +51,13 @@ func (dsg *DBSubnetGroups) GetAndSetIdentifiers(c context.Context, configObj con
 		return nil, err
 	}
 
-	dsg.InstanceNames = awsgo.StringValueSlice(identifiers)
+	dsg.InstanceNames = aws.ToStringSlice(identifiers)
 	return dsg.InstanceNames, nil
 }
 
 // Nuke - nuke 'em all!!!
 func (dsg *DBSubnetGroups) Nuke(identifiers []string) error {
-	if err := dsg.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
+	if err := dsg.nukeAll(aws.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/util/tag.go
+++ b/util/tag.go
@@ -4,12 +4,11 @@ import (
 	autoscaling "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	iam "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	networkfirewalltypes "github.com/aws/aws-sdk-go-v2/service/networkfirewall/types"
-	rdstype "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/rds"
 )
 
 func ConvertS3TypesTagsToMap(tags []s3types.Tag) map[string]string {
@@ -66,7 +65,7 @@ func ConvertIAMTagsToMap(tags []iam.Tag) map[string]string {
 	return tagMap
 }
 
-func ConvertRDSTagsToMap(tags []*rds.Tag) map[string]string {
+func ConvertRDSTypeTagsToMap(tags []rdstypes.Tag) map[string]string {
 	tagMap := make(map[string]string)
 	for _, tag := range tags {
 		tagMap[*tag.Key] = *tag.Value
@@ -74,7 +73,6 @@ func ConvertRDSTagsToMap(tags []*rds.Tag) map[string]string {
 
 	return tagMap
 }
-
 func GetEC2ResourceNameTagValue[T *ec2.Tag | types.Tag](tags []T) *string {
 	var tagMap map[string]string
 
@@ -97,17 +95,6 @@ func ConvertNetworkFirewallTagsToMap(tags []networkfirewalltypes.Tag) map[string
 	tagMap := make(map[string]string)
 	for _, tag := range tags {
 		tagMap[*tag.Key] = *tag.Value
-	}
-
-	return tagMap
-}
-
-func ConvertRDSTypeTagsToMap(tags []rdstype.Tag) map[string]string {
-	tagMap := make(map[string]string)
-	for _, tag := range tags {
-		if tag.Key != nil && tag.Value != nil {
-			tagMap[*tag.Key] = *tag.Value
-		}
 	}
 
 	return tagMap

--- a/v2_migration_report/output.md
+++ b/v2_migration_report/output.md
@@ -87,13 +87,13 @@ run `go generate ./...` to refresh this report.
 | oidcprovider                     | :white_check_mark: |
 | opensearchdomain                 | :white_check_mark: |
 | rds                              | :white_check_mark: |
-| rds-cluster                      |                    |
-| rds-global-cluster               |                    |
-| rds-global-cluster-membership    |                    |
-| rds-parameter-group              |                    |
-| rds-proxy                        |                    |
-| rds-snapshot                     |                    |
-| rds-subnet-group                 |                    |
+| rds-cluster                      | :white_check_mark: |
+| rds-global-cluster               | :white_check_mark: |
+| rds-global-cluster-membership    | :white_check_mark: |
+| rds-parameter-group              | :white_check_mark: |
+| rds-proxy                        | :white_check_mark: |
+| rds-snapshot                     | :white_check_mark: |
+| rds-subnet-group                 | :white_check_mark: |
 | redshift                         |                    |
 | route53-cidr-collection          | :white_check_mark: |
 | route53-hosted-zone              | :white_check_mark: |


### PR DESCRIPTION
…r group, global cluster, global cluster membership, rds-cluster

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
