### PR TITLE
enable cloud-nuke for new AWS account CONFIGTESTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,45 @@ jobs:
               --delete-unaliased-kms-keys \
               --log-level debug
           no_output_timeout: 1h
+  nuke_configtestss:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          command: |
+            # We explicitly list the resource types we want to nuke, as we are not ready to nuke some resource types in
+            # the AWS account we use at Gruntwork for testing (Phx DevOps) (e.g., S3)
+            go run  -ldflags="-X 'main.VERSION=$CIRCLE_SHA1'" main.go aws \
+              --older-than 2h \
+              --force \
+              --config ./.circleci/nuke_config.yml \
+              --region ap-northeast-1 \
+              --region ap-northeast-2 \
+              --region ap-northeast-3 \
+              --region ap-south-1 \
+              --region ap-southeast-1 \
+              --region ap-southeast-2 \
+              --region ca-central-1 \
+              --region eu-central-1 \
+              --region eu-north-1 \
+              --region eu-west-1 \
+              --region eu-west-2 \
+              --region eu-west-3 \
+              --region me-central-1 \
+              --region sa-east-1 \
+              --region us-east-1 \
+              --region us-east-2 \
+              --region us-west-1 \
+              --region us-west-2 \
+              --exclude-resource-type iam \
+              --exclude-resource-type iam-service-linked-role \
+              --exclude-resource-type ecr \
+              --exclude-resource-type config-rules \
+              --exclude-resource-type nat-gateway \
+              --exclude-resource-type ec2-subnet \
+              --delete-unaliased-kms-keys \
+              --log-level debug
+          no_output_timeout: 1h
   deploy:
     <<: *env
     macos:
@@ -233,6 +272,16 @@ workflows:
       - nuke_phx_devops:
           context:
             - AWS__PHXDEVOPS__circle-ci-test
+            - GITHUB__PAT__gruntwork-ci
+  nuke_configtestss:
+    when:
+      and:
+        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - equal: ["every 3 hours", << pipeline.schedule.name >>]
+    jobs:
+      - nuke_configtestss:
+          context:
+            - AWS__CONFIGTESTS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
   nuke_sandbox:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
               --delete-unaliased-kms-keys \
               --log-level debug
           no_output_timeout: 1h
-  nuke_configtestss:
+  nuke_configtests:
     <<: *defaults
     steps:
       - checkout
@@ -273,13 +273,13 @@ workflows:
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
-  nuke_configtestss:
+  nuke_configtests:
     when:
       and:
         - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - equal: ["every 3 hours", << pipeline.schedule.name >>]
     jobs:
-      - nuke_configtestss:
+      - nuke_configtests:
           context:
             - AWS__CONFIGTESTS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #841. Adds cloud-nuke support for a new AWS account, CONFIGTESTS. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Adds cloud-nuke support for a new AWS account CONFIGTESTS