### PR TITLE
fix: detect and delete RDS clusters/instances with deletion protection enabled

### DIFF
--- a/aws/resources/rds.go
+++ b/aws/resources/rds.go
@@ -22,11 +22,6 @@ func (di *DBInstances) getAll(ctx context.Context, configObj config.Config) ([]*
 	var names []*string
 
 	for _, database := range result.DBInstances {
-		// Skip deletion-protected instances when config doesn't explicitly include them
-		if database.DeletionProtection != nil && *database.DeletionProtection && !configObj.DBInstances.IncludeDeletionProtected {
-			continue
-		}
-
 		if configObj.DBInstances.ShouldInclude(config.ResourceValue{
 			Time: database.InstanceCreateTime,
 			Name: database.DBInstanceIdentifier,

--- a/aws/resources/rds_cluster.go
+++ b/aws/resources/rds_cluster.go
@@ -47,11 +47,6 @@ func (instance *DBClusters) getAll(c context.Context, configObj config.Config) (
 
 	var names []*string
 	for _, database := range result.DBClusters {
-		// Skip deletion-protected clusters when config doesn't explicitly include them
-		if database.DeletionProtection != nil && *database.DeletionProtection && !configObj.DBClusters.IncludeDeletionProtected {
-			continue
-		}
-
 		if configObj.DBClusters.ShouldInclude(config.ResourceValue{
 			Name: database.DBClusterIdentifier,
 			Time: database.ClusterCreateTime,

--- a/aws/resources/rds_cluster_test.go
+++ b/aws/resources/rds_cluster_test.go
@@ -63,13 +63,15 @@ func TestRDSClusterGetAll(t *testing.T) {
 		},
 	}
 
-	// Test Case 1: Empty config - should exclude deletion-protected clusters by default
+	// Test Case 1: Empty config - should include both protected and unprotected clusters
+	// Deletion protection is automatically disabled during deletion, so we include these clusters
 	clusters, err := dbCluster.getAll(context.Background(), config.Config{DBClusters: config.AWSProtectectableResourceType{}})
 	assert.NoError(t, err)
 	assert.Contains(t, aws.ToStringSlice(clusters), strings.ToLower(testName))
-	assert.NotContains(t, aws.ToStringSlice(clusters), strings.ToLower(testProtectedName))
+	assert.Contains(t, aws.ToStringSlice(clusters), strings.ToLower(testProtectedName))
 
-	// Test Case 2: IncludeDeletionProtected=true - should include both protected and unprotected clusters
+	// Test Case 2: With IncludeDeletionProtected flag - behavior is now the same as Test Case 1
+	// since deletion-protected clusters are always included
 	clusters, err = dbCluster.getAll(context.Background(), config.Config{
 		DBClusters: config.AWSProtectectableResourceType{
 			IncludeDeletionProtected: true,

--- a/aws/resources/rds_test.go
+++ b/aws/resources/rds_test.go
@@ -100,7 +100,7 @@ func TestDBInstances_GetAll(t *testing.T) {
 	}{
 		"emptyFilter": {
 			configObj: config.AWSProtectectableResourceType{},
-			expected:  []string{testIdentifier1, testIdentifier2},
+			expected:  []string{testIdentifier1, testIdentifier2, testIdentifier3},
 		},
 		"nameExclusionFilter": {
 			configObj: config.AWSProtectectableResourceType{ResourceType: config.ResourceType{
@@ -110,7 +110,7 @@ func TestDBInstances_GetAll(t *testing.T) {
 					}},
 				},
 			}},
-			expected: []string{testIdentifier1, testIdentifier2},
+			expected: []string{testIdentifier1, testIdentifier2, testIdentifier3},
 		},
 		"timeAfterExclusionFilter": {
 			configObj: config.AWSProtectectableResourceType{


### PR DESCRIPTION
## Problem
RDS clusters and instances with deletion protection enabled were not being detected by cloud-nuke, even when they matched tag and time filters. This was because the `getAll` functions filtered out deletion-protected resources during discovery.

Users had to manually disable deletion protection before cloud-nuke could detect and delete these resources.

## Root Cause
In `rds_cluster.go` and `rds.go`, the `getAll` functions contained logic that skipped resources with deletion protection enabled:

```go
if database.DeletionProtection != nil && *database.DeletionProtection && !configObj.DBClusters.IncludeDeletionProtected {
    continue
}
```

This meant deletion-protected resources were excluded from discovery by default, preventing them from being deleted.

## Solution
Removed the deletion protection filtering logic from the `getAll` functions in both `rds_cluster.go` and `rds.go`.

Since the `nukeAll` functions already disable deletion protection before deletion (as of #947), there's no need to filter these resources during discovery. They can be safely included and will be properly cleaned up.

## Testing
- All existing tests pass with updated expectations
- Verified both protected and unprotected RDS resources are now detected and can be deleted

Fixes #953