### PR TITLE
Update IAMRoles.shouldInclude to filter out AWS-managed service linked roles

### DIFF
--- a/aws/resources/iam_role.go
+++ b/aws/resources/iam_role.go
@@ -190,6 +190,14 @@ func (ir *IAMRoles) shouldInclude(iamRole *types.Role, configObj config.Config) 
 		return false
 	}
 
+	// The IAM roles with names starting with "AWSServiceRoleFor" are AWS Service-Linked Roles.
+	// These are automatically created and managed by AWS services and cannot be manually deleted or modified.
+	// Hence, we filter them out from cloud-nuke operations.
+	if strings.HasPrefix(aws.ToString(iamRole.RoleName), "AWSServiceRoleFor") {
+		logging.Debugf("Filtering out service linked role %s", aws.ToString(iamRole.RoleName))
+		return false
+	}
+
 	return configObj.IAMRoles.ShouldInclude(config.ResourceValue{
 		Name: iamRole.RoleName,
 		Time: iamRole.CreateDate,


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #https://github.com/gruntwork-io/cloud-nuke/issues/880.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
