### PR TITLE
fix: prevent JSON renderer from writing multiple documents to output file

### DIFF
--- a/renderers/json_test.go
+++ b/renderers/json_test.go
@@ -39,8 +39,9 @@ func TestJSONRenderer_InspectOutput(t *testing.T) {
 		Error:        "timeout",
 	})
 
-	// ScanComplete triggers JSON output for inspect mode
 	r.OnEvent(reporting.ScanComplete{})
+	// Complete triggers JSON output
+	r.OnEvent(reporting.Complete{})
 
 	var output InspectOutput
 	err := json.Unmarshal(buf.Bytes(), &output)
@@ -83,7 +84,8 @@ func TestJSONRenderer_NukeOutput(t *testing.T) {
 		Reason:       "protected",
 	})
 
-	// NukeStarted sets nuke mode
+	// Simulate nuke flow: ScanComplete, then NukeStarted, deletions, NukeComplete
+	r.OnEvent(reporting.ScanComplete{})
 	r.OnEvent(reporting.NukeStarted{Total: 2})
 
 	r.OnEvent(reporting.ResourceDeleted{
@@ -105,8 +107,9 @@ func TestJSONRenderer_NukeOutput(t *testing.T) {
 		Error:        "timeout",
 	})
 
-	// NukeComplete triggers JSON output
 	r.OnEvent(reporting.NukeComplete{})
+	// Complete triggers JSON output
+	r.OnEvent(reporting.Complete{})
 
 	var output NukeOutput
 	err := json.Unmarshal(buf.Bytes(), &output)
@@ -125,8 +128,9 @@ func TestJSONRenderer_EmptyOutput(t *testing.T) {
 		Command: "inspect-aws",
 	})
 
-	// ScanComplete triggers output even with no data
 	r.OnEvent(reporting.ScanComplete{})
+	// Complete triggers output even with no data
+	r.OnEvent(reporting.Complete{})
 
 	var output InspectOutput
 	err := json.Unmarshal(buf.Bytes(), &output)
@@ -134,4 +138,50 @@ func TestJSONRenderer_EmptyOutput(t *testing.T) {
 
 	assert.Equal(t, 0, output.Summary.TotalResources)
 	assert.Len(t, output.Resources, 0)
+}
+
+// TestJSONRenderer_NukeDoesNotOutputOnScanComplete verifies that nuke commands
+// only output on Complete, not on ScanComplete. This prevents writing two
+// JSON documents to the same file which would corrupt the output.
+func TestJSONRenderer_NukeDoesNotOutputOnScanComplete(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewJSONRenderer(&buf, JSONRendererConfig{
+		Command: "aws",
+		Regions: []string{"us-east-1"},
+	})
+
+	// Simulate scan phase
+	r.OnEvent(reporting.ResourceFound{
+		ResourceType: "ec2",
+		Region:       "us-east-1",
+		Identifier:   "i-123",
+		Nukable:      true,
+	})
+
+	// ScanComplete should NOT trigger output
+	r.OnEvent(reporting.ScanComplete{})
+	assert.Empty(t, buf.String(), "should not output on ScanComplete")
+
+	// Simulate nuke phase
+	r.OnEvent(reporting.NukeStarted{Total: 1})
+	r.OnEvent(reporting.ResourceDeleted{
+		ResourceType: "ec2",
+		Region:       "us-east-1",
+		Identifier:   "i-123",
+		Success:      true,
+	})
+
+	// NukeComplete should NOT trigger output either
+	r.OnEvent(reporting.NukeComplete{})
+	assert.Empty(t, buf.String(), "should not output on NukeComplete")
+
+	// Only Complete should trigger output
+	r.OnEvent(reporting.Complete{})
+	assert.NotEmpty(t, buf.String(), "should output on Complete")
+
+	// Verify it's valid JSON with nuke output structure (single document)
+	var output NukeOutput
+	err := json.Unmarshal(buf.Bytes(), &output)
+	require.NoError(t, err, "output should be valid JSON (single document)")
+	assert.Equal(t, 1, output.Summary.Deleted)
 }

--- a/reporting/collector_test.go
+++ b/reporting/collector_test.go
@@ -64,8 +64,10 @@ func TestCollector_FullFlow(t *testing.T) {
 	assert.IsType(t, ResourceDeleted{}, r.events[2])
 	assert.IsType(t, GeneralError{}, r.events[4])
 
-	// Complete marks collector as closed
+	// Complete emits Complete event and marks collector as closed
 	c.Complete()
+	assert.Len(t, r.events, 6)
+	assert.IsType(t, Complete{}, r.events[5])
 
 	// Events after close should be ignored
 	c.Emit(ResourceDeleted{
@@ -74,10 +76,11 @@ func TestCollector_FullFlow(t *testing.T) {
 		Identifier:   "i-4",
 		Success:      true,
 	})
-	assert.Len(t, r.events, 5)
+	assert.Len(t, r.events, 6) // Still 6, new event ignored
 
-	// Second complete should be no-op
+	// Second complete should be no-op (no additional Complete event)
 	c.Complete()
+	assert.Len(t, r.events, 6)
 }
 
 func TestCollector_ConcurrentAccess(t *testing.T) {

--- a/reporting/events.go
+++ b/reporting/events.go
@@ -87,7 +87,12 @@ func (NukeProgress) EventType() string { return "nuke_progress" }
 
 // NukeComplete is emitted when all nuke operations are finished.
 // Used by CLI renderer to stop progress bar and display deletion results.
-// Used by JSON renderer to output final JSON.
 type NukeComplete struct{}
 
 func (NukeComplete) EventType() string { return "nuke_complete" }
+
+// Complete is emitted by collector.Complete(), signaling the end of the operation.
+// JSON renderer outputs on this event (using nukeMode to decide format).
+type Complete struct{}
+
+func (Complete) EventType() string { return "complete" }


### PR DESCRIPTION
## Summary
- JSON renderer was writing on both `ScanComplete` and `NukeComplete`, corrupting output file with two JSON documents
- GitHub Actions `jq` parsing failed with "Invalid format '0'" error
- Fix: Add `Complete` event emitted by `collector.Complete()`, JSON renderer outputs only on this event

## Test plan
- [x] Unit tests pass
- [x] Added `TestJSONRenderer_NukeDoesNotOutputOnScanComplete` to verify fix