### PR TITLE
chore: restore CircleCI nuke schedules as backup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,152 @@ jobs:
           root: .
           paths: bin
 
+  nuke_phx_devops:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          command: |
+            # We explicitly list the resource types we want to nuke, as we are not ready to nuke some resource types in
+            # the AWS account we use at Gruntwork for testing (Phx DevOps) (e.g., S3)
+            go run  -ldflags="-X 'main.VERSION=$CIRCLE_SHA1'" main.go aws \
+              --older-than 2h \
+              --force \
+              --config ./.circleci/nuke_config.yml \
+              --region global \
+              --region ap-northeast-1 \
+              --region ap-northeast-2 \
+              --region ap-northeast-3 \
+              --region ap-south-1 \
+              --region ap-southeast-1 \
+              --region ap-southeast-2 \
+              --region ca-central-1 \
+              --region eu-central-1 \
+              --region eu-north-1 \
+              --region eu-west-1 \
+              --region eu-west-2 \
+              --region eu-west-3 \
+              --region me-central-1 \
+              --region sa-east-1 \
+              --region us-east-1 \
+              --region us-east-2 \
+              --region us-west-1 \
+              --region us-west-2 \
+              --exclude-resource-type iam \
+              --exclude-resource-type iam-group \
+              --exclude-resource-type iam-policy \
+              --exclude-resource-type iam-role \
+              --exclude-resource-type iam-service-linked-role \
+              --exclude-resource-type oidcprovider \
+              --exclude-resource-type route53-hosted-zone \
+              --exclude-resource-type route53-cidr-collection \
+              --exclude-resource-type route53-traffic-policy \
+              --exclude-resource-type ecr \
+              --exclude-resource-type config-rules \
+              --exclude-resource-type nat-gateway \
+              --exclude-resource-type ec2-subnet \
+              --delete-unaliased-kms-keys \
+              --log-level debug
+          no_output_timeout: 1h
+  nuke_sandbox:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          command: |
+            export AWS_ACCESS_KEY_ID=$SANDBOX_AWS_ACCESS_KEY_ID
+            export AWS_SECRET_ACCESS_KEY=$SANDBOX_AWS_SECRET_ACCESS_KEY
+            # We explicitly list the resource types we want to nuke, as we are not ready to nuke some resource types in
+            # the AWS account we use at Gruntwork for testing (Sandbox) (e.g., S3)
+            go run -ldflags="-X 'main.VERSION=$CIRCLE_SHA1'" main.go aws \
+              --older-than 24h \
+              --force \
+              --config ./.circleci/nuke_config.yml \
+              --region global \
+              --region ap-northeast-1 \
+              --region ap-northeast-2 \
+              --region ap-northeast-3 \
+              --region ap-south-1 \
+              --region ap-southeast-1 \
+              --region ap-southeast-2 \
+              --region ca-central-1 \
+              --region eu-central-1 \
+              --region eu-north-1 \
+              --region eu-west-1 \
+              --region eu-west-2 \
+              --region eu-west-3 \
+              --region me-central-1 \
+              --region sa-east-1 \
+              --region us-east-1 \
+              --region us-east-2 \
+              --region us-west-1 \
+              --region us-west-2 \
+              --exclude-resource-type iam \
+              --exclude-resource-type iam-group \
+              --exclude-resource-type iam-policy \
+              --exclude-resource-type iam-role \
+              --exclude-resource-type iam-service-linked-role \
+              --exclude-resource-type oidcprovider \
+              --exclude-resource-type route53-hosted-zone \
+              --exclude-resource-type route53-cidr-collection \
+              --exclude-resource-type route53-traffic-policy \
+              --exclude-resource-type ecr \
+              --exclude-resource-type config-rules \
+              --exclude-resource-type nat-gateway \
+              --exclude-resource-type ec2-subnet \
+              --exclude-resource-type eip \
+              --delete-unaliased-kms-keys \
+              --log-level debug
+          no_output_timeout: 1h
+  nuke_configtests:
+    resource_class: large
+    docker:
+      - image: 677276116620.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.22.6-tf1.5-tg58.8-pck1.8-ci56.0
+    steps:
+      - checkout
+      - run:
+          command: |
+            # We explicitly list the resource types we want to nuke, as we are not ready to nuke some resource types in
+            # the AWS account we use at Gruntwork for testing (Phx DevOps) (e.g., S3)
+            go run  -ldflags="-X 'main.VERSION=$CIRCLE_SHA1'" main.go aws \
+              --older-than 2h \
+              --force \
+              --config ./.circleci/nuke_config.yml \
+              --region global \
+              --region ap-northeast-1 \
+              --region ap-northeast-2 \
+              --region ap-northeast-3 \
+              --region ap-south-1 \
+              --region ap-southeast-1 \
+              --region ap-southeast-2 \
+              --region ca-central-1 \
+              --region eu-central-1 \
+              --region eu-north-1 \
+              --region eu-west-1 \
+              --region eu-west-2 \
+              --region eu-west-3 \
+              --region sa-east-1 \
+              --region us-east-1 \
+              --region us-east-2 \
+              --region us-west-1 \
+              --region us-west-2 \
+              --exclude-resource-type iam \
+              --exclude-resource-type iam-group \
+              --exclude-resource-type iam-policy \
+              --exclude-resource-type iam-role \
+              --exclude-resource-type iam-service-linked-role \
+              --exclude-resource-type oidcprovider \
+              --exclude-resource-type route53-hosted-zone \
+              --exclude-resource-type route53-cidr-collection \
+              --exclude-resource-type route53-traffic-policy \
+              --exclude-resource-type ecr \
+              --exclude-resource-type config-rules \
+              --exclude-resource-type nat-gateway \
+              --exclude-resource-type internet-gateway \
+              --exclude-resource-type ec2-subnet \
+              --delete-unaliased-kms-keys \
+              --log-level debug
+          no_output_timeout: 1h
   deploy:
     <<: *env
     macos:
@@ -87,6 +233,9 @@ workflows:
   version: 2
   # Release workflow - build and deploy on tags only
   release:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - build:
           matrix:
@@ -113,3 +262,34 @@ workflows:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
             - APPLE__OSX__code-signing
+  nuke_phxdevops:
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "every 3 hours", << pipeline.schedule.name >> ]
+    jobs:
+      - nuke_phx_devops:
+          context:
+            - AWS__PHXDEVOPS__circle-ci-test
+            - GITHUB__PAT__gruntwork-ci
+  nuke_configtests:
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "every 3 hours", << pipeline.schedule.name >> ]
+    jobs:
+      - nuke_configtests:
+          context:
+            - AWS__CONFIGTESTS__circle-ci-test
+            - GITHUB__PAT__gruntwork-ci
+  nuke_sandbox:
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "nightly", << pipeline.schedule.name >> ]
+    jobs:
+      - nuke_sandbox:
+          context:
+            - AWS__PHXDEVOPS__circle-ci-test
+            - GITHUB__PAT__gruntwork-ci
+            - AWS__SANDBOX__circle-ci


### PR DESCRIPTION
## Summary
Restore CircleCI scheduled nuke jobs as backup while testing GitHub Actions scheduling.

## Changes
- Restore `nuke_phx_devops` job (every 3 hours)
- Restore `nuke_configtests` job (every 3 hours)
- Restore `nuke_sandbox` job (nightly)

## Notes
Both CircleCI and GitHub Actions schedules can run in parallel. Once GHA scheduling is confirmed working, we can remove CircleCI nuke jobs.