### PR TITLE
Start nuking global resources as part of circleCi automated nuking operation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ jobs:
               --older-than 2h \
               --force \
               --config ./.circleci/nuke_config.yml \
+              --region global \ 
               --region ap-northeast-1 \
               --region ap-northeast-2 \
               --region ap-northeast-3 \
@@ -97,7 +98,14 @@ jobs:
               --region us-west-1 \
               --region us-west-2 \
               --exclude-resource-type iam \
+              --exclude-resource-type iam-group \
+              --exclude-resource-type iam-policy \
+              --exclude-resource-type iam-role \
               --exclude-resource-type iam-service-linked-role \
+              --exclude-resource-type oidcprovider \
+              --exclude-resource-type route53-hosted-zone \
+              --exclude-resource-type route53-cidr-collection \
+              --exclude-resource-type route53-traffic-policy \
               --exclude-resource-type ecr \
               --exclude-resource-type config-rules \
               --exclude-resource-type nat-gateway \
@@ -119,6 +127,7 @@ jobs:
               --older-than 24h \
               --force \
               --config ./.circleci/nuke_config.yml \
+              --region global \ 
               --region ap-northeast-1 \
               --region ap-northeast-2 \
               --region ap-northeast-3 \
@@ -138,7 +147,14 @@ jobs:
               --region us-west-1 \
               --region us-west-2 \
               --exclude-resource-type iam \
+              --exclude-resource-type iam-group \
+              --exclude-resource-type iam-policy \
+              --exclude-resource-type iam-role \
               --exclude-resource-type iam-service-linked-role \
+              --exclude-resource-type oidcprovider \
+              --exclude-resource-type route53-hosted-zone \
+              --exclude-resource-type route53-cidr-collection \
+              --exclude-resource-type route53-traffic-policy \
               --exclude-resource-type ecr \
               --exclude-resource-type config-rules \
               --exclude-resource-type eip \
@@ -161,6 +177,7 @@ jobs:
               --older-than 2h \
               --force \
               --config ./.circleci/nuke_config.yml \
+              --region global \ 
               --region ap-northeast-1 \
               --region ap-northeast-2 \
               --region ap-northeast-3 \
@@ -179,7 +196,14 @@ jobs:
               --region us-west-1 \
               --region us-west-2 \
               --exclude-resource-type iam \
+              --exclude-resource-type iam-group \
+              --exclude-resource-type iam-policy \
+              --exclude-resource-type iam-role \
               --exclude-resource-type iam-service-linked-role \
+              --exclude-resource-type oidcprovider \
+              --exclude-resource-type route53-hosted-zone \
+              --exclude-resource-type route53-cidr-collection \
+              --exclude-resource-type route53-traffic-policy \
               --exclude-resource-type ecr \
               --exclude-resource-type config-rules \
               --exclude-resource-type nat-gateway \


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Start nuking global resources. Excluding other global resources other than iam-instance-profiles to be safe that it doesn't affect other parts of the system unintentionally. 

As part of this linear ticket: https://linear.app/gruntwork/issue/SME-2887/iamlimitexceeded-cannot-exceed-quota-for-instanceprofilesperaccount

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
