### PR TITLE
fix for #825 assignment to nil map in TG.

### DIFF
--- a/aws/resources/transit_gateway_types.go
+++ b/aws/resources/transit_gateway_types.go
@@ -28,6 +28,7 @@ type TransitGateways struct {
 
 func (tgw *TransitGateways) Init(cfg aws.Config) {
 	tgw.Client = ec2.NewFromConfig(cfg)
+	tgw.Nukables = make(map[string]error)
 }
 
 // ResourceName - the simple name of the aws resource


### PR DESCRIPTION
## Description

Fixes #825 Attempting to assign to a nil map in the transit gateway

before the patch
```sh
$ go run main.go aws --region eu-west-1 --resource-type transit-gateway


# AWS Resource Query Parameters
┌───────────────────────────────────────────┐
| Query Parameter         | Value           |
| ----------------------------------------- |
| Target Regions          | eu-west-1       |
| Target Resource Types   | transit-gateway |
| List Unaliased KMS Keys | false           |
└───────────────────────────────────────────┘

▀  Searching transit-gateway resources in eu-west-1 (1s)ERRO[2025-01-13T18:32:05Z] assignment to entry in nil map                binary=cloud-nuke version=
exit status 1
```

after the patch
```sh
$ go run main.go aws --region eu-west-1 --resource-type transit-gateway


# AWS Resource Query Parameters
┌───────────────────────────────────────────┐
| Query Parameter         | Value           |
| ----------------------------------------- |
| Target Regions          | eu-west-1       |
| Target Resource Types   | transit-gateway |
| List Unaliased KMS Keys | false           |
└───────────────────────────────────────────┘

 INFO  Found 1 transit-gateway resources in eu-west-1
 INFO  Done searching for resources
 INFO  Found total of 1 resources

# Found AWS Resources
┌─────────────────────────────────────────────────────────────────────────────┐
| Resource Type   | Region    | Identifier            | Nukable               |
| --------------------------------------------------------------------------- |
| transit-gateway | eu-west-1 | tgw-0ecf1a2b1e6ad3af9 | error:DIFFERENT_OWNER |
└─────────────────────────────────────────────────────────────────────────────┘

 WARNING  THE NEXT STEPS ARE DESTRUCTIVE AND COMPLETELY IRREVERSIBLE, PROCEED WITH CAUTION!!!
```


## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

Fixes #825 Attempting to assign to a nil map in the transit gateway

### Migration Guide
n/a