### PR TITLE
feat: add support for AWS Cloud Map resources

### DIFF
--- a/aws/resource_registry.go
+++ b/aws/resource_registry.go
@@ -72,6 +72,8 @@ func getRegisteredRegionalResources() []AwsResource {
 		&resources.CloudWatchAlarms{},
 		&resources.CloudWatchDashboards{},
 		&resources.CloudWatchLogGroups{},
+		&resources.CloudMapServices{},
+		&resources.CloudMapNamespaces{},
 		&resources.CodeDeployApplications{},
 		&resources.ConfigServiceRecorders{},
 		&resources.ConfigServiceRule{},

--- a/aws/resources/cloudmap_namespace.go
+++ b/aws/resources/cloudmap_namespace.go
@@ -1,0 +1,134 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicediscovery"
+	"github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+func (cns *CloudMapNamespaces) getAll(c context.Context, configObj config.Config) ([]*string, error) {
+	var result []*string
+	
+	paginator := servicediscovery.NewListNamespacesPaginator(cns.Client, &servicediscovery.ListNamespacesInput{})
+	
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(cns.Context)
+		if err != nil {
+			return nil, errors.WithStackTrace(err)
+		}
+		
+		for _, namespace := range page.Namespaces {
+			if configObj.CloudMapNamespace.ShouldInclude(config.ResourceValue{
+				Name: namespace.Name,
+				Time: namespace.CreateDate,
+			}) {
+				result = append(result, namespace.Id)
+			}
+		}
+	}
+	
+	return result, nil
+}
+
+func (cns *CloudMapNamespaces) waitForServicesToDelete(namespaceId *string) error {
+	maxRetries := 30
+	sleepBetweenRetries := 10 * time.Second
+	
+	for i := 0; i < maxRetries; i++ {
+		paginator := servicediscovery.NewListServicesPaginator(cns.Client, &servicediscovery.ListServicesInput{
+			Filters: []types.ServiceFilter{
+				{
+					Name:      types.ServiceFilterNameNamespaceId,
+					Values:    []string{*namespaceId},
+					Condition: types.FilterConditionEq,
+				},
+			},
+		})
+		
+		hasServices := false
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(cns.Context)
+			if err != nil {
+				return errors.WithStackTrace(err)
+			}
+			
+			if len(page.Services) > 0 {
+				hasServices = true
+				break
+			}
+		}
+		
+		if !hasServices {
+			return nil
+		}
+		
+		logging.Debugf("Waiting for services in namespace %s to be deleted (attempt %d/%d)", *namespaceId, i+1, maxRetries)
+		time.Sleep(sleepBetweenRetries)
+	}
+	
+	return errors.WithStackTrace(fmt.Errorf("timeout waiting for services to be deleted in namespace %s", *namespaceId))
+}
+
+func (cns *CloudMapNamespaces) nukeAll(identifiers []*string) error {
+	if len(identifiers) == 0 {
+		logging.Debugf("No Cloud Map namespaces to nuke in region %s", cns.Region)
+		return nil
+	}
+	
+	logging.Debugf("Deleting %d Cloud Map namespaces in region %s", len(identifiers), cns.Region)
+	
+	var deletedNamespaces []*string
+	for _, id := range identifiers {
+		err := cns.waitForServicesToDelete(id)
+		if err != nil {
+			logging.Debugf("Error waiting for services to be deleted in namespace %s: %s", *id, err)
+		}
+		
+		getResp, err := cns.Client.GetNamespace(cns.Context, &servicediscovery.GetNamespaceInput{
+			Id: id,
+		})
+		if err != nil {
+			logging.Debugf("Error getting namespace %s: %s", *id, err)
+			continue
+		}
+		
+		if getResp.Namespace.Properties != nil {
+			if getResp.Namespace.Properties.DnsProperties != nil && getResp.Namespace.Properties.DnsProperties.HostedZoneId != nil {
+				logging.Debugf("Namespace %s has associated Route53 hosted zone %s - it will be cleaned automatically", 
+					*id, *getResp.Namespace.Properties.DnsProperties.HostedZoneId)
+			}
+		}
+		
+		input := &servicediscovery.DeleteNamespaceInput{
+			Id: id,
+		}
+		
+		_, err = cns.Client.DeleteNamespace(cns.Context, input)
+		
+		e := report.Entry{
+			Identifier:   aws.ToString(id),
+			ResourceType: "Cloud Map Namespace",
+			Error:        err,
+		}
+		report.Record(e)
+		
+		if err != nil {
+			logging.Debugf("Error deleting Cloud Map namespace %s: %s", *id, err)
+		} else {
+			logging.Debugf("Successfully deleted Cloud Map namespace: %s", *id)
+			deletedNamespaces = append(deletedNamespaces, id)
+		}
+	}
+	
+	logging.Debugf("[OK] %d of %d Cloud Map namespace(s) deleted in %s", len(deletedNamespaces), len(identifiers), cns.Region)
+	
+	return nil
+}

