### PR TITLE
fix: resolve KMS key filtering issues

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -24,7 +24,10 @@ func GetAllResources(c context.Context, query *Query, configObj config.Config) (
 	configObj.AddExcludeAfterTime(query.ExcludeAfter)
 	configObj.AddIncludeAfterTime(query.IncludeAfter)
 	configObj.AddTimeout(query.Timeout)
-	configObj.KMSCustomerKeys.IncludeUnaliasedKeys = query.ListUnaliasedKMSKeys
+	// Only override the config file value if the CLI flag is explicitly set to true
+	if query.ListUnaliasedKMSKeys {
+		configObj.KMSCustomerKeys.IncludeUnaliasedKeys = true
+	}
 
 	// Setting the DefaultOnly field
 	// This function only sets the objects that have the `DefaultOnly` field, currently VPC, Subnet, and Security Group.

--- a/aws/resources/kms_customer_key.go
+++ b/aws/resources/kms_customer_key.go
@@ -151,8 +151,9 @@ func (kck *KmsCustomerKeys) shouldInclude(
 		resultsChan <- &KmsCheckIncludeResult{KeyId: ""}
 		return
 	}
+	// Check time-based filtering (name filtering was already done above)
 	referenceTime := metadata.CreationDate
-	if !configObj.KMSCustomerKeys.ShouldInclude(config.ResourceValue{Time: referenceTime}) {
+	if !configObj.KMSCustomerKeys.ShouldIncludeBasedOnTime(*referenceTime) {
 		resultsChan <- &KmsCheckIncludeResult{KeyId: ""}
 		return
 	}

--- a/aws/resources/kms_customer_key_test.go
+++ b/aws/resources/kms_customer_key_test.go
@@ -114,6 +114,17 @@ func TestKMS_GetAll(t *testing.T) {
 			},
 			expected: []string{key2},
 		},
+		"nameInclusionFilter": {
+			configObj: config.KMSCustomerKeyResourceType{
+				ResourceType: config.ResourceType{
+					IncludeRule: config.FilterRule{
+						NamesRegExp: []config.Expression{{
+							RE: *regexp.MustCompile(".*key1"),
+						}}},
+				},
+			},
+			expected: []string{key1},
+		},
 		"timeAfterExclusionFilter": {
 			configObj: config.KMSCustomerKeyResourceType{
 				ResourceType: config.ResourceType{
@@ -131,6 +142,78 @@ func TestKMS_GetAll(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, aws.ToStringSlice(names))
+		})
+	}
+}
+
+func TestKMS_GetAll_IncludeUnaliased(t *testing.T) {
+	t.Parallel()
+
+	key1 := "key-with-alias"
+	key2 := "key-without-alias"
+	alias1 := "alias/my-key"
+	now := time.Now()
+	kck := KmsCustomerKeys{
+		Client: mockedKmsCustomerKeys{
+			ListKeysOutput: kms.ListKeysOutput{
+				Keys: []types.KeyListEntry{
+					{KeyId: aws.String(key1)},
+					{KeyId: aws.String(key2)},
+				},
+			},
+			ListAliasesOutput: kms.ListAliasesOutput{
+				Aliases: []types.AliasListEntry{
+					{
+						AliasName:   aws.String(alias1),
+						TargetKeyId: aws.String(key1),
+					},
+					// key2 has no alias
+				},
+			},
+			DescribeKeyOutput: map[string]kms.DescribeKeyOutput{
+				key1: {
+					KeyMetadata: &types.KeyMetadata{
+						KeyId:        aws.String(key1),
+						KeyManager:   types.KeyManagerTypeCustomer,
+						CreationDate: aws.Time(now),
+					},
+				},
+				key2: {
+					KeyMetadata: &types.KeyMetadata{
+						KeyId:        aws.String(key2),
+						KeyManager:   types.KeyManagerTypeCustomer,
+						CreationDate: aws.Time(now),
+					},
+				},
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		configObj config.KMSCustomerKeyResourceType
+		expected  []string
+	}{
+		"excludeUnaliasedByDefault": {
+			configObj: config.KMSCustomerKeyResourceType{
+				IncludeUnaliasedKeys: false,
+			},
+			expected: []string{key1}, // only key with alias
+		},
+		"includeUnaliasedWhenConfigured": {
+			configObj: config.KMSCustomerKeyResourceType{
+				IncludeUnaliasedKeys: true,
+			},
+			expected: []string{key1, key2}, // both keys
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			names, err := kck.getAll(context.Background(), config.Config{
+				KMSCustomerKeys: tc.configObj,
+			})
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.expected, aws.ToStringSlice(names))
 		})
 	}
 }


### PR DESCRIPTION
## Description

Fixes two KMS customer key filtering bugs reported in #950:

### Bug 1: Config file parameter not respected
The `include_unaliased_keys` parameter in the YAML config was being unconditionally overwritten by the CLI flag's default value (false). This prevented users from setting it to `true` in their config files.

**Fix:** Only override the config value when the CLI flag is explicitly set to true, following the same pattern used by other boolean flags in the codebase.

### Bug 2: Regex include patterns not working  
Regex patterns like `alias/.*delete.*` were not matching any keys. The issue was that name filtering was performed twice - once correctly against the alias names, and then again with a nil name value that would fail the check.

**Fix:** Use `ShouldIncludeBasedOnTime()` instead of `ShouldInclude()` for the second filtering stage, since name filtering already occurs earlier in the flow.

## Changes
- Modified `aws/aws.go` to conditionally override `IncludeUnaliasedKeys`
- Modified `aws/resources/kms_customer_key.go` to use time-based filtering only
- Added test cases for include filtering and unaliased key handling

## Testing
All existing tests pass, plus new tests added:
- `nameInclusionFilter` - verifies regex include patterns work
- `TestKMS_GetAll_IncludeUnaliased` - verifies unaliased key config is respected

Closes #950