### PR TITLE
Fix: Exclude resources without tag support when tag filters are specified

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -944,3 +944,27 @@ func TestShouldIncludeBasedOnIncludeRuleTags(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldIncludeBasedOnTag_NilTagsSafety(t *testing.T) {
+	// When include tag filters are specified, resources that don't support tags (nil) should be excluded
+	r := ResourceType{
+		IncludeRule: FilterRule{
+			Tags: map[string]Expression{
+				"Environment": {RE: *regexp.MustCompile("production")},
+			},
+		},
+	}
+
+	// Resource doesn't support tags (nil) - should exclude for safety
+	assert.False(t, r.ShouldIncludeBasedOnTag(nil))
+
+	// Resource supports tags but has none (empty map) - should exclude because tags don't match
+	assert.False(t, r.ShouldIncludeBasedOnTag(map[string]string{}))
+
+	// Resource has matching tags - should include
+	assert.True(t, r.ShouldIncludeBasedOnTag(map[string]string{"Environment": "production"}))
+
+	// When no include tag filters specified, resource without tag support should be included
+	r2 := ResourceType{}
+	assert.True(t, r2.ShouldIncludeBasedOnTag(nil))
+}


### PR DESCRIPTION
## Summary
- Fixes dangerous behavior where resources that don't support tag filtering are included when include tag filters are specified
- Adds safety check to exclude resources with nil tags when include filters are present

## Problem
When using include tag filters in config files to target specific resources, resources that don't support tag filtering were being included anyway, potentially leading to accidental deletion.

## Solution  
Added a check in `ShouldIncludeBasedOnTag()` to exclude resources where tags are nil (indicating no tag support) when include tag filters are specified.

## Test plan
- [x] Added unit test `TestShouldIncludeBasedOnTag_NilTagsSafety` 
- [x] All existing tests pass