### PR TITLE
fix: prevent nil pointer dereference in secrets manager delete and cloudtrail tag handling

### DIFF
--- a/aws/resources/cloudtrail.go
+++ b/aws/resources/cloudtrail.go
@@ -54,6 +54,9 @@ func listCloudtrailTrails(ctx context.Context, client CloudtrailTrailAPI, scope 
 				ResourceIdList: []string{*trail.TrailARN},
 			}); err == nil && len(tags.ResourceTagList) > 0 {
 				for _, tag := range tags.ResourceTagList[0].TagsList {
+					if tag.Key == nil || tag.Value == nil {
+						continue
+					}
 					rv.Tags[*tag.Key] = *tag.Value
 				}
 			}

--- a/aws/resources/secrets_manager.go
+++ b/aws/resources/secrets_manager.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -92,6 +93,9 @@ func deleteSecretsManagerSecret(ctx context.Context, client SecretsManagerAPI, s
 	})
 	if err != nil {
 		return err
+	}
+	if secret == nil {
+		return fmt.Errorf("DescribeSecret returned nil for secret %s", aws.ToString(secretID))
 	}
 
 	// Delete replications if this is a primary secret with replicas

--- a/aws/resources/secrets_manager_test.go
+++ b/aws/resources/secrets_manager_test.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ import (
 type mockSecretsManagerClient struct {
 	ListSecretsOutput                  secretsmanager.ListSecretsOutput
 	DescribeSecretOutput               secretsmanager.DescribeSecretOutput
+	DescribeSecretError                error
 	DeleteSecretOutput                 secretsmanager.DeleteSecretOutput
 	RemoveRegionsFromReplicationOutput secretsmanager.RemoveRegionsFromReplicationOutput
 }
@@ -26,6 +28,9 @@ func (m *mockSecretsManagerClient) ListSecrets(ctx context.Context, params *secr
 }
 
 func (m *mockSecretsManagerClient) DescribeSecret(ctx context.Context, params *secretsmanager.DescribeSecretInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.DescribeSecretOutput, error) {
+	if m.DescribeSecretError != nil {
+		return nil, m.DescribeSecretError
+	}
 	return &m.DescribeSecretOutput, nil
 }
 
@@ -116,4 +121,16 @@ func TestDeleteSecretsManagerSecret_WithReplicas(t *testing.T) {
 
 	err := deleteSecretsManagerSecret(context.Background(), mock, aws.String("arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret"))
 	require.NoError(t, err)
+}
+
+func TestDeleteSecretsManagerSecret_DescribeSecretError(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockSecretsManagerClient{
+		DescribeSecretError: fmt.Errorf("throttling: rate exceeded"),
+	}
+
+	err := deleteSecretsManagerSecret(context.Background(), mock, aws.String("arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "throttling")
 }


### PR DESCRIPTION
## Summary

Closes #1010

- Add nil guard on `DescribeSecret` response in `deleteSecretsManagerSecret` to prevent panic when the API call fails or returns nil
- Add nil guards on `tag.Key`/`tag.Value` in `cloudtrail.go` before dereferencing, matching the defensive pattern already used in `iam_instance_profile.go` and `ecs_service.go`
- Add unit test for `DescribeSecret` error path

## Test plan

- [x] Existing unit tests pass
- [x] New `TestDeleteSecretsManagerSecret_DescribeSecretError` test covers the error path
- [x] `go build ./...` succeeds