### PR TITLE
fix: respect --timeout flag for AWS resource deletion waiters

### DIFF
--- a/aws/resources/asg.go
+++ b/aws/resources/asg.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
@@ -72,7 +71,7 @@ func (ag *ASGroups) nukeAll(groupNames []*string) error {
 		waiter := autoscaling.NewGroupNotExistsWaiter(ag.Client)
 		err := waiter.Wait(ag.Context, &autoscaling.DescribeAutoScalingGroupsInput{
 			AutoScalingGroupNames: deletedGroupNames,
-		}, 5*time.Minute)
+		}, ag.Timeout)
 
 		if err != nil {
 			logging.Errorf("[Failed] %s", err)

--- a/aws/resources/ebs.go
+++ b/aws/resources/ebs.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	goerr "errors"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -118,7 +117,7 @@ func (ev *EBSVolumes) nukeAll(volumeIds []*string) error {
 		waiter := ec2.NewVolumeDeletedWaiter(ev.Client)
 		err := waiter.Wait(ev.Context, &ec2.DescribeVolumesInput{
 			VolumeIds: aws.ToStringSlice(deletedVolumeIDs),
-		}, 5*time.Minute)
+		}, ev.Timeout)
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
 			return errors.WithStackTrace(err)

--- a/aws/resources/ec2.go
+++ b/aws/resources/ec2.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -161,7 +160,7 @@ func (ei *EC2Instances) nukeAll(instanceIds []*string) error {
 				Values: aws.ToStringSlice(instanceIds),
 			},
 		},
-	}, 15*time.Minute)
+	}, ei.Timeout)
 
 	if err != nil {
 		logging.Debugf("[Failed] %s", err)

--- a/aws/resources/ec2_network_interface.go
+++ b/aws/resources/ec2_network_interface.go
@@ -212,7 +212,7 @@ func (ni *NetworkInterface) nukeInstance(id *string) error {
 	waiter := ec2.NewInstanceTerminatedWaiter(ni.Client)
 	err = waiter.Wait(ni.Context, &ec2.DescribeInstancesInput{
 		InstanceIds: []string{instanceID},
-	}, 5*time.Minute)
+	}, ni.Timeout)
 	if err != nil {
 		logging.Debugf("[nukeInstance] Instance termination waiting failed for instance %s: %v", instanceID, err)
 		return errors.WithStackTrace(err)

--- a/aws/resources/ecs_service.go
+++ b/aws/resources/ecs_service.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
@@ -160,7 +159,7 @@ func (services *ECSServices) waitUntilServicesDrained(ecsServiceArns []*string) 
 		}
 
 		waiter := ecs.NewServicesStableWaiter(services.Client)
-		err := waiter.Wait(services.Context, params, 15*time.Minute)
+		err := waiter.Wait(services.Context, params, services.Timeout)
 		if err != nil {
 			logging.Debugf("[Failed] Failed waiting for service to be stable %s: %s", *ecsServiceArn, err)
 		} else {
@@ -202,7 +201,7 @@ func (services *ECSServices) waitUntilServicesDeleted(ecsServiceArns []*string) 
 		}
 
 		waiter := ecs.NewServicesInactiveWaiter(services.Client)
-		err := waiter.Wait(services.Context, params, 15*time.Minute)
+		err := waiter.Wait(services.Context, params, services.Timeout)
 
 		// Record status of this resource
 		e := report.Entry{

--- a/aws/resources/elasticache.go
+++ b/aws/resources/elasticache.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
@@ -126,7 +125,7 @@ func (cache *Elasticaches) nukeNonReplicationGroupElasticacheCluster(clusterId *
 		&elasticache.DescribeCacheClustersInput{
 			CacheClusterId: clusterId,
 		},
-		15*time.Minute,
+		cache.Timeout,
 	)
 }
 
@@ -145,7 +144,7 @@ func (cache *Elasticaches) nukeReplicationGroupMemberElasticacheCluster(clusterI
 	waitErr := waiter.Wait(
 		cache.Context,
 		&elasticache.DescribeReplicationGroupsInput{ReplicationGroupId: clusterId},
-		15*time.Minute,
+		cache.Timeout,
 	)
 
 	if waitErr != nil {

--- a/aws/resources/elbv2.go
+++ b/aws/resources/elbv2.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
@@ -69,7 +68,7 @@ func (balancer *LoadBalancersV2) nukeAll(arns []*string) error {
 		waiter := elasticloadbalancingv2.NewLoadBalancersDeletedWaiter(balancer.Client)
 		err := waiter.Wait(balancer.Context, &elasticloadbalancingv2.DescribeLoadBalancersInput{
 			LoadBalancerArns: aws.ToStringSlice(deletedArns),
-		}, 15*time.Minute)
+		}, balancer.Timeout)
 		if err != nil {
 			logging.Debugf("[Failed] %s", err)
 			return errors.WithStackTrace(err)

--- a/aws/resources/rds.go
+++ b/aws/resources/rds.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
@@ -83,11 +82,10 @@ func (di *DBInstances) nukeAll(names []*string) error {
 
 	if len(deletedNames) > 0 {
 		for _, name := range deletedNames {
-
 			waiter := rds.NewDBInstanceDeletedWaiter(di.Client)
 			err := waiter.Wait(di.Context, &rds.DescribeDBInstancesInput{
 				DBInstanceIdentifier: name,
-			}, 1*time.Minute)
+			}, di.Timeout)
 
 			// Record status of this resource
 			e := report.Entry{

--- a/aws/resources/rds_cluster.go
+++ b/aws/resources/rds_cluster.go
@@ -17,9 +17,9 @@ import (
 )
 
 func (instance *DBClusters) waitUntilRdsClusterDeleted(input *rds.DescribeDBClustersInput) error {
-	const maxRetries = 90                  // 90 attempts
-	const retryInterval = 10 * time.Second // 10 seconds between attempts
-	// Total wait time: 90 * 10s = 900s = 15 minutes
+	waitTimeout := instance.Timeout
+	const retryInterval = 10 * time.Second
+	maxRetries := int(waitTimeout / retryInterval)
 
 	for i := 0; i < maxRetries; i++ {
 		_, err := instance.Client.DescribeDBClusters(instance.Context, input)

--- a/aws/resources/redshift.go
+++ b/aws/resources/redshift.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
@@ -65,7 +64,7 @@ func (rc *RedshiftClusters) nukeAll(identifiers []*string) error {
 			waiter := redshift.NewClusterDeletedWaiter(rc.Client)
 			err := waiter.Wait(rc.Context, &redshift.DescribeClustersInput{
 				ClusterIdentifier: id,
-			}, 5*time.Minute)
+			}, rc.Timeout)
 
 			// Record status of this resource
 			e := report.Entry{


### PR DESCRIPTION
## Summary
AWS SDK waiters had hardcoded timeout values that ignored the `--timeout` flag. This PR sets a default timeout in `PrepareContext` and updates all resources with deletion waiters to use it.

## Test plan
- [x] Build passes
- [x] Manual test with `--timeout` flag

Fixes #964