--- a/aws/resources/cloudmap_namespace_test.go
+++ b/aws/resources/cloudmap_namespace_test.go
@@ -1,0 +1,135 @@
+package resources
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicediscovery"
+	"github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/stretchr/testify/require"
+)
+
+type mockedCloudMapNamespacesAPI struct {
+	CloudMapNamespacesAPI
+	ListNamespacesOutput  servicediscovery.ListNamespacesOutput
+	DeleteNamespaceOutput servicediscovery.DeleteNamespaceOutput
+	GetNamespaceOutput    servicediscovery.GetNamespaceOutput
+	ListServicesOutput    servicediscovery.ListServicesOutput
+}
+
+func (m mockedCloudMapNamespacesAPI) ListNamespaces(ctx context.Context, params *servicediscovery.ListNamespacesInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.ListNamespacesOutput, error) {
+	return &m.ListNamespacesOutput, nil
+}
+
+func (m mockedCloudMapNamespacesAPI) DeleteNamespace(ctx context.Context, params *servicediscovery.DeleteNamespaceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.DeleteNamespaceOutput, error) {
+	return &m.DeleteNamespaceOutput, nil
+}
+
+func (m mockedCloudMapNamespacesAPI) GetNamespace(ctx context.Context, params *servicediscovery.GetNamespaceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.GetNamespaceOutput, error) {
+	return &m.GetNamespaceOutput, nil
+}
+
+func (m mockedCloudMapNamespacesAPI) ListServices(ctx context.Context, params *servicediscovery.ListServicesInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.ListServicesOutput, error) {
+	return &m.ListServicesOutput, nil
+}
+
+func TestCloudMapNamespaces_GetAll(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	testNamespace1 := "ns-123456789"
+	testNamespace2 := "ns-987654321"
+	testNamespace1Name := "test-namespace-1"
+	testNamespace2Name := "test-namespace-2"
+
+	cns := CloudMapNamespaces{
+		Client: mockedCloudMapNamespacesAPI{
+			ListNamespacesOutput: servicediscovery.ListNamespacesOutput{
+				Namespaces: []types.NamespaceSummary{
+					{
+						Id:         aws.String(testNamespace1),
+						Name:       aws.String(testNamespace1Name),
+						CreateDate: aws.Time(now.Add(-1 * time.Hour)),
+					},
+					{
+						Id:         aws.String(testNamespace2),
+						Name:       aws.String(testNamespace2Name),
+						CreateDate: aws.Time(now),
+					},
+				},
+			},
+		},
+	}
+	cns.BaseAwsResource.Init(aws.Config{})
+
+	tests := map[string]struct {
+		configObj config.Config
+		expected  []string
+	}{
+		"emptyFilter": {
+			configObj: config.Config{
+				CloudMapNamespace: config.ResourceType{},
+			},
+			expected: []string{testNamespace1, testNamespace2},
+		},
+		"nameExclusionFilter": {
+			configObj: config.Config{
+				CloudMapNamespace: config.ResourceType{
+					ExcludeRule: config.FilterRule{
+						NamesRegExp: []config.Expression{{
+							RE: *regexp.MustCompile("test-namespace-1"),
+						}},
+					},
+				},
+			},
+			expected: []string{testNamespace2},
+		},
+		"timeAfterExclusionFilter": {
+			configObj: config.Config{
+				CloudMapNamespace: config.ResourceType{
+					ExcludeRule: config.FilterRule{
+						TimeAfter: aws.Time(now.Add(-30 * time.Minute)),
+					},
+				},
+			},
+			expected: []string{testNamespace1},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			names, err := cns.getAll(context.Background(), tc.configObj)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, aws.ToStringSlice(names))
+		})
+	}
+}
+
+func TestCloudMapNamespaces_NukeAll(t *testing.T) {
+	t.Parallel()
+
+	cns := CloudMapNamespaces{
+		Client: mockedCloudMapNamespacesAPI{
+			ListServicesOutput: servicediscovery.ListServicesOutput{
+				Services: []types.ServiceSummary{},
+			},
+			GetNamespaceOutput: servicediscovery.GetNamespaceOutput{
+				Namespace: &types.Namespace{
+					Id:   aws.String("ns-123456789"),
+					Name: aws.String("test-namespace"),
+				},
+			},
+			DeleteNamespaceOutput: servicediscovery.DeleteNamespaceOutput{
+				OperationId: aws.String("operation-123"),
+			},
+		},
+	}
+	cns.BaseAwsResource.Init(aws.Config{})
+
+	err := cns.nukeAll([]*string{aws.String("ns-123456789")})
+	require.NoError(t, err)
+}

