### PR TITLE
feat: add tag support for CloudMap namespaces and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,8 +618,8 @@ of the file that are supported are listed here.
 | cloudwatch-dashboard             | CloudWatchDashboard           | ✅ (Dashboard Name)                    | ✅ (LastModified Time)               | ❌    | ✅       |
 | cloudwatch-loggroup              | CloudWatchLogGroup            | ✅ (Log Group Name)                    | ✅ (Creation Time)                   | ❌    | ✅       |
 | cloudtrail                       | CloudtrailTrail               | ✅ (Trail Name)                        | ❌                                   | ✅    | ✅       |
-| cloudmap-namespace               | CloudMapNamespace             | ✅ (Namespace Name)                    | ✅ (Creation Time)                   | ❌    | ✅       |
-| cloudmap-service                 | CloudMapService               | ✅ (Service Name)                      | ✅ (Creation Time)                   | ❌    | ✅       |
+| cloudmap-namespace               | CloudMapNamespace             | ✅ (Namespace Name)                    | ✅ (Creation Time)                   | ✅    | ✅       |
+| cloudmap-service                 | CloudMapService               | ✅ (Service Name)                      | ✅ (Creation Time)                   | ✅    | ✅       |
 | codedeploy-application           | CodeDeployApplications        | ✅ (Application Name)                  | ✅ (Creation Time)                   | ❌    | ✅       |
 | config-recorders                 | ConfigServiceRecorder         | ✅ (Recorder Name)                     | ❌                                   | ❌    | ✅       |
 | config-rules                     | ConfigServiceRule             | ✅ (Rule Name)                         | ❌                                   | ❌    | ✅       |

--- a/aws/resources/cloudmap_namespace_types.go
+++ b/aws/resources/cloudmap_namespace_types.go
@@ -16,6 +16,7 @@ type CloudMapNamespacesAPI interface {
 	DeleteNamespace(ctx context.Context, params *servicediscovery.DeleteNamespaceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.DeleteNamespaceOutput, error)
 	GetNamespace(ctx context.Context, params *servicediscovery.GetNamespaceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.GetNamespaceOutput, error)
 	ListServices(ctx context.Context, params *servicediscovery.ListServicesInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.ListServicesOutput, error)
+	ListTagsForResource(ctx context.Context, params *servicediscovery.ListTagsForResourceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.ListTagsForResourceOutput, error)
 }
 
 // CloudMapNamespaces represents all Cloud Map namespaces found in a region.

--- a/aws/resources/cloudmap_service_types.go
+++ b/aws/resources/cloudmap_service_types.go
@@ -16,6 +16,7 @@ type CloudMapServicesAPI interface {
 	DeleteService(ctx context.Context, params *servicediscovery.DeleteServiceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.DeleteServiceOutput, error)
 	ListInstances(ctx context.Context, params *servicediscovery.ListInstancesInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.ListInstancesOutput, error)
 	DeregisterInstance(ctx context.Context, params *servicediscovery.DeregisterInstanceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.DeregisterInstanceOutput, error)
+	ListTagsForResource(ctx context.Context, params *servicediscovery.ListTagsForResourceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.ListTagsForResourceOutput, error)
 }
 
 // CloudMapServices represents all Cloud Map services found in a region.


### PR DESCRIPTION
## Summary

Implements tag filtering for CloudMap resources (cloudmap-namespace and cloudmap-service).

Fixes https://github.com/gruntwork-io/cloud-nuke/issues/937

## Changes

- Adding ListTagsForResource to CloudMapNamespacesAPI and CloudMapServicesAPI interfaces
- Implementing getAllTags methods to retrieve tags from AWS CloudMap API
- Updating getAll methods to fetch and include tags in resource filtering
- Adding comprehensive test coverage for tag-based filtering

## Impact

Users can now use tag-based filters (e.g., cloud-nuke-excluded) with CloudMap resources, bringing them in line with other AWS resources that support tag filtering.

## Test plan

- [x] Unit tests pass: `go test -v ./aws/resources -run TestCloudMap`
- [x] Project builds successfully