### PR TITLE
Fix Route53HostedZone loopvar scoping

### DIFF
--- a/aws/resources/route53_hostedzone.go
+++ b/aws/resources/route53_hostedzone.go
@@ -20,7 +20,8 @@ func (r *Route53HostedZone) getAll(_ context.Context, configObj config.Config) (
 		return nil, err
 	}
 
-	for _, zone := range result.HostedZones {
+	for _, z := range result.HostedZones {
+		zone := z
 		if configObj.Route53HostedZone.ShouldInclude(config.ResourceValue{
 			Name: zone.Name,
 		}) {
@@ -68,7 +69,8 @@ func (r *Route53HostedZone) nukeRecordSet(id *string) (err error) {
 	var domainName = aws.ToString(r.HostedZonesDomains[aws.ToString(id)].Name)
 
 	var changes []types.Change
-	for _, record := range output.ResourceRecordSets {
+	for _, rec := range output.ResourceRecordSets {
+		record := rec
 		// Note : We can't delete the SOA record or the NS record named ${domain-name}.
 		// Reference : https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-deleting.html
 		if (record.Type == types.RRTypeNs || record.Type == types.RRTypeSoa) && aws.ToString(record.Name) == domainName {


### PR DESCRIPTION
## Description

I was testing the current [`master` HEAD of `cloud-nuke`](https://github.com/gruntwork-io/cloud-nuke/commit/ffd2e750f762da98b679702156a1261c06dd1e57) to test deletion of Route53 hosted zones to notice, it failed deleting any of the hosted zones in my AWS account (with 150+ hosted zones to delete). Using latest `v0.37.2` worked without an issue.

Inspecting the code, I noticed the issue was introduced on migration to aws SDK v2 in PR #796:
https://github.com/gruntwork-io/cloud-nuke/pull/796/files#diff-b2873b3af2b9d6f0921199d7c781bbe53417e4264feda1aa000eecb8906cb3cdL28-R28
![image](https://github.com/user-attachments/assets/276e4161-a27f-49a8-83cd-ea972fe3fdf9)

The change caused, all values of the `HostedZonesDomains` map were pointing to the same zone address, causing the deletion problem.

Additionally, due to the same loopvar issue,  it was unable to delete the `ChangeResourceRecordSets`, as it was failing with:
```
  ERROR   [Failed] unable to nuke resource record set: operation error Route 53: ChangeResourceRecordSets, https response error StatusCode: 400, RequestID: d7f9a096-7811-41d6-828a-5ee2144d0af7, InvalidChangeBatch: [The request contains an invalid set of changes for a resource record set 'SOA cd2o99ufsia5fk25ebig.dev.cloud.example.net.']
```

Attaching the error log:
[route3-hosted-zone-error.txt](https://github.com/user-attachments/files/18167701/route3-hosted-zone-error.txt)

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

Fixed Route53HostedZone loopvar scoping

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
