### PR TITLE
Add new resource - SageMaker Endpoint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ Cloud-nuke suppports 🔎 inspecting and 🔥💀 deleting the following AWS res
 | Managed Prometheus      | Prometheus Workspace                                     |
 | GuardDuty               | Detectors                                                |
 | Macie                   | Member accounts                                          |
-| SageMaker               | Notebook instances                                       |
-| SageMaker Endpoint      | Endpoint                                                 |
-| SageMaker Studio        | Studio domain (and all associated resources)             |
+| SageMaker AI            | Notebook instances                                       |
+| SageMaker AI            | Endpoint                                                 |
+| SageMaker AI            | Endpoint configuration                                   |
+| SageMaker AI            | Studio domain (and all associated resources)             |
 | Kinesis                 | Streams                                                  |
 | Kinesis                 | Firehose                                                 |
 | API Gateway             | Gateways (v1 and v2)                                     |
@@ -660,6 +661,7 @@ of the file that are supported are listed here.
 | sqs                              | SQS                           | ✅ (Queue Name)                        | ✅ (Creation Time)                   | ❌    | ✅       |
 | sagemaker-notebook-smni          | SageMakerNotebook             | ✅ (Notebook Instance Name)            | ✅ (Creation Time)                   | ❌    | ✅       |
 | sagemaker-endpoint               | SageMakerEndpoint             | ✅ (Endpoint Name)                     | ✅ (Creation Time)                   | ✅    | ✅       |
+| sagemaker-endpoint-config        | SageMakerEndpointConfig       | ✅ (Endpoint Configuration Name)       | ✅ (Creation Time)                   | ✅    | ✅       |
 | sagemaker-studio                 | SageMakerStudioDomain         | ❌                                     | ❌                                   | ❌    | ✅       |
 | secretsmanager                   | SecretsManager                | ✅ (Secret Name)                       | ✅ (Last Accessed or Creation Time)  | ❌    | ✅       |
 | security-hub                     | SecurityHub                   | ❌                                     | ✅ (Created Time)                    | ❌    | ✅       |

