### PR TITLE
add tests for `TransformAWSError` func from `util` pkg before migrating to aws SDK v2.

### DIFF
--- a/util/error_test.go
+++ b/util/error_test.go
@@ -1,0 +1,82 @@
+package util
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/smithy-go"
+	commonErr "github.com/gruntwork-io/go-commons/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransformAWSError(t *testing.T) {
+	errUnhandled := errors.New("unhandled error")
+	tests := []struct {
+		name    string
+		argErr  error
+		wantErr error
+	}{
+		{
+			name:    "unhandled error",
+			argErr:  errUnhandled,
+			wantErr: errUnhandled,
+		},
+		{
+			name:    "insufficient permission",
+			argErr:  awserr.New("UnauthorizedOperation", "UnauthorizedOperation", nil),
+			wantErr: ErrInSufficientPermission,
+		},
+		{
+			name:    "AWS access denied exception",
+			argErr:  awserr.New("AccessDeniedException", "AccessDeniedException", nil),
+			wantErr: ErrInSufficientPermission,
+		},
+		{
+			name:    "request canceled",
+			argErr:  awserr.New("RequestCanceled", "RequestCanceled", nil),
+			wantErr: ErrContextExecutionTimeout,
+		},
+		{
+			name:    "wrap request canceled",
+			argErr:  commonErr.WithStackTrace(awserr.New("RequestCanceled", "RequestCanceled", nil)),
+			wantErr: ErrContextExecutionTimeout,
+		},
+		{
+			name:    "invalid network interface ID NotFound",
+			argErr:  awserr.New("InvalidNetworkInterfaceID.NotFound", "InvalidNetworkInterfaceID.NotFound", nil),
+			wantErr: ErrInterfaceIDNotFound,
+		},
+		{
+			name:    "dry run operation",
+			argErr:  awserr.New("DryRunOperation", "Request would have succeeded, but DryRun flag is set.", nil),
+			wantErr: nil,
+		},
+		{
+			name:    "invalid permission not found",
+			argErr:  awserr.New("InvalidPermission.NotFound", "InvalidPermission.NotFound", nil),
+			wantErr: ErrInvalidPermisionNotFound,
+		},
+		{
+			name:    "resource not found exception",
+			argErr:  awserr.New("ResourceNotFoundException", "ResourceNotFoundException", nil),
+			wantErr: ErrResourceNotFoundException,
+		},
+		{
+			name: "smithy dry run operation",
+			argErr: &smithy.GenericAPIError{
+				Code:    "DryRunOperation",
+				Message: "Request would have succeeded, but DryRun flag is set.",
+				Fault:   smithy.FaultClient,
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := TransformAWSError(tt.argErr)
+			require.Equal(t, tt.wantErr, out)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This change adds test coverage for the `TransformAWSError` function to ensure all cases are covered during the AWS SDK v2 migration.

<img width="1275" alt="coverage" src="https://github.com/user-attachments/assets/bbce0e20-2d7c-4d29-a132-8ad9256df6f2" />


## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.

## Release Notes (draft)

Added tests for `TransformAWSError` func from `util` pkg before migrating to aws SDK v2

### Migration Guide
n/a
