### PR TITLE
feat: use mise.toml for tool version management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,18 +18,19 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install Go 1.24
+          name: Install mise
           command: |
-            curl -sSL https://go.dev/dl/go1.24.0.linux-amd64.tar.gz | tar -xz -C /tmp
-            echo 'export PATH=/tmp/go/bin:$PATH' >> $BASH_ENV
-            echo 'export GOROOT=/tmp/go' >> $BASH_ENV
+            curl https://mise.run | sh
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> $BASH_ENV
+      - run:
+          name: Install tools via mise
+          command: |
+            mise install
+            eval "$(mise activate bash --shims)"
+            echo 'eval "$(mise activate bash --shims)"' >> $BASH_ENV
       - run:
           name: Download Go modules
           command: go mod download
-      - run:
-          name: Install golangci-lint
-          command: |
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
       - run:
           name: Run golangci-lint
           command: |

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+go = "1.24.0"
+golangci-lint = "1.64.8"


### PR DESCRIPTION
## Summary
- Add `mise.toml` with Go 1.24.0 and golangci-lint 1.64.8
- Update CircleCI lint job to install tools via mise
- Centralizes tool version management, matching terragrunt's approach

Closes #974

## Test plan
- [x] Verify lint job passes with mise-installed tools