### PR TITLE
feat: Add tag support for ECS services and fix tag support for EC2 launch templates

### DIFF
--- a/aws/resources/launch_template.go
+++ b/aws/resources/launch_template.go
@@ -20,7 +20,13 @@ func (lt *LaunchTemplates) getAll(c context.Context, configObj config.Config) ([
 
 	var templateNames []*string
 	for _, template := range result.LaunchTemplates {
-		tags := lt.extractTagsFromLatestVersion(c, template.LaunchTemplateId)
+		// Extract tags directly from the launch template resource
+		tags := make(map[string]string)
+		for _, tag := range template.Tags {
+			if tag.Key != nil && tag.Value != nil {
+				tags[*tag.Key] = *tag.Value
+			}
+		}
 
 		logging.Debugf("Tags for Launch Template %s: %v", *template.LaunchTemplateName, tags)
 
@@ -45,36 +51,6 @@ func (lt *LaunchTemplates) getAll(c context.Context, configObj config.Config) ([
 	})
 
 	return templateNames, nil
-}
-
-// extractTagsFromLatestVersion retrieves tags from the latest version of a launch template
-func (lt *LaunchTemplates) extractTagsFromLatestVersion(ctx context.Context, templateID *string) map[string]string {
-	tags := make(map[string]string)
-
-	versionsInput := &ec2.DescribeLaunchTemplateVersionsInput{
-		LaunchTemplateId: templateID,
-		Versions:         []string{"$Latest"},
-	}
-
-	versionsResult, err := lt.Client.DescribeLaunchTemplateVersions(ctx, versionsInput)
-	if err != nil || len(versionsResult.LaunchTemplateVersions) == 0 {
-		return tags
-	}
-
-	latestVersion := versionsResult.LaunchTemplateVersions[0]
-	if latestVersion.LaunchTemplateData == nil {
-		return tags
-	}
-
-	for _, tagSpec := range latestVersion.LaunchTemplateData.TagSpecifications {
-		for _, tag := range tagSpec.Tags {
-			if tag.Key != nil && tag.Value != nil {
-				tags[*tag.Key] = *tag.Value
-			}
-		}
-	}
-
-	return tags
 }
 
 // Deletes all Launch Templates

--- a/aws/resources/launch_template_test.go
+++ b/aws/resources/launch_template_test.go
@@ -15,9 +15,8 @@ import (
 
 type mockedLaunchTemplate struct {
 	LaunchTemplatesAPI
-	DescribeLaunchTemplatesOutput        ec2.DescribeLaunchTemplatesOutput
-	DeleteLaunchTemplateOutput           ec2.DeleteLaunchTemplateOutput
-	DescribeLaunchTemplateVersionsOutput ec2.DescribeLaunchTemplateVersionsOutput
+	DescribeLaunchTemplatesOutput ec2.DescribeLaunchTemplatesOutput
+	DeleteLaunchTemplateOutput    ec2.DeleteLaunchTemplateOutput
 }
 
 func (m mockedLaunchTemplate) DescribeLaunchTemplates(ctx context.Context, params *ec2.DescribeLaunchTemplatesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeLaunchTemplatesOutput, error) {
@@ -26,23 +25,6 @@ func (m mockedLaunchTemplate) DescribeLaunchTemplates(ctx context.Context, param
 
 func (m mockedLaunchTemplate) DeleteLaunchTemplate(ctx context.Context, params *ec2.DeleteLaunchTemplateInput, optFns ...func(*ec2.Options)) (*ec2.DeleteLaunchTemplateOutput, error) {
 	return &m.DeleteLaunchTemplateOutput, nil
-}
-
-func (m mockedLaunchTemplate) DescribeLaunchTemplateVersions(ctx context.Context, params *ec2.DescribeLaunchTemplateVersionsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeLaunchTemplateVersionsOutput, error) {
-	if params.LaunchTemplateId != nil && *params.LaunchTemplateId == "lt-123456789" {
-		return &m.DescribeLaunchTemplateVersionsOutput, nil
-	}
-
-	emptyVersionOutput := &ec2.DescribeLaunchTemplateVersionsOutput{
-		LaunchTemplateVersions: []types.LaunchTemplateVersion{
-			{
-				LaunchTemplateData: &types.ResponseLaunchTemplateData{
-					TagSpecifications: []types.LaunchTemplateTagSpecification{},
-				},
-			},
-		},
-	}
-	return emptyVersionOutput, nil
 }
 
 func TestLaunchTemplate_GetAll(t *testing.T) {
@@ -64,7 +46,6 @@ func TestLaunchTemplate_GetAll(t *testing.T) {
 					templateWithoutTags,
 				},
 			},
-			DescribeLaunchTemplateVersionsOutput: createVersionOutputWithTags(),
 		},
 	}
 
@@ -119,6 +100,12 @@ func createLaunchTemplateWithTags(name, id string, createTime time.Time) types.L
 		LaunchTemplateName: aws.String(name),
 		LaunchTemplateId:   aws.String(id),
 		CreateTime:         aws.Time(createTime),
+		Tags: []types.Tag{
+			{
+				Key:   aws.String("Environment"),
+				Value: aws.String("test"),
+			},
+		},
 	}
 }
 
@@ -127,27 +114,6 @@ func createLaunchTemplateWithoutTags(name, id string, createTime time.Time) type
 		LaunchTemplateName: aws.String(name),
 		LaunchTemplateId:   aws.String(id),
 		CreateTime:         aws.Time(createTime),
-	}
-}
-
-func createVersionOutputWithTags() ec2.DescribeLaunchTemplateVersionsOutput {
-	return ec2.DescribeLaunchTemplateVersionsOutput{
-		LaunchTemplateVersions: []types.LaunchTemplateVersion{
-			{
-				LaunchTemplateData: &types.ResponseLaunchTemplateData{
-					TagSpecifications: []types.LaunchTemplateTagSpecification{
-						{
-							Tags: []types.Tag{
-								{
-									Key:   aws.String("Environment"),
-									Value: aws.String("test"),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
 	}
 }
 

--- a/aws/resources/launch_template_types.go
+++ b/aws/resources/launch_template_types.go
@@ -12,7 +12,6 @@ import (
 type LaunchTemplatesAPI interface {
 	DescribeLaunchTemplates(ctx context.Context, params *ec2.DescribeLaunchTemplatesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeLaunchTemplatesOutput, error)
 	DeleteLaunchTemplate(ctx context.Context, params *ec2.DeleteLaunchTemplateInput, optFns ...func(*ec2.Options)) (*ec2.DeleteLaunchTemplateOutput, error)
-	DescribeLaunchTemplateVersions(ctx context.Context, params *ec2.DescribeLaunchTemplateVersionsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeLaunchTemplateVersionsOutput, error)
 }
 
 // LaunchTemplates - represents all launch templates


### PR DESCRIPTION
## Summary
- Adds tag filtering support for ECS services
- Fixes tag filtering for EC2 launch templates to use resource tags instead of instance tags

## Changes
- **ECS Services**: Modified `DescribeServices` call to include tags and pass them to the filtering logic
- **EC2 Launch Templates**: Fixed tag extraction to read from the launch template resource (`template.Tags`) instead of incorrectly reading from `LaunchTemplateData.TagSpecifications` (which are tags applied to instances created from the template)
- Removed unused `extractTagsFromLatestVersion` function and API interface method

## Testing
All existing tests pass with the updated implementation.