### PR TITLE
Migrate TGW Route Table to AWS SDK v2

### DIFF
--- a/aws/resources/tgw_route_tables_types.go
+++ b/aws/resources/tgw_route_tables_types.go
@@ -3,25 +3,31 @@ package resources
 import (
 	"context"
 
-	awsgo "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/go-commons/errors"
 )
 
+type TransitGatewaysRouteTablesAPI interface {
+	DeleteTransitGatewayRouteTable(ctx context.Context, params *ec2.DeleteTransitGatewayRouteTableInput, optFns ...func(*ec2.Options)) (*ec2.DeleteTransitGatewayRouteTableOutput, error)
+	DescribeTransitGatewayRouteTables(ctx context.Context, params *ec2.DescribeTransitGatewayRouteTablesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeTransitGatewayRouteTablesOutput, error)
+}
+
 // TransitGatewaysRouteTables - represents all transit gateways route tables
 type TransitGatewaysRouteTables struct {
 	BaseAwsResource
-	Client ec2iface.EC2API
+	Client TransitGatewaysRouteTablesAPI
 	Region string
 	Ids    []string
 }
 
-func (tgw *TransitGatewaysRouteTables) Init(session *session.Session) {
-	tgw.Client = ec2.New(session)
+func (tgw *TransitGatewaysRouteTables) InitV2(cfg aws.Config) {
+	tgw.Client = ec2.NewFromConfig(cfg)
 }
+
+func (tgw *TransitGatewaysRouteTables) IsUsingV2() bool { return true }
 
 // ResourceName - the simple name of the aws resource
 func (tgw *TransitGatewaysRouteTables) ResourceName() string {
@@ -44,13 +50,13 @@ func (tgw *TransitGatewaysRouteTables) GetAndSetIdentifiers(c context.Context, c
 		return nil, err
 	}
 
-	tgw.Ids = awsgo.StringValueSlice(identifiers)
+	tgw.Ids = aws.ToStringSlice(identifiers)
 	return tgw.Ids, nil
 }
 
 // Nuke - nuke 'em all!!!
 func (tgw *TransitGatewaysRouteTables) Nuke(identifiers []string) error {
-	if err := tgw.nukeAll(awsgo.StringSlice(identifiers)); err != nil {
+	if err := tgw.nukeAll(aws.StringSlice(identifiers)); err != nil {
 		return errors.WithStackTrace(err)
 	}
 

--- a/v2_migration_report/output.md
+++ b/v2_migration_report/output.md
@@ -116,7 +116,7 @@ run `go generate ./...` to refresh this report.
 | sqs                              | :white_check_mark: |
 | transit-gateway                  | :white_check_mark: |
 | transit-gateway-attachment       | :white_check_mark: |
-| transit-gateway-route-table      |                    |
+| transit-gateway-route-table      | :white_check_mark: |
 | vpc                              | :white_check_mark: |
 | vpc-lattice-service              | :white_check_mark: |
 | vpc-lattice-service-network      | :white_check_mark: |


### PR DESCRIPTION
## Description

Fixes #770. These commits are cherry-picked from my other PR here: https://github.com/gruntwork-io/cloud-nuke/pull/800

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

Updated `transit-gateway-route-table` to AWS SDK v2