### PR TITLE
Add capability to use multiple tagging to exclude resources

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -269,11 +269,12 @@ type ResourceType struct {
 }
 
 type FilterRule struct {
-	NamesRegExp []Expression `yaml:"names_regex"`
-	TimeAfter   *time.Time   `yaml:"time_after"`
-	TimeBefore  *time.Time   `yaml:"time_before"`
-	Tag         *string      `yaml:"tag"` // A tag to filter resources by. (e.g., If set under ExcludedRule, resources with this tag will be excluded).
-	TagValue    *Expression  `yaml:"tag_value"`
+	NamesRegExp []Expression          `yaml:"names_regex"`
+	TimeAfter   *time.Time            `yaml:"time_after"`
+	TimeBefore  *time.Time            `yaml:"time_before"`
+	Tag         *string               `yaml:"tag"`       // Deprecated ~ A tag to filter resources by. (e.g., If set under ExcludedRule, resources with this tag will be excluded).
+	TagValue    *Expression           `yaml:"tag_value"` // Deprecated
+	Tags        map[string]Expression `yaml:"tags"`
 }
 
 type Expression struct {
@@ -408,6 +409,15 @@ func (r ResourceType) ShouldIncludeBasedOnTag(tags map[string]string) bool {
 	if value, ok := tags[exclusionTag]; ok {
 		if matches(strings.ToLower(value), []Expression{*exclusionTagValue}) {
 			return false
+		}
+	}
+
+	// Check if additionalTag is not empty
+	for additionalTag, additionalTagValue := range r.ExcludeRule.Tags {
+		if value, ok := tags[additionalTag]; ok {
+			if matches(strings.ToLower(value), []Expression{additionalTagValue}) {
+				return false
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/834

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
