### PR TITLE
fix: transform DryRunOperation error in ec2-endpoint permission check

### DIFF
--- a/aws/resources/ec2_endpoints.go
+++ b/aws/resources/ec2_endpoints.go
@@ -112,5 +112,5 @@ func verifyEC2EndpointPermission(ctx context.Context, client EC2EndpointsAPI, id
 		VpcEndpointIds: []string{aws.ToString(id)},
 		DryRun:         aws.Bool(true),
 	})
-	return err
+	return util.TransformAWSError(err)
 }


### PR DESCRIPTION
## Summary
- `verifyEC2EndpointPermission` returned raw AWS errors instead of using `util.TransformAWSError`, causing inspect/dry-run mode to display error text instead of a checkmark for nukable resources
- Wraps the return value with `util.TransformAWSError(err)` to match the pattern used by other resources (e.g., `security_group.go`, `ec2_network_acl.go`)

Closes #1000