### PR TITLE
fix: handle nil output from DescribeResourcePolicy in network firewall

### DIFF
--- a/aws/resources/network_firewall_resource_policy.go
+++ b/aws/resources/network_firewall_resource_policy.go
@@ -51,7 +51,7 @@ func (nfrp *NetworkFirewallResourcePolicy) getAll(_ context.Context, configObj c
 		}
 
 		// if the policy exists for a resource
-		if output.Policy != nil {
+		if output != nil && output.Policy != nil {
 			if configObj.NetworkFirewallResourcePolicy.ShouldInclude(config.ResourceValue{
 				Name: arn,
 			}) {


### PR DESCRIPTION
## Summary
- Fixed nil pointer dereference error when running `cloud-nuke inspect-aws --resource-type network-firewall-resource-policy`
- Added proper nil check for the output from DescribeResourcePolicy API call before accessing its fields

## Problem
When querying network firewall resource policies, the code was experiencing a runtime panic with "invalid memory address or nil pointer dereference" error. This occurred because the DescribeResourcePolicy API can return a nil output even when no error is returned, and the code was attempting to access `output.Policy` without first checking if `output` itself was nil.