### PR TITLE
add support for `cloud-nuke-excluded` tag in VPC resource, fix #810

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ of the file that are supported are listed here.
 | transit-gateway                  | TransitGateway                | ❌                                     | ✅ (Creation Time)                   | ❌    | ✅       |
 | transit-gateway-route-table      | TransitGatewayRouteTable      | ❌                                     | ✅ (Creation Time)                   | ❌    | ✅       |
 | transit-gateway-attachment       | TransitGatewaysVpcAttachment  | ❌                                     | ✅ (Creation Time)                   | ❌    | ✅       |
-| vpc                              | VPC                           | ✅ (EC2 Name Tag)                      | ✅ (First Seen Tag Time)             | ❌    | ❌       |
+| vpc                              | VPC                           | ✅ (EC2 Name Tag)                      | ✅ (First Seen Tag Time)             | ✅    | ❌       |
 | route53-hosted-zone              | Route53HostedZone             | ✅ (Hosted zone name)                  | ❌                                   | ❌    | ❌       |
 | route53-cidr-collection          | Route53CIDRCollection         | ✅ (Cidr collection name)              | ❌                                   | ❌    | ❌       |
 | route53-traffic-policy           | Route53TrafficPolicy          | ✅ (Traffic policy name)               | ❌                                   | ❌    | ❌       |

--- a/aws/resources/ec2_vpc.go
+++ b/aws/resources/ec2_vpc.go
@@ -53,6 +53,7 @@ func (v *EC2VPCs) getAll(c context.Context, configObj config.Config) ([]*string,
 		if configObj.VPC.ShouldInclude(config.ResourceValue{
 			Time: firstSeenTime,
 			Name: util.GetEC2ResourceNameTagValue(vpc.Tags),
+			Tags: util.ConvertTypesTagsToMap(vpc.Tags),
 		}) {
 			ids = append(ids, vpc.VpcId)
 		}


### PR DESCRIPTION
## Description

Fixes #810 add support `cloud-nuke-excluded` tag.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)
Added support `cloud-nuke-excluded` tag - Fixes #810 

### Migration Guide
n/a