### PR TITLE
allow global region to be overriden by env

### DIFF
--- a/aws/region.go
+++ b/aws/region.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -51,7 +52,11 @@ const (
 func NewSession(region string) (aws.Config, error) {
 	// Note: As there is no actual region named `global` we have to pick one valid region and create the session.
 	if region == GlobalRegion {
-		return externalcreds.Get(DefaultRegion)
+		v, ok := os.LookupEnv("CLOUD_NUKE_AWS_GLOBAL_REGION")
+		if !ok {
+			v = DefaultRegion
+		}
+		return externalcreds.Get(v)
 	}
 
 	return externalcreds.Get(region)

--- a/aws/region_test.go
+++ b/aws/region_test.go
@@ -1,0 +1,26 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGlobalRegion(t *testing.T) {
+	t.Run("NoEnv", func(t *testing.T) {
+		c, err := NewSession(GlobalRegion)
+		require.NoError(t, err)
+		assert.Equal(t, DefaultRegion, c.Region)
+
+	})
+
+	t.Run("WithEnv", func(t *testing.T) {
+		global := "us-gov-east-1"
+		t.Setenv("CLOUD_NUKE_AWS_GLOBAL_REGION", global)
+		c, err := NewSession(GlobalRegion)
+		require.NoError(t, err)
+		assert.Equal(t, global, c.Region)
+	})
+
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/832

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
