### PR TITLE
fix: add go mod download before lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Download Go modules
+          command: go mod download
+      - run:
           name: Install golangci-lint
           command: |
             curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0


### PR DESCRIPTION
## Summary
Add `go mod download` step before running golangci-lint to fix undefined type errors.

## Test plan
- [x] CI lint job passes

Fixes #968