### PR TITLE
Support proper tag reading in RDS module

### DIFF
--- a/aws/resources/rds_subnet_group_test.go
+++ b/aws/resources/rds_subnet_group_test.go
@@ -26,6 +26,16 @@ func (m mockedDBSubnetGroups) DescribeDBSubnetGroups(ctx context.Context, params
 func (m mockedDBSubnetGroups) DeleteDBSubnetGroup(ctx context.Context, params *rds.DeleteDBSubnetGroupInput, optFns ...func(*rds.Options)) (*rds.DeleteDBSubnetGroupOutput, error) {
 	return &m.DeleteDBSubnetGroupOutput, nil
 }
+func (m mockedDBSubnetGroups) ListTagsForResource(ctx context.Context, params *rds.ListTagsForResourceInput, optFns ...func(*rds.Options)) (*rds.ListTagsForResourceOutput, error) {
+	return &rds.ListTagsForResourceOutput{
+		TagList: []types.Tag{
+			{
+				Key:   aws.String("resource_name"),
+				Value: params.ResourceName,
+			},
+		},
+	}, nil
+}
 
 var dbSubnetGroupNotFoundError = &types.DBSubnetGroupNotFoundFault{}
 
@@ -41,9 +51,11 @@ func TestDBSubnetGroups_GetAll(t *testing.T) {
 				DBSubnetGroups: []types.DBSubnetGroup{
 					{
 						DBSubnetGroupName: aws.String(testName1),
+						DBSubnetGroupArn:  aws.String("arn:" + testName1),
 					},
 					{
 						DBSubnetGroupName: aws.String(testName2),
+						DBSubnetGroupArn:  aws.String("arn:" + testName2),
 					},
 				},
 			},
@@ -64,6 +76,17 @@ func TestDBSubnetGroups_GetAll(t *testing.T) {
 					NamesRegExp: []config.Expression{{
 						RE: *regexp.MustCompile(testName1),
 					}}},
+			},
+			expected: []string{testName2},
+		},
+		"tagsExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					Tag: aws.String("resource_name"),
+					TagValue: &config.Expression{
+						RE: *regexp.MustCompile("^arn:" + testName1 + "$"),
+					},
+				},
 			},
 			expected: []string{testName2},
 		},

--- a/aws/resources/rds_subnet_group_types.go
+++ b/aws/resources/rds_subnet_group_types.go
@@ -12,6 +12,7 @@ import (
 type DBSubnetGroupsAPI interface {
 	DescribeDBSubnetGroups(ctx context.Context, params *rds.DescribeDBSubnetGroupsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBSubnetGroupsOutput, error)
 	DeleteDBSubnetGroup(ctx context.Context, params *rds.DeleteDBSubnetGroupInput, optFns ...func(*rds.Options)) (*rds.DeleteDBSubnetGroupOutput, error)
+	ListTagsForResource(ctx context.Context, params *rds.ListTagsForResourceInput, optFns ...func(*rds.Options)) (*rds.ListTagsForResourceOutput, error)
 }
 
 type DBSubnetGroups struct {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/848.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