--- a/aws/resource_registry.go
+++ b/aws/resource_registry.go
@@ -133,6 +133,7 @@ func getRegisteredRegionalResources() []AwsResource {
 		&resources.SageMakerNotebookInstances{},
 		&resources.SageMakerStudio{},
 		&resources.SageMakerEndpoint{},
+		&resources.SageMakerEndpointConfig{},
 		&resources.SecretsManagerSecrets{},
 		&resources.SecurityHub{},
 		&resources.SesConfigurationSet{},

--- a/aws/resources/sagemaker_endpoint_config.go
+++ b/aws/resources/sagemaker_endpoint_config.go
@@ -1,0 +1,134 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	goerrors "github.com/gruntwork-io/go-commons/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+// GetAll retrieves all SageMaker Endpoint Configurations in the region.
+// It applies filtering rules from the configuration and includes tag information.
+func (s *SageMakerEndpointConfig) GetAll(c context.Context, configObj config.Config) ([]*string, error) {
+	var endpointConfigNames []*string
+	paginator := sagemaker.NewListEndpointConfigsPaginator(s.Client, &sagemaker.ListEndpointConfigsInput{})
+
+	// Get account ID from context
+	accountID, ok := c.Value(util.AccountIdKey).(string)
+	if !ok {
+		return nil, goerrors.WithStackTrace(fmt.Errorf("unable to get account ID from context"))
+	}
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(c)
+		if err != nil {
+			return nil, goerrors.WithStackTrace(err)
+		}
+
+		for _, endpointConfig := range output.EndpointConfigs {
+			if endpointConfig.EndpointConfigName != nil {
+				logging.Debugf("Found SageMaker Endpoint Configuration: %s", *endpointConfig.EndpointConfigName)
+
+				// Construct the proper ARN for the endpoint config
+				endpointConfigArn := fmt.Sprintf("arn:aws:sagemaker:%s:%s:endpoint-config/%s",
+					s.Region, accountID, *endpointConfig.EndpointConfigName)
+
+				// Get tags for the endpoint config
+				input := &sagemaker.ListTagsInput{
+					ResourceArn: aws.String(endpointConfigArn),
+				}
+				tagsOutput, err := s.Client.ListTags(s.Context, input)
+				if err != nil {
+					logging.Debugf("Failed to get tags for endpoint config %s: %s", *endpointConfig.EndpointConfigName, err)
+					continue
+				}
+
+				// Convert tags to map
+				tagMap := util.ConvertSageMakerTagsToMap(tagsOutput.Tags)
+
+				// Check if this endpoint config has any of the specified exclusion tags
+				shouldExclude := false
+
+				// Check tags
+				for tag, pattern := range configObj.SageMakerEndpointConfig.ExcludeRule.Tags {
+					if tagValue, hasTag := tagMap[tag]; hasTag {
+						if pattern.RE.MatchString(tagValue) {
+							shouldExclude = true
+							logging.Debugf("Excluding endpoint config %s due to tag '%s' with value '%s' matching pattern '%s'",
+								*endpointConfig.EndpointConfigName, tag, tagValue, pattern.RE.String())
+							break
+						}
+					}
+				}
+
+				// Skip this endpoint config if it should be excluded
+				if shouldExclude {
+					continue
+				}
+
+				resourceValue := config.ResourceValue{
+					Name: endpointConfig.EndpointConfigName,
+					Time: endpointConfig.CreationTime,
+					Tags: tagMap,
+				}
+
+				if configObj.SageMakerEndpointConfig.ShouldInclude(resourceValue) {
+					endpointConfigNames = append(endpointConfigNames, endpointConfig.EndpointConfigName)
+				}
+			}
+		}
+	}
+	return endpointConfigNames, nil
+}
+
+// nukeAll deletes all provided SageMaker Endpoint Configurations in parallel.
+func (s *SageMakerEndpointConfig) nukeAll(identifiers []string) error {
+	if len(identifiers) == 0 {
+		logging.Debugf("No SageMaker Endpoint Configurations to nuke in region %s", s.Region)
+		return nil
+	}
+
+	g := new(errgroup.Group)
+	for _, endpointConfigName := range identifiers {
+		if endpointConfigName == "" {
+			continue
+		}
+		endpointConfigName := endpointConfigName
+		g.Go(func() error {
+			err := s.nukeEndpointConfig(endpointConfigName)
+			report.Record(report.Entry{
+				Identifier:   endpointConfigName,
+				ResourceType: "SageMaker Endpoint Configuration",
+				Error:        err,
+			})
+			return err
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return goerrors.WithStackTrace(err)
+	}
+
+	logging.Debugf("[OK] %d SageMaker Endpoint Configuration(s) deleted in %s", len(identifiers), s.Region)
+	return nil
+}
+
+// nukeEndpointConfig deletes a single SageMaker Endpoint Configuration.
+func (s *SageMakerEndpointConfig) nukeEndpointConfig(endpointConfigName string) error {
+	logging.Debugf("Starting deletion of SageMaker Endpoint Configuration %s in region %s", endpointConfigName, s.Region)
+
+	_, err := s.Client.DeleteEndpointConfig(s.Context, &sagemaker.DeleteEndpointConfigInput{
+		EndpointConfigName: aws.String(endpointConfigName),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/aws/resources/sagemaker_endpoint_config_test.go
+++ b/aws/resources/sagemaker_endpoint_config_test.go
@@ -1,0 +1,141 @@
+package resources
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
+	"github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/stretchr/testify/require"
+)
+
+type mockedSageMakerEndpointConfig struct {
+	SageMakerEndpointConfigAPI
+	ListEndpointConfigsOutput  sagemaker.ListEndpointConfigsOutput
+	DeleteEndpointConfigOutput sagemaker.DeleteEndpointConfigOutput
+	ListTagsOutput             sagemaker.ListTagsOutput
+}
+
+func (m mockedSageMakerEndpointConfig) ListEndpointConfigs(ctx context.Context, params *sagemaker.ListEndpointConfigsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListEndpointConfigsOutput, error) {
+	return &m.ListEndpointConfigsOutput, nil
+}
+
+func (m mockedSageMakerEndpointConfig) DeleteEndpointConfig(ctx context.Context, params *sagemaker.DeleteEndpointConfigInput, optFns ...func(*sagemaker.Options)) (*sagemaker.DeleteEndpointConfigOutput, error) {
+	return &m.DeleteEndpointConfigOutput, nil
+}
+
+func (m mockedSageMakerEndpointConfig) ListTags(ctx context.Context, params *sagemaker.ListTagsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListTagsOutput, error) {
+	return &m.ListTagsOutput, nil
+}
+
+func TestSageMakerEndpointConfig_GetAll(t *testing.T) {
+	t.Parallel()
+
+	testName1 := "endpoint-config-1"
+	testName2 := "endpoint-config-2"
+	now := time.Now()
+
+	endpointConfig := SageMakerEndpointConfig{
+		Client: mockedSageMakerEndpointConfig{
+			ListEndpointConfigsOutput: sagemaker.ListEndpointConfigsOutput{
+				EndpointConfigs: []types.EndpointConfigSummary{
+					{
+						EndpointConfigName: aws.String(testName1),
+						CreationTime:       aws.Time(now),
+					},
+					{
+						EndpointConfigName: aws.String(testName2),
+						CreationTime:       aws.Time(now.Add(1)),
+					},
+				},
+			},
+			ListTagsOutput: sagemaker.ListTagsOutput{
+				Tags: []types.Tag{
+					{
+						Key:   aws.String("Environment"),
+						Value: aws.String("test"),
+					},
+				},
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		configObj config.ResourceType
+		expected  []string
+	}{
+		"emptyFilter": {
+			configObj: config.ResourceType{},
+			expected:  []string{testName1, testName2},
+		},
+		"nameExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					NamesRegExp: []config.Expression{{
+						RE: *regexp.MustCompile(testName1),
+					}}},
+			},
+			expected: []string{testName2},
+		},
+		"timeAfterExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					TimeAfter: aws.Time(now),
+				}},
+			expected: []string{testName1},
+		},
+		"tagFilter": {
+			configObj: config.ResourceType{
+				IncludeRule: config.FilterRule{
+					Tags: map[string]config.Expression{
+						"Environment": {RE: *regexp.MustCompile("test")},
+					},
+				}},
+			expected: []string{testName1, testName2},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, util.AccountIdKey, "test-account-id")
+
+			endpointConfigs, err := endpointConfig.GetAll(ctx, config.Config{
+				SageMakerEndpointConfig: tc.configObj,
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, aws.ToStringSlice(endpointConfigs))
+		})
+	}
+}
+
+func TestSageMakerEndpointConfig_NukeAll(t *testing.T) {
+	t.Parallel()
+
+	endpointConfig := SageMakerEndpointConfig{
+		Client: mockedSageMakerEndpointConfig{
+			DeleteEndpointConfigOutput: sagemaker.DeleteEndpointConfigOutput{},
+		},
+	}
+
+	err := endpointConfig.nukeAll([]string{"endpoint-config-1", "endpoint-config-2"})
+	require.NoError(t, err)
+}
+
+func TestSageMakerEndpointConfig_EmptyNukeAll(t *testing.T) {
+	t.Parallel()
+
+	endpointConfig := SageMakerEndpointConfig{
+		Client: mockedSageMakerEndpointConfig{
+			DeleteEndpointConfigOutput: sagemaker.DeleteEndpointConfigOutput{},
+		},
+	}
+
+	err := endpointConfig.nukeAll([]string{})
+	require.NoError(t, err)
+}

