### PR TITLE
Add support for nuking Redshift Snapshot Copy Grants

### DIFF
--- a/aws/resource_registry.go
+++ b/aws/resource_registry.go
@@ -126,6 +126,7 @@ func getRegisteredRegionalResources() []AwsResource {
 		&resources.RdsSnapshot{},
 		&resources.RdsParameterGroup{},
 		&resources.RedshiftClusters{},
+		&resources.RedshiftSnapshotCopyGrants{},
 		&resources.S3Buckets{},
 		&resources.S3AccessPoint{},
 		&resources.S3ObjectLambdaAccessPoint{},

--- a/aws/resources/redshift_snapshot_copy_grant.go
+++ b/aws/resources/redshift_snapshot_copy_grant.go
@@ -1,0 +1,75 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/report"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+func (g *RedshiftSnapshotCopyGrants) getAll(ctx context.Context, configObj config.Config) ([]*string, error) {
+	var grantNames []*string
+	var marker *string
+
+	for {
+		output, err := g.Client.DescribeSnapshotCopyGrants(ctx, &redshift.DescribeSnapshotCopyGrantsInput{
+			Marker: marker,
+		})
+		if err != nil {
+			logging.Debugf("[Redshift Snapshot Copy Grant] Failed to list grants: %s", err)
+			return nil, errors.WithStackTrace(err)
+		}
+
+		for _, grant := range output.SnapshotCopyGrants {
+			if configObj.RedshiftSnapshotCopyGrant.ShouldInclude(config.ResourceValue{
+				Name: grant.SnapshotCopyGrantName,
+			}) {
+				grantNames = append(grantNames, grant.SnapshotCopyGrantName)
+			}
+		}
+
+		if output.Marker == nil {
+			break
+		}
+		marker = output.Marker
+	}
+
+	return grantNames, nil
+}
+
+func (g *RedshiftSnapshotCopyGrants) nukeAll(identifiers []*string) error {
+	if len(identifiers) == 0 {
+		logging.Debugf("No Redshift Snapshot Copy Grants to nuke in region %s", g.Region)
+		return nil
+	}
+
+	logging.Debugf("Deleting all Redshift Snapshot Copy Grants in region %s", g.Region)
+
+	deletedCount := 0
+	for _, name := range identifiers {
+		_, err := g.Client.DeleteSnapshotCopyGrant(g.Context, &redshift.DeleteSnapshotCopyGrantInput{
+			SnapshotCopyGrantName: name,
+		})
+
+		e := report.Entry{
+			Identifier:   aws.ToString(name),
+			ResourceType: "Redshift Snapshot Copy Grant",
+			Error:        err,
+		}
+		report.Record(e)
+
+		if err != nil {
+			logging.Errorf("[Failed] %s: %s", aws.ToString(name), err)
+		} else {
+			deletedCount++
+			logging.Debugf("Deleted Redshift Snapshot Copy Grant: %s", aws.ToString(name))
+		}
+	}
+
+	logging.Debugf("[OK] %d Redshift Snapshot Copy Grant(s) deleted in %s", deletedCount, g.Region)
+	return nil
+}

--- a/aws/resources/redshift_snapshot_copy_grant_test.go
+++ b/aws/resources/redshift_snapshot_copy_grant_test.go
@@ -1,0 +1,93 @@
+package resources
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	"github.com/aws/aws-sdk-go-v2/service/redshift/types"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/stretchr/testify/require"
+)
+
+type mockedRedshiftSnapshotCopyGrants struct {
+	RedshiftSnapshotCopyGrantsAPI
+
+	DescribeSnapshotCopyGrantsOutput redshift.DescribeSnapshotCopyGrantsOutput
+	DeleteSnapshotCopyGrantOutput    redshift.DeleteSnapshotCopyGrantOutput
+}
+
+func (m mockedRedshiftSnapshotCopyGrants) DescribeSnapshotCopyGrants(ctx context.Context, input *redshift.DescribeSnapshotCopyGrantsInput, opts ...func(*redshift.Options)) (*redshift.DescribeSnapshotCopyGrantsOutput, error) {
+	return &m.DescribeSnapshotCopyGrantsOutput, nil
+}
+
+func (m mockedRedshiftSnapshotCopyGrants) DeleteSnapshotCopyGrant(ctx context.Context, input *redshift.DeleteSnapshotCopyGrantInput, opts ...func(*redshift.Options)) (*redshift.DeleteSnapshotCopyGrantOutput, error) {
+	return &m.DeleteSnapshotCopyGrantOutput, nil
+}
+
+func TestRedshiftSnapshotCopyGrant_GetAll(t *testing.T) {
+	t.Parallel()
+
+	testName1 := "test-grant1"
+	testName2 := "test-grant2"
+	g := RedshiftSnapshotCopyGrants{
+		Client: mockedRedshiftSnapshotCopyGrants{
+			DescribeSnapshotCopyGrantsOutput: redshift.DescribeSnapshotCopyGrantsOutput{
+				SnapshotCopyGrants: []types.SnapshotCopyGrant{
+					{
+						SnapshotCopyGrantName: aws.String(testName1),
+					},
+					{
+						SnapshotCopyGrantName: aws.String(testName2),
+					},
+				},
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		configObj config.ResourceType
+		expected  []string
+	}{
+		"emptyFilter": {
+			configObj: config.ResourceType{},
+			expected:  []string{testName1, testName2},
+		},
+		"nameExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					NamesRegExp: []config.Expression{{
+						RE: *regexp.MustCompile(testName1),
+					}},
+				},
+			},
+			expected: []string{testName2},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			names, err := g.getAll(context.Background(), config.Config{
+				RedshiftSnapshotCopyGrant: tc.configObj,
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, aws.ToStringSlice(names))
+		})
+	}
+}
+
+func TestRedshiftSnapshotCopyGrant_NukeAll(t *testing.T) {
+	t.Parallel()
+
+	g := RedshiftSnapshotCopyGrants{
+		Client: mockedRedshiftSnapshotCopyGrants{
+			DeleteSnapshotCopyGrantOutput: redshift.DeleteSnapshotCopyGrantOutput{},
+		},
+	}
+	g.Context = context.Background()
+
+	err := g.nukeAll([]*string{aws.String("test-grant")})
+	require.NoError(t, err)
+}