--- a/aws/resources/cloudmap_namespace_types.go
+++ b/aws/resources/cloudmap_namespace_types.go
@@ -1,0 +1,61 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicediscovery"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+type CloudMapNamespacesAPI interface {
+	ListNamespaces(ctx context.Context, params *servicediscovery.ListNamespacesInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.ListNamespacesOutput, error)
+	DeleteNamespace(ctx context.Context, params *servicediscovery.DeleteNamespaceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.DeleteNamespaceOutput, error)
+	GetNamespace(ctx context.Context, params *servicediscovery.GetNamespaceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.GetNamespaceOutput, error)
+	ListServices(ctx context.Context, params *servicediscovery.ListServicesInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.ListServicesOutput, error)
+}
+
+type CloudMapNamespaces struct {
+	BaseAwsResource
+	Client       CloudMapNamespacesAPI
+	Region       string
+	NamespaceIds []string
+}
+
+func (cns *CloudMapNamespaces) Init(cfg aws.Config) {
+	cns.Client = servicediscovery.NewFromConfig(cfg)
+}
+
+func (cns *CloudMapNamespaces) ResourceName() string {
+	return "cloudmap-namespace"
+}
+
+func (cns *CloudMapNamespaces) ResourceIdentifiers() []string {
+	return cns.NamespaceIds
+}
+
+func (cns *CloudMapNamespaces) GetAndSetResourceConfig(configObj config.Config) config.ResourceType {
+	return configObj.CloudMapNamespace
+}
+
+func (cns *CloudMapNamespaces) MaxBatchSize() int {
+	return 50
+}
+
+func (cns *CloudMapNamespaces) GetAndSetIdentifiers(c context.Context, configObj config.Config) ([]string, error) {
+	identifiers, err := cns.getAll(c, configObj)
+	if err != nil {
+		return nil, err
+	}
+	
+	cns.NamespaceIds = aws.ToStringSlice(identifiers)
+	return cns.NamespaceIds, nil
+}
+
+func (cns *CloudMapNamespaces) Nuke(identifiers []string) error {
+	if err := cns.nukeAll(aws.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+	return nil
+}

--- a/aws/resources/cloudmap_service.go
+++ b/aws/resources/cloudmap_service.go
@@ -1,0 +1,145 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicediscovery"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+func (cms *CloudMapServices) getAll(c context.Context, configObj config.Config) ([]*string, error) {
+	var result []*string
+	
+	paginator := servicediscovery.NewListServicesPaginator(cms.Client, &servicediscovery.ListServicesInput{})
+	
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(cms.Context)
+		if err != nil {
+			return nil, errors.WithStackTrace(err)
+		}
+		
+		for _, service := range page.Services {
+			if configObj.CloudMapService.ShouldInclude(config.ResourceValue{
+				Name: service.Name,
+				Time: service.CreateDate,
+			}) {
+				result = append(result, service.Id)
+			}
+		}
+	}
+	
+	return result, nil
+}
+
+func (cms *CloudMapServices) deregisterAllInstances(serviceId *string) error {
+	paginator := servicediscovery.NewListInstancesPaginator(cms.Client, &servicediscovery.ListInstancesInput{
+		ServiceId: serviceId,
+	})
+	
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(cms.Context)
+		if err != nil {
+			return errors.WithStackTrace(err)
+		}
+		
+		for _, instance := range page.Instances {
+			logging.Debugf("Deregistering instance %s from service %s", *instance.Id, *serviceId)
+			
+			_, err := cms.Client.DeregisterInstance(cms.Context, &servicediscovery.DeregisterInstanceInput{
+				ServiceId:  serviceId,
+				InstanceId: instance.Id,
+			})
+			
+			if err != nil {
+				logging.Debugf("Error deregistering instance %s: %s", *instance.Id, err)
+			}
+		}
+	}
+	
+	return nil
+}
+
+func (cms *CloudMapServices) waitForInstanceDeregistration(serviceId *string) error {
+	maxRetries := 30
+	sleepBetweenRetries := 5 * time.Second
+	
+	for i := 0; i < maxRetries; i++ {
+		paginator := servicediscovery.NewListInstancesPaginator(cms.Client, &servicediscovery.ListInstancesInput{
+			ServiceId: serviceId,
+		})
+		
+		hasInstances := false
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(cms.Context)
+			if err != nil {
+				return errors.WithStackTrace(err)
+			}
+			
+			if len(page.Instances) > 0 {
+				hasInstances = true
+				break
+			}
+		}
+		
+		if !hasInstances {
+			return nil
+		}
+		
+		logging.Debugf("Waiting for instances in service %s to be deregistered (attempt %d/%d)", *serviceId, i+1, maxRetries)
+		time.Sleep(sleepBetweenRetries)
+	}
+	
+	return errors.WithStackTrace(fmt.Errorf("timeout waiting for instances to be deregistered in service %s", *serviceId))
+}
+
+func (cms *CloudMapServices) nukeAll(identifiers []*string) error {
+	if len(identifiers) == 0 {
+		logging.Debugf("No Cloud Map services to nuke in region %s", cms.Region)
+		return nil
+	}
+	
+	logging.Debugf("Deleting %d Cloud Map services in region %s", len(identifiers), cms.Region)
+	
+	var deletedServices []*string
+	for _, id := range identifiers {
+		err := cms.deregisterAllInstances(id)
+		if err != nil {
+			logging.Debugf("Error deregistering instances for service %s: %s", *id, err)
+		}
+		
+		err = cms.waitForInstanceDeregistration(id)
+		if err != nil {
+			logging.Debugf("Error waiting for instances to be deregistered in service %s: %s", *id, err)
+		}
+		
+		input := &servicediscovery.DeleteServiceInput{
+			Id: id,
+		}
+		
+		_, err = cms.Client.DeleteService(cms.Context, input)
+		
+		e := report.Entry{
+			Identifier:   aws.ToString(id),
+			ResourceType: "Cloud Map Service",
+			Error:        err,
+		}
+		report.Record(e)
+		
+		if err != nil {
+			logging.Debugf("Error deleting Cloud Map service %s: %s", *id, err)
+		} else {
+			logging.Debugf("Successfully deleted Cloud Map service: %s", *id)
+			deletedServices = append(deletedServices, id)
+		}
+	}
+	
+	logging.Debugf("[OK] %d of %d Cloud Map service(s) deleted in %s", len(deletedServices), len(identifiers), cms.Region)
+	
+	return nil
+}

