### PR TITLE
Start nuking global resources to cleanup some left-over resources in test environment. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ jobs:
               --exclude-resource-type config-rules \
               --exclude-resource-type nat-gateway \
               --exclude-resource-type ec2-subnet \
+              --delete-unaliased-kms-keys \
               --log-level debug
           no_output_timeout: 1h
   nuke_sandbox:
@@ -158,6 +159,7 @@ jobs:
               --exclude-resource-type config-rules \
               --exclude-resource-type nat-gateway \
               --exclude-resource-type ec2-subnet \
+              --delete-unaliased-kms-keys \
               --log-level debug
           no_output_timeout: 1h
   nuke_configtests:
@@ -205,6 +207,7 @@ jobs:
               --exclude-resource-type config-rules \
               --exclude-resource-type nat-gateway \
               --exclude-resource-type ec2-subnet \
+              --delete-unaliased-kms-keys \
               --log-level debug
           no_output_timeout: 1h
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,7 @@ jobs:
               --exclude-resource-type config-rules \
               --exclude-resource-type nat-gateway \
               --exclude-resource-type ec2-subnet \
+              --exclude-resource-type eip \
               --delete-unaliased-kms-keys \
               --log-level debug
           no_output_timeout: 1h

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ jobs:
               --older-than 2h \
               --force \
               --config ./.circleci/nuke_config.yml \
+              --region global \
               --region ap-northeast-1 \
               --region ap-northeast-2 \
               --region ap-northeast-3 \
@@ -119,6 +120,7 @@ jobs:
               --older-than 24h \
               --force \
               --config ./.circleci/nuke_config.yml \
+              --region global \
               --region ap-northeast-1 \
               --region ap-northeast-2 \
               --region ap-northeast-3 \
@@ -161,6 +163,7 @@ jobs:
               --older-than 2h \
               --force \
               --config ./.circleci/nuke_config.yml \
+              --region global \
               --region ap-northeast-1 \
               --region ap-northeast-2 \
               --region ap-northeast-3 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,12 +98,18 @@ jobs:
               --region us-west-1 \
               --region us-west-2 \
               --exclude-resource-type iam \
+              --exclude-resource-type iam-group \
+              --exclude-resource-type iam-policy \
+              --exclude-resource-type iam-role \
               --exclude-resource-type iam-service-linked-role \
+              --exclude-resource-type oidcprovider \
+              --exclude-resource-type route53-hosted-zone \
+              --exclude-resource-type route53-cidr-collection \
+              --exclude-resource-type route53-traffic-policy \
               --exclude-resource-type ecr \
               --exclude-resource-type config-rules \
               --exclude-resource-type nat-gateway \
               --exclude-resource-type ec2-subnet \
-              --delete-unaliased-kms-keys \
               --log-level debug
           no_output_timeout: 1h
   nuke_sandbox:
@@ -140,13 +146,18 @@ jobs:
               --region us-west-1 \
               --region us-west-2 \
               --exclude-resource-type iam \
+              --exclude-resource-type iam-group \
+              --exclude-resource-type iam-policy \
+              --exclude-resource-type iam-role \
               --exclude-resource-type iam-service-linked-role \
+              --exclude-resource-type oidcprovider \
+              --exclude-resource-type route53-hosted-zone \
+              --exclude-resource-type route53-cidr-collection \
+              --exclude-resource-type route53-traffic-policy \
               --exclude-resource-type ecr \
               --exclude-resource-type config-rules \
-              --exclude-resource-type eip \
               --exclude-resource-type nat-gateway \
               --exclude-resource-type ec2-subnet \
-              --delete-unaliased-kms-keys \
               --log-level debug
           no_output_timeout: 1h
   nuke_configtests:
@@ -182,12 +193,18 @@ jobs:
               --region us-west-1 \
               --region us-west-2 \
               --exclude-resource-type iam \
+              --exclude-resource-type iam-group \
+              --exclude-resource-type iam-policy \
+              --exclude-resource-type iam-role \
               --exclude-resource-type iam-service-linked-role \
+              --exclude-resource-type oidcprovider \
+              --exclude-resource-type route53-hosted-zone \
+              --exclude-resource-type route53-cidr-collection \
+              --exclude-resource-type route53-traffic-policy \
               --exclude-resource-type ecr \
               --exclude-resource-type config-rules \
               --exclude-resource-type nat-gateway \
               --exclude-resource-type ec2-subnet \
-              --delete-unaliased-kms-keys \
               --log-level debug
           no_output_timeout: 1h
   deploy:
@@ -235,7 +252,7 @@ workflows:
     # Make sure this pipeline doesn't run when a schedule is triggered
     when:
       not:
-        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - test:
           filters:
@@ -270,8 +287,8 @@ workflows:
   nuke_phxdevops:
     when:
       and:
-        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - equal: ["every 3 hours", << pipeline.schedule.name >>]
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "every 3 hours", << pipeline.schedule.name >> ]
     jobs:
       - nuke_phx_devops:
           context:
@@ -280,8 +297,8 @@ workflows:
   nuke_configtests:
     when:
       and:
-        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - equal: ["every 3 hours", << pipeline.schedule.name >>]
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "every 3 hours", << pipeline.schedule.name >> ]
     jobs:
       - nuke_configtests:
           context:
@@ -290,8 +307,8 @@ workflows:
   nuke_sandbox:
     when:
       and:
-        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - equal: ["nightly", << pipeline.schedule.name >>]
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "nightly", << pipeline.schedule.name >> ]
     jobs:
       - nuke_sandbox:
           context:


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Had originally issue with this PR - https://github.com/gruntwork-io/cloud-nuke/commit/98fb5dae4bc9cf37ca4c45ace5cb35fd306a681d. 
Turns out there were some spaces in the command line. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
