### PR TITLE
feat(iam-policy): add tag filtering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ of the file that are supported are listed here.
 | grafana                          | Grafana                       | ✅ (Workspace Name)                    | ✅ (Creation Time)                   | ✅    | ✅       |
 | guardduty                        | GuardDuty                     | ❌                                     | ✅ (Created Time)                    | ❌    | ✅       |
 | iam-group                        | IAMGroups                     | ✅ (Group Name)                        | ✅ (Creation Time)                   | ❌    | ✅       |
-| iam-policy                       | IAMPolicies                   | ✅ (Policy Name)                       | ✅ (Creation Time)                   | ❌    | ✅       |
+| iam-policy                       | IAMPolicies                   | ✅ (Policy Name)                       | ✅ (Creation Time)                   | ✅    | ✅       |
 | iam-role                         | IAMRoles                      | ✅ (Role Name)                         | ✅ (Creation Time)                   | ✅    | ✅       |
 | iam-service-linked-role          | IAMServiceLinkedRoles         | ✅ (Service Linked Role Name)          | ✅ (Creation Time)                   | ❌    | ✅       |
 | iam                              | IAMUsers                      | ✅ (User Name)                         | ✅ (Creation Time)                   | ✅    | ✅       |
@@ -669,7 +669,7 @@ of the file that are supported are listed here.
 | nat-gateway                      | NatGateway                    | ✅ (EC2 Name Tag)                      | ✅ (Creation Time)                   | ✅    | ✅       |
 | network-acl                      | NetworkACL                    | ✅ (ACL Name Tag)                      | ✅ (Creation Time)                   | ✅    | ✅       |
 | network-interface                | NetworkInterface              | ✅ (Interface Name Tag)                | ✅ (Creation Time)                   | ✅    | ✅       |
-| oidcprovider                     | OIDCProvider                  | ✅ (Provider URL)                      | ✅ (Creation Time)                   | ✅    | ✅       |
+| oidcprovider                     | OIDCProvider                  | ✅ (Provider URL)                      | ✅ (Creation Time)                   | ❌    | ✅       |
 | opensearchdomain                 | OpenSearchDomain              | ✅ (Domain Name)                       | ✅ (First Seen Tag Time)             | ❌    | ✅       |
 | redshift                         | Redshift                      | ✅ (Cluster Identifier)                | ✅ (Creation Time)                   | ❌    | ✅       |
 | rds-cluster                      | DBClusters                    | ✅ (DB Cluster Identifier )            | ✅ (Creation Time)                   | ✅    | ✅       |

--- a/aws/resources/iam_policy_types.go
+++ b/aws/resources/iam_policy_types.go
@@ -12,6 +12,7 @@ import (
 type IAMPoliciesAPI interface {
 	ListEntitiesForPolicy(ctx context.Context, params *iam.ListEntitiesForPolicyInput, optFns ...func(*iam.Options)) (*iam.ListEntitiesForPolicyOutput, error)
 	ListPolicies(ctx context.Context, params *iam.ListPoliciesInput, optFns ...func(*iam.Options)) (*iam.ListPoliciesOutput, error)
+	ListPolicyTags(ctx context.Context, params *iam.ListPolicyTagsInput, optFns ...func(*iam.Options)) (*iam.ListPolicyTagsOutput, error)
 	ListPolicyVersions(ctx context.Context, params *iam.ListPolicyVersionsInput, optFns ...func(*iam.Options)) (*iam.ListPolicyVersionsOutput, error)
 	DeletePolicy(ctx context.Context, params *iam.DeletePolicyInput, optFns ...func(*iam.Options)) (*iam.DeletePolicyOutput, error)
 	DeletePolicyVersion(ctx context.Context, params *iam.DeletePolicyVersionInput, optFns ...func(*iam.Options)) (*iam.DeletePolicyVersionOutput, error)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #892 .

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [X] Include release notes. If this PR is backward incompatible, include a migration guide.
- [X] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

Added tag filtering for `iam-policy`