--- a/aws/resources/cloudmap_service_test.go
+++ b/aws/resources/cloudmap_service_test.go
@@ -1,0 +1,130 @@
+package resources
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicediscovery"
+	"github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/stretchr/testify/require"
+)
+
+type mockedCloudMapServicesAPI struct {
+	CloudMapServicesAPI
+	ListServicesOutput        servicediscovery.ListServicesOutput
+	DeleteServiceOutput       servicediscovery.DeleteServiceOutput
+	ListInstancesOutput       servicediscovery.ListInstancesOutput
+	DeregisterInstanceOutput  servicediscovery.DeregisterInstanceOutput
+}
+
+func (m mockedCloudMapServicesAPI) ListServices(ctx context.Context, params *servicediscovery.ListServicesInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.ListServicesOutput, error) {
+	return &m.ListServicesOutput, nil
+}
+
+func (m mockedCloudMapServicesAPI) DeleteService(ctx context.Context, params *servicediscovery.DeleteServiceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.DeleteServiceOutput, error) {
+	return &m.DeleteServiceOutput, nil
+}
+
+func (m mockedCloudMapServicesAPI) ListInstances(ctx context.Context, params *servicediscovery.ListInstancesInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.ListInstancesOutput, error) {
+	return &m.ListInstancesOutput, nil
+}
+
+func (m mockedCloudMapServicesAPI) DeregisterInstance(ctx context.Context, params *servicediscovery.DeregisterInstanceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.DeregisterInstanceOutput, error) {
+	return &m.DeregisterInstanceOutput, nil
+}
+
+func TestCloudMapServices_GetAll(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	testService1 := "srv-123456789"
+	testService2 := "srv-987654321"
+	testService1Name := "test-service-1"
+	testService2Name := "test-service-2"
+
+	cms := CloudMapServices{
+		Client: mockedCloudMapServicesAPI{
+			ListServicesOutput: servicediscovery.ListServicesOutput{
+				Services: []types.ServiceSummary{
+					{
+						Id:         aws.String(testService1),
+						Name:       aws.String(testService1Name),
+						CreateDate: aws.Time(now.Add(-1 * time.Hour)),
+					},
+					{
+						Id:         aws.String(testService2),
+						Name:       aws.String(testService2Name),
+						CreateDate: aws.Time(now),
+					},
+				},
+			},
+		},
+	}
+	cms.BaseAwsResource.Init(aws.Config{})
+
+	tests := map[string]struct {
+		configObj config.Config
+		expected  []string
+	}{
+		"emptyFilter": {
+			configObj: config.Config{
+				CloudMapService: config.ResourceType{},
+			},
+			expected: []string{testService1, testService2},
+		},
+		"nameExclusionFilter": {
+			configObj: config.Config{
+				CloudMapService: config.ResourceType{
+					ExcludeRule: config.FilterRule{
+						NamesRegExp: []config.Expression{{
+							RE: *regexp.MustCompile("test-service-1"),
+						}},
+					},
+				},
+			},
+			expected: []string{testService2},
+		},
+		"timeAfterExclusionFilter": {
+			configObj: config.Config{
+				CloudMapService: config.ResourceType{
+					ExcludeRule: config.FilterRule{
+						TimeAfter: aws.Time(now.Add(-30 * time.Minute)),
+					},
+				},
+			},
+			expected: []string{testService1},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			names, err := cms.getAll(context.Background(), tc.configObj)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, aws.ToStringSlice(names))
+		})
+	}
+}
+
+func TestCloudMapServices_NukeAll(t *testing.T) {
+	t.Parallel()
+
+	cms := CloudMapServices{
+		Client: mockedCloudMapServicesAPI{
+			ListInstancesOutput: servicediscovery.ListInstancesOutput{
+				Instances: []types.InstanceSummary{},
+			},
+			DeregisterInstanceOutput: servicediscovery.DeregisterInstanceOutput{
+				OperationId: aws.String("operation-123"),
+			},
+			DeleteServiceOutput: servicediscovery.DeleteServiceOutput{},
+		},
+	}
+	cms.BaseAwsResource.Init(aws.Config{})
+
+	err := cms.nukeAll([]*string{aws.String("srv-123456789")})
+	require.NoError(t, err)
+}

