### PR TITLE
fix: exclude internet gateways with gruntwork/gw- prefix from nuking

### DIFF
--- a/.circleci/nuke_config.yml
+++ b/.circleci/nuke_config.yml
@@ -284,10 +284,9 @@ MSKCluster:
 InternetGateway:
   exclude:
     names_regex:
-      # Exclude the IGW for default VPCs in phxdevops. This IGW is attached to the default VPC
-      # and is used by tests that require internet access from within the VPC. Without it, any
-      # VPC-based test that requires internet will fail.
-      - "gw-new-default-igw"
+      # Exclude any IGW with gruntwork or gw- prefix to protect infrastructure resources
+      - "^gruntwork.*"
+      - "^gw-.*"
 
 Route53HostedZone:
   exclude:

--- a/.github/nuke_config.yml
+++ b/.github/nuke_config.yml
@@ -286,10 +286,9 @@ MSKCluster:
 InternetGateway:
   exclude:
     names_regex:
-      # Exclude the IGW for default VPCs in phxdevops. This IGW is attached to the default VPC
-      # and is used by tests that require internet access from within the VPC. Without it, any
-      # VPC-based test that requires internet will fail.
-      - "gw-new-default-igw"
+      # Exclude any IGW with gruntwork or gw- prefix to protect infrastructure resources
+      - "^gruntwork.*"
+      - "^gw-.*"
 
 Route53HostedZone:
   exclude:


### PR DESCRIPTION
## Summary
- Add exclude rules for internet gateways with `gruntwork` or `gw-` name prefix in both `.circleci/nuke_config.yml` and `.github/nuke_config.yml`
- Prevents accidental deletion of infrastructure IGWs

## Test plan
- [x] Verified with `aws --dry-run --config` that IGWs with `gw-` prefix are excluded
- [x] Verified with `inspect-aws` (no config) that the IGW exists but is filtered out by the config