### PR TITLE
fix: EventBridge rule pagination bug causing infinite loop and inflated resource count

### DIFF
--- a/aws/resources/eventbridge_rule.go
+++ b/aws/resources/eventbridge_rule.go
@@ -144,12 +144,12 @@ func (ebr *EventBridgeRule) getAll(ctx context.Context, cnfObj config.Config) ([
 
 	for _, bus := range eBusNames {
 		hasMorePages := true
-		params := &eventbridge.ListEventBusesInput{}
+		params := &eventbridge.ListRulesInput{
+			EventBusName: bus,
+		}
 
 		for hasMorePages {
-			rules, err := ebr.Client.ListRules(ctx, &eventbridge.ListRulesInput{
-				EventBusName: bus,
-			})
+			rules, err := ebr.Client.ListRules(ctx, params)
 			if err != nil {
 				logging.Debugf("[Event Bridge] Failed to list event rules: %s", err)
 				return nil, errors.WithStackTrace(err)


### PR DESCRIPTION
## Description

This PR fixes a critical bug in the `getAll()` function of `aws/resources/eventbridge_rule.go` that causes an infinite loop when listing EventBridge rules, resulting in massively inflated resource counts.

## The Bug

When running cloud-nuke, I observed that it reported **204,500 EventBridge rules** in my AWS account, when the actual count (via AWS CLI `aws events list-rules`) was only **~100 rules**.

### Root Cause Analysis

The `getAll()` function had three interrelated bugs:

```go
// BEFORE (buggy code)
for _, bus := range eBusNames {
    hasMorePages := true
    params := &eventbridge.ListEventBusesInput{}  // BUG 1: Wrong type!

    for hasMorePages {
        rules, err := ebr.Client.ListRules(ctx, &eventbridge.ListRulesInput{
            EventBusName: bus,
            // BUG 2: NextToken is NEVER passed here!
        })
        // ...
        params.NextToken = rules.NextToken  // BUG 3: Assigned to wrong variable
        hasMorePages = params.NextToken != nil
    }
}
```

**Bug 1**: `params` was declared as `ListEventBusesInput` instead of `ListRulesInput`

**Bug 2**: `ListRules()` was called with a new inline `ListRulesInput` that never included `NextToken`

**Bug 3**: The `NextToken` from the response was assigned to the wrong `params` variable (which was never used in the API call)

### Result

When there are more than 100 rules (the default page size), this creates an **infinite loop**:

1. First iteration: Fetches page 1 (100 rules), gets NextToken
2. Second iteration: Fetches page 1 **again** (same 100 rules) because NextToken is never passed
3. Loop continues indefinitely...

In my case: `100 rules × 2,045 iterations = 204,500 "rules"` reported

## The Fix

```go
// AFTER (fixed code)
for _, bus := range eBusNames {
    hasMorePages := true
    params := &eventbridge.ListRulesInput{  // FIX 1: Correct type
        EventBusName: bus,
    }

    for hasMorePages {
        rules, err := ebr.Client.ListRules(ctx, params)  // FIX 2: Use params with NextToken
        // ...
        params.NextToken = rules.NextToken  // FIX 3: Now updates the correct variable
        hasMorePages = params.NextToken != nil
    }
}
```

## Testing

- Verified the fix correctly paginates through rules
- The pattern now matches other working implementations in the codebase (e.g., `getBusNames()` and `getTargets()` functions in the same file)

## Impact

This bug affects any AWS account with more than 100 EventBridge rules, causing:
- Extremely long scan times
- Memory issues from storing duplicate entries
- Incorrect resource counts in reports
- Potential deletion of the same rules multiple times

## Related

This is a newly discovered bug - I could not find any existing issues reported for this problem.