--- a/aws/resources/redshift_snapshot_copy_grant_types.go
+++ b/aws/resources/redshift_snapshot_copy_grant_types.go
@@ -1,0 +1,60 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+type RedshiftSnapshotCopyGrantsAPI interface {
+	DescribeSnapshotCopyGrants(ctx context.Context, params *redshift.DescribeSnapshotCopyGrantsInput, optFns ...func(*redshift.Options)) (*redshift.DescribeSnapshotCopyGrantsOutput, error)
+	DeleteSnapshotCopyGrant(ctx context.Context, params *redshift.DeleteSnapshotCopyGrantInput, optFns ...func(*redshift.Options)) (*redshift.DeleteSnapshotCopyGrantOutput, error)
+}
+
+type RedshiftSnapshotCopyGrants struct {
+	BaseAwsResource
+	Client     RedshiftSnapshotCopyGrantsAPI
+	Region     string
+	GrantNames []string
+}
+
+func (g *RedshiftSnapshotCopyGrants) Init(cfg aws.Config) {
+	g.Client = redshift.NewFromConfig(cfg)
+}
+
+func (g *RedshiftSnapshotCopyGrants) ResourceName() string {
+	return "redshift-snapshot-copy-grant"
+}
+
+func (g *RedshiftSnapshotCopyGrants) ResourceIdentifiers() []string {
+	return g.GrantNames
+}
+
+func (g *RedshiftSnapshotCopyGrants) MaxBatchSize() int {
+	return 49
+}
+
+func (g *RedshiftSnapshotCopyGrants) GetAndSetResourceConfig(configObj config.Config) config.ResourceType {
+	return configObj.RedshiftSnapshotCopyGrant
+}
+
+func (g *RedshiftSnapshotCopyGrants) GetAndSetIdentifiers(c context.Context, configObj config.Config) ([]string, error) {
+	identifiers, err := g.getAll(c, configObj)
+	if err != nil {
+		return nil, err
+	}
+
+	g.GrantNames = aws.ToStringSlice(identifiers)
+	return g.GrantNames, nil
+}
+
+func (g *RedshiftSnapshotCopyGrants) Nuke(identifiers []string) error {
+	if err := g.nukeAll(aws.StringSlice(identifiers)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -103,6 +103,7 @@ type Config struct {
 	OIDCProvider                    ResourceType                  `yaml:"OIDCProvider"`
 	OpenSearchDomain                ResourceType                  `yaml:"OpenSearchDomain"`
 	Redshift                        ResourceType                  `yaml:"Redshift"`
+	RedshiftSnapshotCopyGrant       ResourceType                  `yaml:"RedshiftSnapshotCopyGrant"`
 	RdsSnapshot                     ResourceType                  `yaml:"RdsSnapshot"`
 	RdsParameterGroup               ResourceType                  `yaml:"RdsParameterGroup"`
 	RdsProxy                        ResourceType                  `yaml:"RdsProxy"`


### PR DESCRIPTION
## Summary
- Adds new `redshift-snapshot-copy-grant` resource type
- Implements listing via `DescribeSnapshotCopyGrants` and deletion via `DeleteSnapshotCopyGrant`
- Adds unit tests and config entry for `.circleci/nuke_config.yml`

Closes #965

## Test plan
- [x] Unit tests pass
- [x] Manual test with actual AWS account