### PR TITLE
docs: update README to reflect tag support for ECS services and launch templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ of the file that are supported are listed here.
 | ec2-endpoint                     | EC2Endpoint                   | ✅ (Endpoint Name)                     | ✅ (Creation Time)                   | ✅    | ✅       |
 | ecr                              | ECRRepository                 | ✅ (Repository Name)                   | ✅ (Creation Time)                   | ❌    | ✅       |
 | ecscluster                       | ECSCluster                    | ✅ (Cluster Name)                      | ✅ (First Seen Tag Time)             | ✅    | ✅       |
-| ecsserv                          | ECSService                    | ✅ (Service Name)                      | ✅ (Creation Time)                   | ❌    | ✅       |
+| ecsserv                          | ECSService                    | ✅ (Service Name)                      | ✅ (Creation Time)                   | ✅    | ✅       |
 | ekscluster                       | EKSCluster                    | ✅ (Cluster Name)                      | ✅ (Creation Time)                   | ✅    | ✅       |
 | elb                              | ELBv1                         | ✅ (Load Balancer Name)                | ✅ (Created Time)                    | ❌    | ✅       |
 | elbv2                            | ELBv2                         | ✅ (Load Balancer Name)                | ✅ (Created Time)                    | ❌    | ✅       |
@@ -670,7 +670,7 @@ of the file that are supported are listed here.
 | kinesis-firehose                 | KinesisFirehose               | ✅ (Delivery Stream Name)              | ❌                                   | ❌    | ✅       |
 | lambda                           | LambdaFunction                | ✅ (Function Name)                     | ✅ (Last Modified Time)              | ✅    | ✅       |
 | lc                               | LaunchConfiguration           | ✅ (Launch Configuration Name)         | ✅ (Created Time)                    | ❌    | ✅       |
-| lt                               | LaunchTemplate                | ✅ (Launch Template Name)              | ✅ (Created Time)                    | ❌    | ✅       |
+| lt                               | LaunchTemplate                | ✅ (Launch Template Name)              | ✅ (Created Time)                    | ✅    | ✅       |
 | macie-member                     | MacieMember                   | ❌                                     | ✅ (Creation Time)                   | ❌    | ✅       |
 | msk-cluster                      | MSKCluster                    | ✅ (Cluster Name)                      | ✅ (Creation Time)                   | ❌    | ✅       |
 | managed-prometheus               | ManagedPrometheus             | ✅ (Workspace Alias)                   | ✅ (Creation Time)                   | ✅    | ✅       |


### PR DESCRIPTION
## Summary
- Update ECS Service tag support status from ❌ to ✅
- Update Launch Template tag support status from ❌ to ✅

This PR updates the README to reflect the actual tag filtering support that was fixed in PR #942. The fix addressed a bug in v0.43.0 where launch templates were reading the wrong tags.

## Context
Version 0.43.0 introduced tag support for launch templates in PR #915, but it had a bug where it was reading tags from `LaunchTemplateData.TagSpecifications` (tags applied to instances) instead of `template.Tags` (tags on the launch template resource). This was fixed in PR #942.

This documentation update is part of preparing for the v0.43.1 release.

## Test plan
- [x] Verify README.md changes are correct
- [x] Confirm documentation matches current implementation on master