### PR TITLE
Added new resource - SageMaker Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Cloud-nuke suppports 🔎 inspecting and 🔥💀 deleting the following AWS res
 | GuardDuty               | Detectors                                                |
 | Macie                   | Member accounts                                          |
 | SageMaker               | Notebook instances                                       |
+| SageMaker Endpoint      | Endpoint                                                 |
 | SageMaker Studio        | Studio domain (and all associated resources)             |
 | Kinesis                 | Streams                                                  |
 | Kinesis                 | Firehose                                                 |
@@ -657,7 +658,9 @@ of the file that are supported are listed here.
 | ses-receipt-filter               | SesReceiptFilter              | ✅ (Receipt Filter Name)               | ❌                                   | ❌    | ✅       |
 | snstopic                         | SNS                           | ✅ (Topic Name)                        | ✅ (First Seen Tag Time)             | ❌    | ✅       |
 | sqs                              | SQS                           | ✅ (Queue Name)                        | ✅ (Creation Time)                   | ❌    | ✅       |
-| sagemaker-notebook-smni          | SageMakerNotebook             | ✅ (Notebook Instnace Name)            | ✅ (Creation Time)                   | ❌    | ✅       |
+| sagemaker-notebook-smni          | SageMakerNotebook             | ✅ (Notebook Instance Name)            | ✅ (Creation Time)                   | ❌    | ✅       |
+| sagemaker-endpoint               | SageMakerEndpoint             | ✅ (Endpoint Name)                     | ✅ (Creation Time)                   | ✅    | ✅       |
+| sagemaker-studio                 | SageMakerStudioDomain         | ❌                                     | ❌                                   | ❌    | ✅       |
 | secretsmanager                   | SecretsManager                | ✅ (Secret Name)                       | ✅ (Last Accessed or Creation Time)  | ❌    | ✅       |
 | security-hub                     | SecurityHub                   | ❌                                     | ✅ (Created Time)                    | ❌    | ✅       |
 | snap                             | Snapshots                     | ❌                                     | ✅ (Creation Time)                   | ✅    | ✅       |