--- a/aws/resources/sagemaker_endpoint_config_types.go
+++ b/aws/resources/sagemaker_endpoint_config_types.go
@@ -1,0 +1,90 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
+	"github.com/gruntwork-io/cloud-nuke/config"
+)
+
+// SageMakerEndpointConfigAPI represents the shape of the AWS SageMaker API for testing
+// This interface allows for mocking in tests and defines all required SageMaker operations
+type SageMakerEndpointConfigAPI interface {
+	ListEndpointConfigs(ctx context.Context, params *sagemaker.ListEndpointConfigsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListEndpointConfigsOutput, error)
+	DeleteEndpointConfig(ctx context.Context, params *sagemaker.DeleteEndpointConfigInput, optFns ...func(*sagemaker.Options)) (*sagemaker.DeleteEndpointConfigOutput, error)
+	ListTags(ctx context.Context, params *sagemaker.ListTagsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListTagsOutput, error)
+}
+
+// SageMakerEndpointConfig represents an AWS SageMaker Endpoint Configuration resource to be nuked
+// It implements the Resource interface and handles the deletion of SageMaker Endpoint Configurations
+type SageMakerEndpointConfig struct {
+	BaseAwsResource
+	Client              SageMakerEndpointConfigAPI // AWS SageMaker client or mock for testing
+	Region              string                     // AWS region where the resources are located
+	EndpointConfigNames []string                   // List of SageMaker Endpoint Configuration names to be nuked
+}
+
+// Init initializes the SageMaker client with the provided AWS configuration
+func (s *SageMakerEndpointConfig) Init(cfg aws.Config) {
+	s.Client = sagemaker.NewFromConfig(cfg)
+}
+
+// ResourceName returns the identifier string for this resource type
+// Used for logging and reporting purposes
+func (s *SageMakerEndpointConfig) ResourceName() string {
+	return "sagemaker-endpoint-config"
+}
+
+// ResourceIdentifiers returns the list of endpoint configuration names that will be nuked
+func (s *SageMakerEndpointConfig) ResourceIdentifiers() []string {
+	return s.EndpointConfigNames
+}
+
+// MaxBatchSize returns the maximum number of resources that can be deleted in parallel
+// This limit helps prevent AWS API throttling
+func (s *SageMakerEndpointConfig) MaxBatchSize() int {
+	// Tentative batch size to ensure AWS doesn't throttle
+	return 10
+}
+
+// GetAndSetResourceConfig retrieves the configuration for SageMaker Endpoint Configuration resources
+func (s *SageMakerEndpointConfig) GetAndSetResourceConfig(configObj config.Config) config.ResourceType {
+	return configObj.SageMakerEndpointConfig
+}
+
+// GetAndSetIdentifiers retrieves all SageMaker Endpoint Configurations and stores their identifiers
+func (s *SageMakerEndpointConfig) GetAndSetIdentifiers(c context.Context, configObj config.Config) ([]string, error) {
+	identifiers, err := s.GetAll(c, configObj)
+	if err != nil {
+		return nil, err
+	}
+
+	s.EndpointConfigNames = aws.ToStringSlice(identifiers)
+	return s.EndpointConfigNames, nil
+}
+
+// IsNukable determines whether a specific SageMaker Endpoint Configuration can be deleted
+// It will respect tag exclusion rules from the configuration
+func (s *SageMakerEndpointConfig) IsNukable(identifier string) (bool, error) {
+	// Look for endpoint config with this name in our list
+	for _, endpointConfigName := range s.EndpointConfigNames {
+		if endpointConfigName == identifier {
+			// This endpoint config was already vetted through our filtering process
+			// and is included in the list of endpoint configs to nuke
+			return true, nil
+		}
+	}
+
+	// If we can't find it in our approved list, don't allow it to be nuked
+	// This means either it was filtered out by tag exclusion rules or
+	// it doesn't exist in the current account/region
+	return false, fmt.Errorf("endpoint configuration is protected by tag exclusion rules or not found")
+}
+
+// Nuke implements the AwsResource interface by calling nukeAll
+// It takes a list of endpoint configuration identifiers and deletes those endpoint configs
+func (s *SageMakerEndpointConfig) Nuke(identifiers []string) error {
+	return s.nukeAll(identifiers)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -114,6 +114,7 @@ type Config struct {
 	SNS                             ResourceType                  `yaml:"SNS"`
 	SQS                             ResourceType                  `yaml:"SQS"`
 	SageMakerEndpoint               ResourceType                  `yaml:"SageMakerEndpoint"`
+	SageMakerEndpointConfig         ResourceType                  `yaml:"SageMakerEndpointConfig"`
 	SageMakerNotebook               ResourceType                  `yaml:"SageMakerNotebook"`
 	SageMakerStudioDomain           ResourceType                  `yaml:"SageMakerStudioDomain"`
 	SecretsManagerSecrets           ResourceType                  `yaml:"SecretsManager"`

--- a/config/examples/complete.yaml
+++ b/config/examples/complete.yaml
@@ -1425,6 +1425,22 @@ SageMakerEndpoint:
     tag: test
   timeout: 1h
   protect_until_expire: true
+SageMakerEndpointConfig:
+  include:
+    names_regex:
+      - that.*
+      - thats.*
+    time_after: 2024-02-02T00:00:00Z
+    time_before: 2024-01-01T00:00:00Z
+    tag: test
+  exclude:
+    names_regex:
+      - this.*
+    time_after: 2024-02-02T00:00:00Z
+    time_before: 2024-01-01T00:00:00Z
+    tag: test
+  timeout: 1h
+  protect_until_expire: true
 SageMakerNotebook:
   include:
     names_regex:


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Added support for SageMaker Endpoint configuration deletion with ability to filter by name, creation date and tags.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->

- Added support for SageMaker Endpoint.configuration

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

No breaking changes.
