### PR TITLE
Fix nil pointer exception for macie nukeAll operation

### DIFF
--- a/logging/logger.go
+++ b/logging/logger.go
@@ -59,3 +59,11 @@ func Error(msg string) {
 func Errorf(msg string, args ...interface{}) {
 	Error(fmt.Sprintf(msg, args...))
 }
+
+func Warn(msg string) {
+	pterm.Warning.Println(msg)
+}
+
+func Warnf(msg string, args ...interface{}) {
+	Warn(fmt.Sprintf(msg, args...))
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Seeing nil pointer exception when nuking macie resources. 
```
Nuking batch of 1 macie-member resource(s) in ap-south-1 [4/2373]  0% | 6sERRO[2025-02-17T04:29:24Z] runtime error: invalid memory address or nil pointer dereference  binary=cloud-nuke version=63bbc48e814cec0bfd467b12cc1efb4b20219801
```

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