--- a/aws/resource_registry.go
+++ b/aws/resource_registry.go
@@ -132,6 +132,7 @@ func getRegisteredRegionalResources() []AwsResource {
 		&resources.S3MultiRegionAccessPoint{},
 		&resources.SageMakerNotebookInstances{},
 		&resources.SageMakerStudio{},
+		&resources.SageMakerEndpoint{},
 		&resources.SecretsManagerSecrets{},
 		&resources.SecurityHub{},
 		&resources.SesConfigurationSet{},

--- a/aws/resources/sagemaker_endpoint.go
+++ b/aws/resources/sagemaker_endpoint.go
@@ -1,0 +1,155 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	goerrors "github.com/gruntwork-io/go-commons/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+// GetAll retrieves all SageMaker Endpoints in the region.
+// It applies filtering rules from the configuration and includes tag information.
+func (s *SageMakerEndpoint) GetAll(c context.Context, configObj config.Config) ([]*string, error) {
+	var endpointNames []*string
+	paginator := sagemaker.NewListEndpointsPaginator(s.Client, &sagemaker.ListEndpointsInput{})
+
+	// Get account ID from context
+	accountID, ok := c.Value(util.AccountIdKey).(string)
+	if !ok {
+		return nil, goerrors.WithStackTrace(fmt.Errorf("unable to get account ID from context"))
+	}
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(c)
+		if err != nil {
+			return nil, goerrors.WithStackTrace(err)
+		}
+
+		for _, endpoint := range output.Endpoints {
+			if endpoint.EndpointName != nil {
+				logging.Debugf("Found SageMaker Endpoint: %s (Status: %s)", *endpoint.EndpointName, endpoint.EndpointStatus)
+
+				// Construct the proper ARN for the endpoint
+				endpointArn := fmt.Sprintf("arn:aws:sagemaker:%s:%s:endpoint/%s",
+					s.Region, accountID, *endpoint.EndpointName)
+
+				// Get tags for the endpoint
+				input := &sagemaker.ListTagsInput{
+					ResourceArn: aws.String(endpointArn),
+				}
+				tagsOutput, err := s.Client.ListTags(s.Context, input)
+				if err != nil {
+					logging.Debugf("Failed to get tags for endpoint %s: %s", *endpoint.EndpointName, err)
+					continue
+				}
+
+				// Convert tags to map
+				tagMap := util.ConvertSageMakerTagsToMap(tagsOutput.Tags)
+
+				// Check if this endpoint has any of the specified exclusion tags
+				shouldExclude := false
+
+				// Check the newer Tags map approach
+				for tag, pattern := range configObj.SageMakerEndpoint.ExcludeRule.Tags {
+					if tagValue, hasTag := tagMap[tag]; hasTag {
+						if pattern.RE.MatchString(tagValue) {
+							shouldExclude = true
+							logging.Debugf("Excluding endpoint %s due to tag '%s' with value '%s' matching pattern '%s'",
+								*endpoint.EndpointName, tag, tagValue, pattern.RE.String())
+							break
+						}
+					}
+				}
+
+				// Check the deprecated Tag/TagValue approach
+				if !shouldExclude && configObj.SageMakerEndpoint.ExcludeRule.Tag != nil {
+					tagName := *configObj.SageMakerEndpoint.ExcludeRule.Tag
+					if tagValue, hasTag := tagMap[tagName]; hasTag {
+						// If TagValue is specified, use that pattern, otherwise check if value is "true" (case-insensitive)
+						if configObj.SageMakerEndpoint.ExcludeRule.TagValue != nil {
+							if configObj.SageMakerEndpoint.ExcludeRule.TagValue.RE.MatchString(tagValue) {
+								shouldExclude = true
+								logging.Debugf("Excluding endpoint %s due to deprecated tag '%s' with value '%s' matching pattern '%s'",
+									*endpoint.EndpointName, tagName, tagValue, configObj.SageMakerEndpoint.ExcludeRule.TagValue.RE.String())
+							}
+						} else if strings.EqualFold(tagValue, "true") {
+							shouldExclude = true
+							logging.Debugf("Excluding endpoint %s due to deprecated tag '%s' with default value 'true'",
+								*endpoint.EndpointName, tagName)
+						}
+					}
+				}
+
+				// Skip this endpoint if it should be excluded
+				if shouldExclude {
+					continue
+				}
+
+				resourceValue := config.ResourceValue{
+					Name: endpoint.EndpointName,
+					Time: endpoint.CreationTime,
+					Tags: tagMap,
+				}
+
+				if configObj.SageMakerEndpoint.ShouldInclude(resourceValue) {
+					endpointNames = append(endpointNames, endpoint.EndpointName)
+				}
+			}
+		}
+	}
+	return endpointNames, nil
+}
+
+// nukeAll deletes all provided SageMaker Endpoints in parallel.
+func (s *SageMakerEndpoint) nukeAll(identifiers []string) error {
+	if len(identifiers) == 0 {
+		logging.Debugf("No SageMaker Endpoints to nuke in region %s", s.Region)
+		return nil
+	}
+
+	g := new(errgroup.Group)
+	for _, endpointName := range identifiers {
+		if endpointName == "" {
+			continue
+		}
+		endpointName := endpointName
+		g.Go(func() error {
+			err := s.nukeEndpoint(endpointName)
+			report.Record(report.Entry{
+				Identifier:   endpointName,
+				ResourceType: "SageMaker Endpoint",
+				Error:        err,
+			})
+			return err
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return goerrors.WithStackTrace(err)
+	}
+
+	logging.Debugf("[OK] %d SageMaker Endpoint(s) deleted in %s", len(identifiers), s.Region)
+	return nil
+}
+
+// nukeEndpoint deletes a single SageMaker Endpoint and waits for deletion to complete.
+func (s *SageMakerEndpoint) nukeEndpoint(endpointName string) error {
+	logging.Debugf("Starting deletion of SageMaker Endpoint %s in region %s", endpointName, s.Region)
+
+	_, err := s.Client.DeleteEndpoint(s.Context, &sagemaker.DeleteEndpointInput{
+		EndpointName: aws.String(endpointName),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/aws/resources/sagemaker_endpoint_test.go
+++ b/aws/resources/sagemaker_endpoint_test.go
@@ -1,0 +1,143 @@
+package resources
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
+	"github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/stretchr/testify/require"
+)
+
+type mockedSageMakerEndpoint struct {
+	SageMakerAPI
+	ListEndpointsOutput  sagemaker.ListEndpointsOutput
+	DeleteEndpointOutput sagemaker.DeleteEndpointOutput
+	ListTagsOutput       sagemaker.ListTagsOutput
+}
+
+func (m mockedSageMakerEndpoint) ListEndpoints(ctx context.Context, params *sagemaker.ListEndpointsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListEndpointsOutput, error) {
+	return &m.ListEndpointsOutput, nil
+}
+
+func (m mockedSageMakerEndpoint) DeleteEndpoint(ctx context.Context, params *sagemaker.DeleteEndpointInput, optFns ...func(*sagemaker.Options)) (*sagemaker.DeleteEndpointOutput, error) {
+	return &m.DeleteEndpointOutput, nil
+}
+
+func (m mockedSageMakerEndpoint) ListTags(ctx context.Context, params *sagemaker.ListTagsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListTagsOutput, error) {
+	return &m.ListTagsOutput, nil
+}
+
+func TestSageMakerEndpoint_GetAll(t *testing.T) {
+	t.Parallel()
+
+	testName1 := "endpoint-1"
+	testName2 := "endpoint-2"
+	now := time.Now()
+
+	endpoint := SageMakerEndpoint{
+		Client: mockedSageMakerEndpoint{
+			ListEndpointsOutput: sagemaker.ListEndpointsOutput{
+				Endpoints: []types.EndpointSummary{
+					{
+						EndpointName:   aws.String(testName1),
+						CreationTime:   aws.Time(now),
+						EndpointStatus: types.EndpointStatusInService,
+					},
+					{
+						EndpointName:   aws.String(testName2),
+						CreationTime:   aws.Time(now.Add(1)),
+						EndpointStatus: types.EndpointStatusInService,
+					},
+				},
+			},
+			ListTagsOutput: sagemaker.ListTagsOutput{
+				Tags: []types.Tag{
+					{
+						Key:   aws.String("Environment"),
+						Value: aws.String("test"),
+					},
+				},
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		configObj config.ResourceType
+		expected  []string
+	}{
+		"emptyFilter": {
+			configObj: config.ResourceType{},
+			expected:  []string{testName1, testName2},
+		},
+		"nameExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					NamesRegExp: []config.Expression{{
+						RE: *regexp.MustCompile(testName1),
+					}}},
+			},
+			expected: []string{testName2},
+		},
+		"timeAfterExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					TimeAfter: aws.Time(now),
+				}},
+			expected: []string{testName1},
+		},
+		"tagFilter": {
+			configObj: config.ResourceType{
+				IncludeRule: config.FilterRule{
+					Tags: map[string]config.Expression{
+						"Environment": {RE: *regexp.MustCompile("test")},
+					},
+				}},
+			expected: []string{testName1, testName2},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, util.AccountIdKey, "test-account-id")
+
+			endpoints, err := endpoint.GetAll(ctx, config.Config{
+				SageMakerEndpoint: tc.configObj,
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, aws.ToStringSlice(endpoints))
+		})
+	}
+}
+
+func TestSageMakerEndpoint_NukeAll(t *testing.T) {
+	t.Parallel()
+
+	endpoint := SageMakerEndpoint{
+		Client: mockedSageMakerEndpoint{
+			DeleteEndpointOutput: sagemaker.DeleteEndpointOutput{},
+		},
+	}
+
+	err := endpoint.nukeAll([]string{"endpoint-1", "endpoint-2"})
+	require.NoError(t, err)
+}
+
+func TestSageMakerEndpoint_EmptyNukeAll(t *testing.T) {
+	t.Parallel()
+
+	endpoint := SageMakerEndpoint{
+		Client: mockedSageMakerEndpoint{
+			DeleteEndpointOutput: sagemaker.DeleteEndpointOutput{},
+		},
+	}
+
+	err := endpoint.nukeAll([]string{})
+	require.NoError(t, err)
+}

