### PR TITLE
fix: set default timeout in Init() and update tests

### DIFF
--- a/aws/resources/asg_test.go
+++ b/aws/resources/asg_test.go
@@ -71,6 +71,7 @@ func TestAutoScalingGroupNukeAll(t *testing.T) {
 	ag := ASGroups{
 		BaseAwsResource: BaseAwsResource{
 			Context: context.Background(),
+			Timeout: DefaultWaitTimeout,
 		},
 		Client: mockedASGroups{
 			DeleteAutoScalingGroupOutput: autoscaling.DeleteAutoScalingGroupOutput{},

--- a/aws/resources/base_resource.go
+++ b/aws/resources/base_resource.go
@@ -31,6 +31,7 @@ type BaseAwsResource struct {
 
 func (br *BaseAwsResource) Init(cfg aws.Config) {
 	br.Nukables = make(map[string]error)
+	br.Timeout = DefaultWaitTimeout
 }
 
 func (br *BaseAwsResource) ResourceName() string {

--- a/aws/resources/ec2_test.go
+++ b/aws/resources/ec2_test.go
@@ -138,6 +138,7 @@ func TestEc2Instances_NukeAll(t *testing.T) {
 	ei := EC2Instances{
 		BaseAwsResource: BaseAwsResource{
 			Context: context.Background(),
+			Timeout: DefaultWaitTimeout,
 		},
 		Client: mockedEC2Instances{
 			DescribeInstancesOutput: ec2.DescribeInstancesOutput{
@@ -166,6 +167,7 @@ func TestEc2InstancesWithEIP_NukeAll(t *testing.T) {
 	ei := EC2Instances{
 		BaseAwsResource: BaseAwsResource{
 			Context: context.Background(),
+			Timeout: DefaultWaitTimeout,
 		},
 		Client: mockedEC2Instances{
 			DescribeInstancesOutput: ec2.DescribeInstancesOutput{

--- a/aws/resources/elbv2_test.go
+++ b/aws/resources/elbv2_test.go
@@ -116,6 +116,7 @@ func TestElbV2_NukeAll(t *testing.T) {
 	balancer := LoadBalancersV2{
 		BaseAwsResource: BaseAwsResource{
 			Context: context.Background(),
+			Timeout: DefaultWaitTimeout,
 		},
 		Client: mockedElbV2{
 			DescribeLoadBalancersOutput:    elasticloadbalancingv2.DescribeLoadBalancersOutput{},

--- a/aws/resources/rds_cluster_test.go
+++ b/aws/resources/rds_cluster_test.go
@@ -108,6 +108,8 @@ func TestRDSClusterNukeAll(t *testing.T) {
 			DeleteDBClusterOutput:    rds.DeleteDBClusterOutput{},
 		},
 	}
+	dbCluster.Context = context.Background()
+	dbCluster.Timeout = DefaultWaitTimeout
 
 	err := dbCluster.nukeAll([]*string{&testName})
 	assert.NoError(t, err)

--- a/aws/resources/rds_test.go
+++ b/aws/resources/rds_test.go
@@ -161,6 +161,7 @@ func TestDBInstances_NukeAll(t *testing.T) {
 			},
 		}
 		di.Context = context.Background()
+		di.Timeout = DefaultWaitTimeout
 
 		err := di.nukeAll([]*string{aws.String("test-standalone")})
 		require.NoError(t, err)
@@ -184,6 +185,7 @@ func TestDBInstances_NukeAll(t *testing.T) {
 			},
 		}
 		di.Context = context.Background()
+		di.Timeout = DefaultWaitTimeout
 
 		err := di.nukeAll([]*string{aws.String("test-cluster-member")})
 		require.NoError(t, err)

--- a/aws/resources/redshift_test.go
+++ b/aws/resources/redshift_test.go
@@ -106,6 +106,7 @@ func TestRedshiftCluster_NukeAll(t *testing.T) {
 		},
 	}
 	rc.Context = context.Background()
+	rc.Timeout = DefaultWaitTimeout
 
 	err := rc.nukeAll([]*string{aws.String("test")})
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Set `br.Timeout = DefaultWaitTimeout` in `Init()` for production code
- Add `Timeout: DefaultWaitTimeout` to tests that use waiters

## Problem
Tests failed with "maximum wait time for waiter must be greater than zero" after #967 changed resources to use `br.Timeout` instead of hardcoded values.

## Test plan
- [x] `go test ./aws/resources/...` passes