### PR TITLE
fix: handle IAM policies used as permissions boundaries

### DIFF
--- a/aws/resources/iam_policy_types.go
+++ b/aws/resources/iam_policy_types.go
@@ -19,6 +19,8 @@ type IAMPoliciesAPI interface {
 	DetachGroupPolicy(ctx context.Context, params *iam.DetachGroupPolicyInput, optFns ...func(*iam.Options)) (*iam.DetachGroupPolicyOutput, error)
 	DetachUserPolicy(ctx context.Context, params *iam.DetachUserPolicyInput, optFns ...func(*iam.Options)) (*iam.DetachUserPolicyOutput, error)
 	DetachRolePolicy(ctx context.Context, params *iam.DetachRolePolicyInput, optFns ...func(*iam.Options)) (*iam.DetachRolePolicyOutput, error)
+	DeleteUserPermissionsBoundary(ctx context.Context, params *iam.DeleteUserPermissionsBoundaryInput, optFns ...func(*iam.Options)) (*iam.DeleteUserPermissionsBoundaryOutput, error)
+	DeleteRolePermissionsBoundary(ctx context.Context, params *iam.DeleteRolePermissionsBoundaryInput, optFns ...func(*iam.Options)) (*iam.DeleteRolePermissionsBoundaryOutput, error)
 }
 
 // IAMPolicies - represents all IAM Policies on the AWS account


### PR DESCRIPTION
## Summary
- Detach IAM policies from entities where they are used as permissions boundaries before deletion
- Uses `ListEntitiesForPolicy` with `PolicyUsageFilter=PermissionsBoundary` to find boundary attachments
- Calls `DeleteUserPermissionsBoundary` and `DeleteRolePermissionsBoundary` to remove attachments

Fixes #972

## Test plan
- [x] Unit tests pass
- [ ] Manual test with policy attached as permissions boundary