### PR TITLE
fix: restore IAMUsers resource type name to 'iam'

### DIFF
--- a/aws/resources/iam.go
+++ b/aws/resources/iam.go
@@ -45,7 +45,7 @@ type IAMUsersAPI interface {
 // NewIAMUsers creates a new IAMUsers resource using the generic resource pattern.
 func NewIAMUsers() AwsResource {
 	return NewAwsResource(&resource.Resource[IAMUsersAPI]{
-		ResourceTypeName: "iam-user",
+		ResourceTypeName: "iam",
 		BatchSize:        DefaultBatchSize,
 		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[IAMUsersAPI], cfg aws.Config) {


### PR DESCRIPTION
## Summary
- Restores the `ResourceTypeName` for IAMUsers from `"iam-user"` back to `"iam"`
- Fixes backwards compatibility broken by the migration to generic `Resource[C]` pattern in #992

## Problem
After #992, running `cloud-nuke --resource-types iam` fails with:
```
Invalid resourceTypes [iam] specified: Try --list-resource-types to get a list of valid resource types.
```

## Root Cause
The migration changed `ResourceTypeName` from `"iam"` to `"iam-user"`, but the original name was `"iam"` as returned by the old `ResourceName()` method.

## Test plan
- [x] Verify `cloud-nuke --resource-types iam` no longer errors
- [x] Verify `cloud-nuke --list-resource-types` shows `iam` (not `iam-user`)