--- a/aws/resources/sagemaker_endpoint_types.go
+++ b/aws/resources/sagemaker_endpoint_types.go
@@ -1,0 +1,90 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
+	"github.com/gruntwork-io/cloud-nuke/config"
+)
+
+// SageMakerAPI represents the shape of the AWS SageMaker API for testing
+// This interface allows for mocking in tests and defines all required SageMaker operations
+type SageMakerAPI interface {
+	ListEndpoints(ctx context.Context, params *sagemaker.ListEndpointsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListEndpointsOutput, error)
+	DeleteEndpoint(ctx context.Context, params *sagemaker.DeleteEndpointInput, optFns ...func(*sagemaker.Options)) (*sagemaker.DeleteEndpointOutput, error)
+	ListTags(ctx context.Context, params *sagemaker.ListTagsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListTagsOutput, error)
+}
+
+// SageMakerEndpoint represents an AWS SageMaker Endpoint resource to be nuked
+// It implements the Resource interface and handles the deletion of SageMaker Endpoints
+type SageMakerEndpoint struct {
+	BaseAwsResource
+	Client        SageMakerAPI // AWS SageMaker client or mock for testing
+	Region        string       // AWS region where the resources are located
+	EndpointNames []string     // List of SageMaker Endpoint names to be nuked
+}
+
+// Init initializes the SageMaker client with the provided AWS configuration
+func (s *SageMakerEndpoint) Init(cfg aws.Config) {
+	s.Client = sagemaker.NewFromConfig(cfg)
+}
+
+// ResourceName returns the identifier string for this resource type
+// Used for logging and reporting purposes
+func (s *SageMakerEndpoint) ResourceName() string {
+	return "sagemaker-endpoint"
+}
+
+// ResourceIdentifiers returns the list of endpoint names that will be nuked
+func (s *SageMakerEndpoint) ResourceIdentifiers() []string {
+	return s.EndpointNames
+}
+
+// MaxBatchSize returns the maximum number of resources that can be deleted in parallel
+// This limit helps prevent AWS API throttling
+func (s *SageMakerEndpoint) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 10
+}
+
+// GetAndSetResourceConfig retrieves the configuration for SageMaker Endpoint resources
+func (s *SageMakerEndpoint) GetAndSetResourceConfig(configObj config.Config) config.ResourceType {
+	return configObj.SageMakerEndpoint
+}
+
+// GetAndSetIdentifiers retrieves all SageMaker Endpoints and stores their identifiers
+func (s *SageMakerEndpoint) GetAndSetIdentifiers(c context.Context, configObj config.Config) ([]string, error) {
+	identifiers, err := s.GetAll(c, configObj)
+	if err != nil {
+		return nil, err
+	}
+
+	s.EndpointNames = aws.ToStringSlice(identifiers)
+	return s.EndpointNames, nil
+}
+
+// IsNukable determines whether a specific SageMaker Endpoint can be deleted
+// It will respect tag exclusion rules from the configuration
+func (s *SageMakerEndpoint) IsNukable(identifier string) (bool, error) {
+	// Look for endpoint with this name in our list
+	for _, endpointName := range s.EndpointNames {
+		if endpointName == identifier {
+			// This endpoint was already vetted through our filtering process
+			// and is included in the list of endpoints to nuke
+			return true, nil
+		}
+	}
+
+	// If we can't find it in our approved list, don't allow it to be nuked
+	// This means either it was filtered out by tag exclusion rules or
+	// it doesn't exist in the current account/region
+	return false, fmt.Errorf("endpoint is protected by tag exclusion rules or not found")
+}
+
+// Nuke implements the AwsResource interface by calling nukeAll
+// It takes a list of endpoint identifiers and deletes those endpoints
+func (s *SageMakerEndpoint) Nuke(identifiers []string) error {
+	return s.nukeAll(identifiers)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -113,6 +113,7 @@ type Config struct {
 	SESEmailTemplates               ResourceType                  `yaml:"SesEmailTemplates"`
 	SNS                             ResourceType                  `yaml:"SNS"`
 	SQS                             ResourceType                  `yaml:"SQS"`
+	SageMakerEndpoint               ResourceType                  `yaml:"SageMakerEndpoint"`
 	SageMakerNotebook               ResourceType                  `yaml:"SageMakerNotebook"`
 	SageMakerStudioDomain           ResourceType                  `yaml:"SageMakerStudioDomain"`
 	SecretsManagerSecrets           ResourceType                  `yaml:"SecretsManager"`

--- a/config/examples/complete.yaml
+++ b/config/examples/complete.yaml
@@ -1409,6 +1409,22 @@ SQS:
     tag: test
   timeout: 1h
   protect_until_expire: true
+SageMakerEndpoint:
+  include:
+    names_regex:
+      - that.*
+      - thats.*
+    time_after: 2024-02-02T00:00:00Z
+    time_before: 2024-01-01T00:00:00Z
+    tag: test
+  exclude:
+    names_regex:
+      - this.*
+    time_after: 2024-02-02T00:00:00Z
+    time_before: 2024-01-01T00:00:00Z
+    tag: test
+  timeout: 1h
+  protect_until_expire: true
 SageMakerNotebook:
   include:
     names_regex:

--- a/util/tag.go
+++ b/util/tag.go
@@ -7,6 +7,7 @@ import (
 	networkfirewalltypes "github.com/aws/aws-sdk-go-v2/service/networkfirewall/types"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	sagemakertypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 )
 
 func ConvertS3TypesTagsToMap(tags []s3types.Tag) map[string]string {
@@ -79,4 +80,15 @@ func ConvertNetworkFirewallTagsToMap(tags []networkfirewalltypes.Tag) map[string
 	}
 
 	return tagMap
+}
+
+// ConvertSageMakerTagsToMap converts SageMaker tags to a map[string]string
+func ConvertSageMakerTagsToMap(tags []sagemakertypes.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, tag := range tags {
+		if tag.Key != nil && tag.Value != nil {
+			result[*tag.Key] = *tag.Value
+		}
+	}
+	return result
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Added support for SageMaker Endpoint deletion with ability to filter by name, creation date and tags.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

- Added support for SageMaker Endpoint.

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

No breaking changes.

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