--- a/aws/resources/cloudmap_service_types.go
+++ b/aws/resources/cloudmap_service_types.go
@@ -1,0 +1,61 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicediscovery"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+type CloudMapServicesAPI interface {
+	ListServices(ctx context.Context, params *servicediscovery.ListServicesInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.ListServicesOutput, error)
+	DeleteService(ctx context.Context, params *servicediscovery.DeleteServiceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.DeleteServiceOutput, error)
+	ListInstances(ctx context.Context, params *servicediscovery.ListInstancesInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.ListInstancesOutput, error)
+	DeregisterInstance(ctx context.Context, params *servicediscovery.DeregisterInstanceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.DeregisterInstanceOutput, error)
+}
+
+type CloudMapServices struct {
+	BaseAwsResource
+	Client     CloudMapServicesAPI
+	Region     string
+	ServiceIds []string
+}
+
+func (cms *CloudMapServices) Init(cfg aws.Config) {
+	cms.Client = servicediscovery.NewFromConfig(cfg)
+}
+
+func (cms *CloudMapServices) ResourceName() string {
+	return "cloudmap-service"
+}
+
+func (cms *CloudMapServices) ResourceIdentifiers() []string {
+	return cms.ServiceIds
+}
+
+func (cms *CloudMapServices) GetAndSetResourceConfig(configObj config.Config) config.ResourceType {
+	return configObj.CloudMapService
+}
+
+func (cms *CloudMapServices) MaxBatchSize() int {
+	return 50
+}
+
+func (cms *CloudMapServices) GetAndSetIdentifiers(c context.Context, configObj config.Config) ([]string, error) {
+	identifiers, err := cms.getAll(c, configObj)
+	if err != nil {
+		return nil, err
+	}
+	
+	cms.ServiceIds = aws.ToStringSlice(identifiers)
+	return cms.ServiceIds, nil
+}
+
+func (cms *CloudMapServices) Nuke(identifiers []string) error {
+	if err := cms.nukeAll(aws.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,8 @@ type Config struct {
 	CloudWatchAlarm                 ResourceType                  `yaml:"CloudWatchAlarm"`
 	CloudWatchDashboard             ResourceType                  `yaml:"CloudWatchDashboard"`
 	CloudWatchLogGroup              ResourceType                  `yaml:"CloudWatchLogGroup"`
+	CloudMapNamespace               ResourceType                  `yaml:"CloudMapNamespace"`
+	CloudMapService                 ResourceType                  `yaml:"CloudMapService"`
 	CloudtrailTrail                 ResourceType                  `yaml:"CloudtrailTrail"`
 	CloudfrontDistribution          ResourceType                  `yaml:"CloudfrontDistribution"`
 	CodeDeployApplications          ResourceType                  `yaml:"CodeDeployApplications"`

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.6
 
 require (
 	cloud.google.com/go/storage v1.39.1
-	github.com/aws/aws-sdk-go-v2 v1.36.3
+	github.com/aws/aws-sdk-go-v2 v1.38.1
 	github.com/aws/aws-sdk-go-v2/config v1.29.5
 	github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.36.12
 	github.com/aws/aws-sdk-go-v2/service/acm v1.30.17
@@ -60,7 +60,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.37.13
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.13
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.13.9
-	github.com/aws/smithy-go v1.22.2
+	github.com/aws/smithy-go v1.22.5
 	github.com/charmbracelet/lipgloss v0.6.0
 	github.com/go-errors/errors v1.4.2
 	github.com/gruntwork-io/go-commons v0.17.0
@@ -84,8 +84,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.8 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.58 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.27 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.4 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.2 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.31 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.2 // indirect
@@ -93,6 +93,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.12 // indirect
+	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.39.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.14 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.13 // indirect
 	github.com/containerd/console v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/MarvinJWendt/testza v0.4.2/go.mod h1:mSdhXiKH8sg/gQehJ63bINcCKp7RtYew
 github.com/atomicgo/cursor v0.0.1/go.mod h1:cBON2QmmrysudxNBFthvMtN32r3jxVRIvzkUiF/RuIk=
 github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
 github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
+github.com/aws/aws-sdk-go-v2 v1.38.1 h1:j7sc33amE74Rz0M/PoCpsZQ6OunLqys/m5antM0J+Z8=
+github.com/aws/aws-sdk-go-v2 v1.38.1/go.mod h1:9Q0OoGQoboYIAJyslFyF1f5K1Ryddop8gqMhWx/n4Wg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.8 h1:zAxi9p3wsZMIaVCdoiQp2uZ9k1LsZvmAnoTBeZPXom0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.8/go.mod h1:3XkePX5dSaxveLAYY7nsbsZZrKxCyEuE5pM4ziFxyGg=
 github.com/aws/aws-sdk-go-v2/config v1.29.5 h1:4lS2IB+wwkj5J43Tq/AwvnscBerBJtQQ6YS7puzCI1k=
@@ -34,8 +36,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.27 h1:7lOW8NUwE9UZekS1DYoiPd
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.27/go.mod h1:w1BASFIPOPUae7AgaH4SbjNbfdkxuggLyGfNFTn8ITY=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 h1:ZK5jHhnrioRkUNOc+hOgQKlUL5JeC3S6JgLxtQ+Rm0Q=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34/go.mod h1:p4VfIceZokChbA9FzMbRGz5OV+lekcVtHlPKEO0gSZY=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.4 h1:IdCLsiiIj5YJ3AFevsewURCPV+YWUlOW8JiPhoAy8vg=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.4/go.mod h1:l4bdfCD7XyyZA9BolKBo1eLqgaJxl0/x91PL4Yqe0ao=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 h1:SZwFm17ZUNNg5Np0ioo/gq8Mn6u9w19Mri8DnJ15Jf0=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34/go.mod h1:dFZsC0BLo346mvKQLWmoJxT+Sjp+qcVR1tRVHQGOH9Q=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.4 h1:j7vjtr1YIssWQOMeOWRbh3z8g2oY/xPjnZH2gLY4sGw=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.4/go.mod h1:yDmJgqOiH4EA8Hndnv4KwAo8jCGTSnM5ASG1nBI+toA=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.2 h1:Pg9URiobXy85kgFev3og2CuOZ8JZUBENF+dcgWBaYNk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.2/go.mod h1:FbtygfRFze9usAadmnGJNc8KsP346kEe+y2/oyhGAGc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.31 h1:8IwBjuLdqIO1dGB+dZ9zJEl8wzY3bVYxcs0Xyu/Lsc0=
@@ -144,6 +150,8 @@ github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.17 h1:OMMxv2xpGkp1cVc2
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.17/go.mod h1:5WGcD7Mks8G/VNlpHp2ZwfP5pVIZp0zp8nauLU7NuLM=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.55.8 h1:+0McIKnas9knQ+22C0fS5j1j4J4wlCvnjMPzvdgVrvQ=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.55.8/go.mod h1:Fab1AoG6jUpxrpAmv9EXzBg19EoJcvnwSIc/oDrEE2o=
+github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.39.3 h1:M3DyWHClr67A6UalxmpBkGvKgU2W54m5giBbTb9A+Tc=
+github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.39.3/go.mod h1:/ZwaUAo11yCI+/RlsS9qenibv8nlhojmhGJZwswFyGg=
 github.com/aws/aws-sdk-go-v2/service/ses v1.29.9 h1:MIiyk/qQEBO+AI1WHRQDSZft9w2XGAenB58lhzVrByg=
 github.com/aws/aws-sdk-go-v2/service/ses v1.29.9/go.mod h1:TPNs3cjA3xDkDpSlPajkTr0VrSw8U9dh8sE+n77QjgE=
 github.com/aws/aws-sdk-go-v2/service/sns v1.33.18 h1:jiLcwPNwOzhnM7sIjuz0L5C3XglgohVj0kmPzsPntyY=
@@ -160,6 +168,8 @@ github.com/aws/aws-sdk-go-v2/service/vpclattice v1.13.9 h1:T6N4RwAqT8cDOu5dnNhNa
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.13.9/go.mod h1:euZAP+7gNAaV0QDx7gvJDsYhpB12U20k1yBWtU/yIvQ=
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/aws/smithy-go v1.22.5 h1:P9ATCXPMb2mPjYBgueqJNCA5S9UfktsW0tTxi+a7eqw=
+github.com/aws/smithy-go v1.22.5/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/charmbracelet/lipgloss v0.6.0 h1:1StyZB9vBSOyuZxQUcUwGr17JmojPNm87inij9N3wJY=


### PR DESCRIPTION
## Summary
- Add support for cleaning up AWS Cloud Map service discovery resources
- Implement CloudMapService and CloudMapNamespace resource types

## Test plan
- [x] Unit tests added for both resource types
- [x] Resources appear in `cloud-nuke inspect-aws --list-resource-types`
- [x] Build passes without errors