### PR TITLE
fix: v1.0.0 release readiness fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ vendor
 .vscode
 cloud-nuke
 config.yaml
+.env
 .envrc

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/reporting"
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/go-commons/collections"
+	"github.com/hashicorp/go-multierror"
 )
 
 // GetAllResources - Lists all aws resources
@@ -56,14 +57,7 @@ func GetAllResources(c context.Context, query *Query, configObj config.Config, c
 		registeredResources := GetAndInitRegisteredResources(cloudNukeSession, region)
 		for _, resource := range registeredResources {
 			if IsNukeable((*resource).ResourceName(), query.ResourceTypes) {
-
-				// PrepareContext sets up the resource context for execution, utilizing the context 'c' and the resource individual configuration.
-				// This function should be called after configuring the timeout to ensure proper execution context.
-				resourceConfig := (*resource).GetAndSetResourceConfig(configObj)
-				err := (*resource).PrepareContext(c, resourceConfig)
-				if err != nil {
-					return nil, err
-				}
+				(*resource).GetAndSetResourceConfig(configObj)
 
 				// Emit scan progress event
 				collector.Emit(reporting.ScanProgress{
@@ -157,8 +151,9 @@ func IsNukeable(resourceType string, resourceTypes []string) bool {
 	return false
 }
 
-func nukeAllResourcesInRegion(account *AwsAccountResources, region string, collector *reporting.Collector) {
+func nukeAllResourcesInRegion(ctx context.Context, account *AwsAccountResources, region string, collector *reporting.Collector) error {
 	resourcesInRegion := account.Resources[region]
+	var allErrors *multierror.Error
 
 	for _, awsResource := range resourcesInRegion.Resources {
 		length := len((*awsResource).ResourceIdentifiers())
@@ -175,7 +170,7 @@ func nukeAllResourcesInRegion(account *AwsAccountResources, region string, colle
 				BatchSize:    len(batch),
 			})
 
-			results, err := (*awsResource).Nuke(context.TODO(), batch)
+			results, err := (*awsResource).Nuke(ctx, batch)
 
 			// Emit ResourceDeleted for each result
 			for _, result := range results {
@@ -194,13 +189,17 @@ func nukeAllResourcesInRegion(account *AwsAccountResources, region string, colle
 
 			if err != nil {
 				// Handle rate limiting
-				if strings.Contains(err.Error(), "RequestLimitExceeded") {
+				if strings.Contains(err.Error(), "RequestLimitExceeded") ||
+					strings.Contains(err.Error(), "ThrottlingException") ||
+					strings.Contains(err.Error(), "TooManyRequestsException") {
 					logging.Debug(
 						"Request limit reached. Waiting 1 minute before making new requests",
 					)
 					time.Sleep(1 * time.Minute)
 					continue
 				}
+
+				allErrors = multierror.Append(allErrors, fmt.Errorf("[%s] %s: %w", region, (*awsResource).ResourceName(), err))
 
 				// Report to telemetry - aggregated metrics of failures per resources.
 				telemetry.TrackEvent(commonTelemetry.EventContext{
@@ -216,16 +215,20 @@ func nukeAllResourcesInRegion(account *AwsAccountResources, region string, colle
 			}
 		}
 	}
+
+	return allErrors.ErrorOrNil()
 }
 
 // NukeAllResources - Nukes all aws resources
-func NukeAllResources(account *AwsAccountResources, regions []string, collector *reporting.Collector) error {
+func NukeAllResources(ctx context.Context, account *AwsAccountResources, regions []string, collector *reporting.Collector) error {
 	// Emit NukeStarted event (CLIRenderer will initialize progress bar)
 	collector.Emit(reporting.NukeStarted{Total: account.TotalResourceCount()})
 
 	telemetry.TrackEvent(commonTelemetry.EventContext{
 		EventName: "Begin nuking resources",
 	}, map[string]interface{}{})
+
+	var allErrors *multierror.Error
 
 	for _, region := range regions {
 		telemetry.TrackEvent(commonTelemetry.EventContext{
@@ -234,10 +237,10 @@ func NukeAllResources(account *AwsAccountResources, regions []string, collector 
 			"region": region,
 		})
 
-		// We intentionally do not handle an error returned from this method, because we collect individual errors
-		// on per-resource basis via the collector. In the run report displayed at the end of
-		// a cloud-nuke run, we show exactly which resources deleted cleanly and which encountered errors
-		nukeAllResourcesInRegion(account, region, collector)
+		if err := nukeAllResourcesInRegion(ctx, account, region, collector); err != nil {
+			allErrors = multierror.Append(allErrors, err)
+		}
+
 		telemetry.TrackEvent(commonTelemetry.EventContext{
 			EventName: "Done Nuking Region",
 		}, map[string]interface{}{
@@ -249,5 +252,5 @@ func NukeAllResources(account *AwsAccountResources, regions []string, collector 
 	// Emit NukeComplete event (triggers final output in renderers)
 	collector.Emit(reporting.NukeComplete{})
 
-	return nil
+	return allErrors.ErrorOrNil()
 }

--- a/aws/resource.go
+++ b/aws/resource.go
@@ -19,7 +19,6 @@ type AwsResource interface {
 	GetAndSetIdentifiers(c context.Context, configObj config.Config) ([]string, error)
 	IsNukable(string) (bool, error)
 
-	PrepareContext(context.Context, config.ResourceType) error
 	GetAndSetResourceConfig(config.Config) config.ResourceType
 }
 

--- a/aws/resource_registry.go
+++ b/aws/resource_registry.go
@@ -1,13 +1,9 @@
 package aws
 
 import (
-	"reflect"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/gruntwork-io/cloud-nuke/aws/resources"
 )
-
-const Global = "global"
 
 // GetAllRegisteredResources - returns a list of all registered resources without initialization.
 // This is useful for listing all resources without initializing them.
@@ -21,7 +17,7 @@ func GetAllRegisteredResources() []*AwsResource {
 // GetAndInitRegisteredResources - returns a list of all registered resources with initialization.
 func GetAndInitRegisteredResources(session aws.Config, region string) []*AwsResource {
 	var registeredResources []AwsResource
-	if region == Global {
+	if region == GlobalRegion {
 		registeredResources = getRegisteredGlobalResources()
 	} else {
 		registeredResources = getRegisteredRegionalResources()
@@ -201,22 +197,7 @@ func toAwsResourcesPointer(resources []AwsResource) []*AwsResource {
 func initRegisteredResources(resources []*AwsResource, session aws.Config, region string) []*AwsResource {
 	for _, resource := range resources {
 		(*resource).Init(session)
-
-		// Note: only regional resources have the field `Region`, which is used for logging purposes only
-		setRegionForRegionalResource(resource, region)
 	}
 
 	return resources
-}
-
-func setRegionForRegionalResource(regionResource *AwsResource, region string) {
-	// Use reflection to set the Region field if the resource type has it
-	resourceValue := reflect.ValueOf(*regionResource) // Dereference the pointer
-	resourceValue = resourceValue.Elem()              // Get the underlying value
-	regionField := resourceValue.FieldByName("Region")
-
-	if regionField.IsValid() && regionField.CanSet() {
-		// The field is valid and can be set
-		regionField.SetString(region)
-	}
 }

--- a/aws/resources/adapter.go
+++ b/aws/resources/adapter.go
@@ -142,14 +142,6 @@ func (a *AwsResourceAdapter[C]) Nuke(ctx context.Context, identifiers []string) 
 	return a.Resource.Nuke(ctx, identifiers)
 }
 
-// PrepareContext is a no-op for generic resources.
-// The generic Resource pattern passes context directly to Nuke() and Lister functions,
-// eliminating the need for context preparation. This method exists solely for
-// compatibility with the AwsResource interface.
-func (a *AwsResourceAdapter[C]) PrepareContext(_ context.Context, _ config.ResourceType) error {
-	return nil
-}
-
 // Compile-time interface satisfaction check.
 // This ensures AwsResourceAdapter correctly implements AwsResource at compile time.
 var _ AwsResource = (*AwsResourceAdapter[any])(nil)

--- a/aws/resources/cloudfront_distribution.go
+++ b/aws/resources/cloudfront_distribution.go
@@ -32,7 +32,6 @@ func NewCloudfrontDistributions() AwsResource {
 	return NewAwsResource(&resource.Resource[CloudfrontDistributionAPI]{
 		ResourceTypeName: "cloudfront-distribution",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[CloudfrontDistributionAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = cloudfront.NewFromConfig(cfg)

--- a/aws/resources/iam.go
+++ b/aws/resources/iam.go
@@ -47,7 +47,6 @@ func NewIAMUsers() AwsResource {
 	return NewAwsResource(&resource.Resource[IAMUsersAPI]{
 		ResourceTypeName: "iam-user",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[IAMUsersAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = iam.NewFromConfig(cfg)

--- a/aws/resources/iam_group.go
+++ b/aws/resources/iam_group.go
@@ -28,7 +28,6 @@ func NewIAMGroups() AwsResource {
 	return NewAwsResource(&resource.Resource[IAMGroupsAPI]{
 		ResourceTypeName: "iam-group",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[IAMGroupsAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = iam.NewFromConfig(cfg)

--- a/aws/resources/iam_instance_profile.go
+++ b/aws/resources/iam_instance_profile.go
@@ -24,7 +24,6 @@ func NewIAMInstanceProfiles() AwsResource {
 	return NewAwsResource(&resource.Resource[IAMInstanceProfilesAPI]{
 		ResourceTypeName: "iam-instance-profile",
 		BatchSize:        20,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[IAMInstanceProfilesAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = iam.NewFromConfig(cfg)

--- a/aws/resources/iam_instance_profile_test.go
+++ b/aws/resources/iam_instance_profile_test.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -95,16 +94,6 @@ func TestIAMInstanceProfiles_ListIAMInstanceProfiles(t *testing.T) {
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now),
-				}},
-			expected: []string{testName1},
-		},
-		"tagExclusion": {
-			configObj: config.ResourceType{
-				ExcludeRule: config.FilterRule{
-					Tag: aws.String("somearn"),
-					TagValue: &config.Expression{
-						RE: *regexp.MustCompile("^" + "some" + strings.ToLower(testArn2) + "$"),
-					},
 				}},
 			expected: []string{testName1},
 		},

--- a/aws/resources/iam_policy.go
+++ b/aws/resources/iam_policy.go
@@ -33,7 +33,6 @@ func NewIAMPolicies() AwsResource {
 	return NewAwsResource(&resource.Resource[IAMPoliciesAPI]{
 		ResourceTypeName: "iam-policy",
 		BatchSize:        20,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[IAMPoliciesAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = iam.NewFromConfig(cfg)

--- a/aws/resources/iam_role.go
+++ b/aws/resources/iam_role.go
@@ -33,7 +33,6 @@ func NewIAMRoles() AwsResource {
 	return NewAwsResource(&resource.Resource[IAMRolesAPI]{
 		ResourceTypeName: "iam-role",
 		BatchSize:        20,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[IAMRolesAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = iam.NewFromConfig(cfg)

--- a/aws/resources/iam_service_linked_role.go
+++ b/aws/resources/iam_service_linked_role.go
@@ -27,7 +27,6 @@ func NewIAMServiceLinkedRoles() AwsResource {
 	return NewAwsResource(&resource.Resource[IAMServiceLinkedRolesAPI]{
 		ResourceTypeName: "iam-service-linked-role",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[IAMServiceLinkedRolesAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = iam.NewFromConfig(cfg)
@@ -84,8 +83,20 @@ func deleteIAMServiceLinkedRole(ctx context.Context, client IAMServiceLinkedRole
 	// Wait for the deletion to start
 	time.Sleep(3 * time.Second)
 
-	// Poll for deletion completion
+	// Poll for deletion completion with a maximum timeout of 5 minutes
+	const maxWait = 5 * time.Minute
+	const pollInterval = 3 * time.Second
+	deadline := time.Now().Add(maxWait)
+
 	for {
+		if err := ctx.Err(); err != nil {
+			return errors.WithStackTrace(fmt.Errorf("context cancelled while waiting for deletion of IAM ServiceLinked Role %s: %w", aws.ToString(roleName), err))
+		}
+
+		if time.Now().After(deadline) {
+			return errors.WithStackTrace(fmt.Errorf("timed out after %s waiting for deletion of IAM ServiceLinked Role %s", maxWait, aws.ToString(roleName)))
+		}
+
 		status, err := client.GetServiceLinkedRoleDeletionStatus(ctx, &iam.GetServiceLinkedRoleDeletionStatusInput{
 			DeletionTaskId: deletionData.DeletionTaskId,
 		})
@@ -98,7 +109,7 @@ func deleteIAMServiceLinkedRole(ctx context.Context, client IAMServiceLinkedRole
 			return nil
 		case types.DeletionTaskStatusTypeInProgress:
 			logging.Debugf("Deletion of IAM ServiceLinked Role %s is still in progress", aws.ToString(roleName))
-			time.Sleep(3 * time.Second)
+			time.Sleep(pollInterval)
 		default:
 			// Failed or unknown status
 			return errors.WithStackTrace(fmt.Errorf("deletion of IAM ServiceLinked Role %s failed with status %s", aws.ToString(roleName), string(status.Status)))

--- a/aws/resources/oidc_provider.go
+++ b/aws/resources/oidc_provider.go
@@ -29,7 +29,6 @@ func NewOIDCProviders() AwsResource {
 	return NewAwsResource(&resource.Resource[OIDCProvidersAPI]{
 		ResourceTypeName: "oidc-provider",
 		BatchSize:        10,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[OIDCProvidersAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = iam.NewFromConfig(cfg)

--- a/aws/resources/rds_global_cluster.go
+++ b/aws/resources/rds_global_cluster.go
@@ -26,7 +26,6 @@ func NewDBGlobalClusters() AwsResource {
 	return NewAwsResource(&resource.Resource[DBGlobalClustersAPI]{
 		ResourceTypeName: "rds-global-cluster",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[DBGlobalClustersAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = rds.NewFromConfig(cfg)

--- a/aws/resources/route53_cidr_collection.go
+++ b/aws/resources/route53_cidr_collection.go
@@ -25,7 +25,6 @@ func NewRoute53CidrCollections() AwsResource {
 	return NewAwsResource(&resource.Resource[Route53CidrCollectionAPI]{
 		ResourceTypeName: "route53-cidr-collection",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[Route53CidrCollectionAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = route53.NewFromConfig(cfg)

--- a/aws/resources/route53_hostedzone.go
+++ b/aws/resources/route53_hostedzone.go
@@ -29,7 +29,6 @@ func NewRoute53HostedZone() AwsResource {
 	return NewAwsResource(&resource.Resource[Route53HostedZoneAPI]{
 		ResourceTypeName: "route53-hosted-zone",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[Route53HostedZoneAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = route53.NewFromConfig(cfg)

--- a/aws/resources/route53_traffic_policy.go
+++ b/aws/resources/route53_traffic_policy.go
@@ -23,7 +23,6 @@ func NewRoute53TrafficPolicies() AwsResource {
 	return NewAwsResource(&resource.Resource[Route53TrafficPolicyAPI]{
 		ResourceTypeName: "route53-traffic-policy",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[Route53TrafficPolicyAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = route53.NewFromConfig(cfg)

--- a/aws/resources/s3.go
+++ b/aws/resources/s3.go
@@ -59,7 +59,6 @@ func NewS3Buckets() AwsResource {
 	return NewAwsResource(&resource.Resource[S3API]{
 		ResourceTypeName: "s3",
 		BatchSize:        500,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[S3API], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = s3.NewFromConfig(cfg)

--- a/aws/resources/s3_multi_region_access_point.go
+++ b/aws/resources/s3_multi_region_access_point.go
@@ -26,7 +26,6 @@ func NewS3MultiRegionAccessPoints() AwsResource {
 		ResourceTypeName: "s3-multi-region-access-point",
 		// S3 Control API has tight rate limits; keep batch size low to avoid throttling.
 		BatchSize: 5,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[S3ControlMultiRegionAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = s3control.NewFromConfig(cfg)

--- a/aws/resources/sagemaker_endpoint.go
+++ b/aws/resources/sagemaker_endpoint.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
@@ -103,24 +102,6 @@ func shouldExcludeByTags(endpointName *string, tagMap map[string]string, cfg con
 			if pattern.RE.MatchString(tagValue) {
 				logging.Debugf("Excluding endpoint %s due to tag '%s' with value '%s' matching pattern '%s'",
 					*endpointName, tag, tagValue, pattern.RE.String())
-				return true
-			}
-		}
-	}
-
-	// Check the deprecated Tag/TagValue approach
-	if cfg.ExcludeRule.Tag != nil {
-		tagName := *cfg.ExcludeRule.Tag
-		if tagValue, hasTag := tagMap[tagName]; hasTag {
-			if cfg.ExcludeRule.TagValue != nil {
-				if cfg.ExcludeRule.TagValue.RE.MatchString(tagValue) {
-					logging.Debugf("Excluding endpoint %s due to deprecated tag '%s' with value '%s' matching pattern '%s'",
-						*endpointName, tagName, tagValue, cfg.ExcludeRule.TagValue.RE.String())
-					return true
-				}
-			} else if strings.EqualFold(tagValue, "true") {
-				logging.Debugf("Excluding endpoint %s due to deprecated tag '%s' with default value 'true'",
-					*endpointName, tagName)
 				return true
 			}
 		}

--- a/aws/resources/sagemaker_studio.go
+++ b/aws/resources/sagemaker_studio.go
@@ -56,10 +56,7 @@ func NewSageMakerStudio() AwsResource {
 			r.Client = sagemaker.NewFromConfig(cfg)
 		}),
 		ConfigGetter: func(c config.Config) config.ResourceType {
-			return config.ResourceType{
-				Timeout:            c.SageMakerStudioDomain.Timeout,
-				ProtectUntilExpire: c.SageMakerStudioDomain.ProtectUntilExpire,
-			}
+			return c.SageMakerStudioDomain
 		},
 		Lister: listSageMakerDomains,
 		Nuker:  nukeSageMakerDomains,

--- a/aws/resources/types.go
+++ b/aws/resources/types.go
@@ -9,6 +9,9 @@ import (
 )
 
 // AwsResource is an interface that represents a single AWS resource.
+// This interface is structurally identical to aws.AwsResource but defined here
+// to avoid a circular import (aws imports resources). Go's structural typing
+// ensures that types satisfying this interface also satisfy aws.AwsResource.
 // This interface is satisfied by AwsResourceAdapter[C] which wraps resource.Resource[C].
 type AwsResource interface {
 	Init(cfg aws.Config)
@@ -18,6 +21,5 @@ type AwsResource interface {
 	Nuke(ctx context.Context, identifiers []string) ([]resource.NukeResult, error)
 	GetAndSetIdentifiers(c context.Context, configObj config.Config) ([]string, error)
 	IsNukable(string) (bool, error)
-	PrepareContext(context.Context, config.ResourceType) error
 	GetAndSetResourceConfig(config.Config) config.ResourceType
 }

--- a/commands/aws_commands.go
+++ b/commands/aws_commands.go
@@ -150,7 +150,7 @@ func awsNukeHelper(c *cli.Context, configObj config.Config, query *aws.Query, ou
 
 	// Execute the nuke operation if confirmed
 	if shouldProceed {
-		return aws.NukeAllResources(account, query.Regions, collector)
+		return aws.NukeAllResources(c.Context, account, query.Regions, collector)
 	}
 
 	return nil

--- a/commands/gcp_commands.go
+++ b/commands/gcp_commands.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/gruntwork-io/cloud-nuke/config"
@@ -27,6 +28,11 @@ func gcpNuke(c *cli.Context) error {
 	// Handle the --list-resource-types flag
 	if c.Bool(FlagListResourceTypes) {
 		return handleListGcpResourceTypes()
+	}
+
+	// --resource-type and --exclude-resource-type are not yet supported for GCP
+	if c.IsSet(FlagResourceType) || c.IsSet(FlagExcludeResourceType) {
+		return fmt.Errorf("--resource-type and --exclude-resource-type are not yet supported for GCP commands; all GCP resource types will be processed")
 	}
 
 	// Parse and set log level
@@ -70,6 +76,11 @@ func gcpInspect(c *cli.Context) error {
 	// Handle the --list-resource-types flag
 	if c.Bool(FlagListResourceTypes) {
 		return handleListGcpResourceTypes()
+	}
+
+	// --resource-type and --exclude-resource-type are not yet supported for GCP
+	if c.IsSet(FlagResourceType) || c.IsSet(FlagExcludeResourceType) {
+		return fmt.Errorf("--resource-type and --exclude-resource-type are not yet supported for GCP commands; all GCP resource types will be processed")
 	}
 
 	// Parse and set log level

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -361,8 +361,7 @@ type EC2ResourceType struct {
 }
 
 type AWSProtectableResourceType struct {
-	ResourceType             `yaml:",inline"`
-	IncludeDeletionProtected bool `yaml:"include_deletion_protected"`
+	ResourceType `yaml:",inline"`
 }
 
 type ResourceType struct {
@@ -376,8 +375,6 @@ type FilterRule struct {
 	NamesRegExp  []Expression          `yaml:"names_regex"`
 	TimeAfter    *time.Time            `yaml:"time_after"`
 	TimeBefore   *time.Time            `yaml:"time_before"`
-	Tag          *string               `yaml:"tag"`       // Deprecated ~ A tag to filter resources by. (e.g., If set under ExcludedRule, resources with this tag will be excluded).
-	TagValue     *Expression           `yaml:"tag_value"` // Deprecated
 	Tags         map[string]Expression `yaml:"tags"`
 	TagsOperator string                `yaml:"tags_operator"` // "AND" or "OR" - defaults to "OR" for backward compatibility
 }
@@ -413,7 +410,7 @@ func GetConfig(filePath string) (*Config, error) {
 		return nil, err
 	}
 
-	yamlFile, err := ioutil.ReadFile(absolutePath)
+	yamlFile, err := os.ReadFile(absolutePath)
 	if err != nil {
 		return nil, err
 	}
@@ -542,18 +539,10 @@ func (r ResourceType) ShouldIncludeBasedOnTime(time time.Time) bool {
 }
 
 func (r ResourceType) getExclusionTag() string {
-	if r.ExcludeRule.Tag != nil {
-		return *r.ExcludeRule.Tag
-	}
-
 	return DefaultAwsResourceExclusionTagKey
 }
 
 func (r ResourceType) getExclusionTagValue() *Expression {
-	if r.ExcludeRule.TagValue != nil {
-		return r.ExcludeRule.TagValue
-	}
-
 	return &Expression{RE: *regexp.MustCompile(DefaultAwsResourceExclusionTagValue)}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -324,34 +324,8 @@ func TestAddIncludeAndExcludeAfterTime(t *testing.T) {
 }
 
 func TestGetExclusionTag(t *testing.T) {
-	tests := []struct {
-		name        string
-		want        string
-		ExcludeRule FilterRule
-	}{
-		{
-			name: "empty config returns default tag",
-			want: DefaultAwsResourceExclusionTagKey,
-		},
-		{
-			name: "custom exclusion tag is returned",
-			ExcludeRule: FilterRule{
-				Tag: aws.String("my-custom-tag"),
-			},
-			want: "my-custom-tag",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			testConfig := &Config{}
-			testConfig.ACM = ResourceType{
-				ExcludeRule: tt.ExcludeRule,
-			}
-
-			require.Equal(t, tt.want, testConfig.ACM.getExclusionTag())
-		})
-	}
+	testConfig := &Config{}
+	require.Equal(t, DefaultAwsResourceExclusionTagKey, testConfig.ACM.getExclusionTag())
 }
 
 func TestShouldIncludeBasedOnTag(t *testing.T) {
@@ -368,90 +342,26 @@ func TestShouldIncludeBasedOnTag(t *testing.T) {
 		expect bool
 	}{
 		{
-			name:   "should include resource with default exclude tag",
+			name:   "should exclude resource with default exclude tag set to true",
 			given:  arg{},
 			when:   map[string]string{DefaultAwsResourceExclusionTagKey: "true"},
 			expect: false,
 		},
 		{
-			name: "should include resource with custom exclude tag",
-			given: arg{
-				ExcludeRule: FilterRule{
-					Tag: aws.String("my-custom-skip-tag"),
-				},
-				ProtectUntilExpire: false,
-			},
-			when:   map[string]string{"my-custom-skip-tag": "true"},
-			expect: false,
-		},
-		{
-			name: "should include resource with custom exclude tag and empty value",
-			given: arg{
-				ExcludeRule: FilterRule{
-					Tag: aws.String("my-custom-skip-tag"),
-					TagValue: &Expression{
-						RE: *regexp.MustCompile(""),
-					},
-				},
-				ProtectUntilExpire: false,
-			},
-			when:   map[string]string{"my-custom-skip-tag": ""},
-			expect: false,
-		},
-		{
-			name: "should include resource with custom exclude tag and empty value (using regular expression)",
-			given: arg{
-				ExcludeRule: FilterRule{
-					Tag: aws.String("my-custom-skip-tag"),
-					TagValue: &Expression{
-						RE: *regexp.MustCompile(".*"),
-					},
-				},
-				ProtectUntilExpire: false,
-			},
-			when:   map[string]string{"my-custom-skip-tag": ""},
-			expect: false,
-		},
-		{
-			name: "should include resource with custom exclude tag and prefix value (using regular expression)",
-			given: arg{
-				ExcludeRule: FilterRule{
-					Tag: aws.String("my-custom-skip-tag"),
-					TagValue: &Expression{
-						RE: *regexp.MustCompile("protected-.*"),
-					},
-				},
-				ProtectUntilExpire: false,
-			},
-			when:   map[string]string{"my-custom-skip-tag": "protected-database"},
-			expect: false,
-		},
-		{
-			name: "should include resource when exclude tag is not set to true",
-			given: arg{
-				ExcludeRule: FilterRule{
-					Tag: aws.String(DefaultAwsResourceExclusionTagKey),
-				},
-				ProtectUntilExpire: false,
-			},
+			name:   "should include resource when exclude tag is not set to true",
+			given:  arg{},
 			when:   map[string]string{DefaultAwsResourceExclusionTagKey: "false"},
 			expect: true,
 		},
 		{
-			name: "should include resource when no tags are set",
-			given: arg{
-				ExcludeRule: FilterRule{
-					Tag: aws.String(DefaultAwsResourceExclusionTagKey),
-				},
-				ProtectUntilExpire: false,
-			},
+			name:   "should include resource when no tags are set",
+			given:  arg{},
 			when:   map[string]string{},
 			expect: true,
 		},
 		{
-			name: "should include resource when protection expires in the future",
+			name: "should exclude resource when protection expires in the future",
 			given: arg{
-				ExcludeRule:        FilterRule{},
 				ProtectUntilExpire: true,
 			},
 			when:   map[string]string{CloudNukeAfterExclusionTagKey: timeIn2h.Format(time.RFC3339)},
@@ -460,7 +370,6 @@ func TestShouldIncludeBasedOnTag(t *testing.T) {
 		{
 			name: "should include resource when protection expired in the past",
 			given: arg{
-				ExcludeRule:        FilterRule{},
 				ProtectUntilExpire: true,
 			},
 			when:   map[string]string{CloudNukeAfterExclusionTagKey: time.Now().Format(time.RFC3339)},

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,23 @@ s3:
   timeout: 10m
 ```
 
+### protect_until_expire
+
+Enable time-based protection using the `cloud-nuke-after` tag. When enabled, resources tagged with `cloud-nuke-after` and a future timestamp will be protected from deletion until that time passes.
+
+```yaml
+EC2:
+  protect_until_expire: true
+```
+
+To protect a resource, tag it with `cloud-nuke-after` and an RFC 3339 timestamp:
+
+```
+cloud-nuke-after = 2026-06-01T00:00:00Z
+```
+
+The resource will be excluded from deletion until after `2026-06-01T00:00:00Z`. Once the timestamp passes, the resource becomes eligible for deletion again.
+
 ## Exclusion Tag
 
 By default, resources tagged with `cloud-nuke-excluded` are excluded from deletion.

--- a/docs/supported-resources.md
+++ b/docs/supported-resources.md
@@ -4,12 +4,12 @@ cloud-nuke supports inspecting and deleting the following AWS resources. The **C
 
 | CLI ID | Resource |
 |---|---|
-| `accessanalyzer` | IAM Access Analyzer |
+| `access-analyzer` | IAM Access Analyzer |
 | `acm` | ACM Certificate |
 | `acmpca` | ACM Private CA |
 | `ami` | EC2 AMI |
-| `apigateway` | API Gateway (v1) |
-| `apigatewayv2` | API Gateway (v2) |
+| `api-gateway` | API Gateway (v1) |
+| `api-gateway-v2` | API Gateway (v2) |
 | `app-runner-service` | App Runner Service |
 | `asg` | Auto Scaling Group |
 | `backup-vault` | Backup Vault |
@@ -28,6 +28,7 @@ cloud-nuke supports inspecting and deleting the following AWS resources. The **C
 | `data-sync-task` | DataSync Task |
 | `dynamodb` | DynamoDB Table |
 | `ebs` | EBS Volume |
+| `ebs-snapshot` | EBS Snapshot |
 | `ec2` | EC2 Instance |
 | `ec2-dedicated-hosts` | EC2 Dedicated Host |
 | `ec2-dhcp-option` | EC2 DHCP Option Set |
@@ -36,17 +37,17 @@ cloud-nuke supports inspecting and deleting the following AWS resources. The **C
 | `ec2-placement-groups` | EC2 Placement Group |
 | `ec2-subnet` | EC2 Subnet |
 | `ecr` | ECR Repository |
-| `ecscluster` | ECS Cluster |
-| `ecsserv` | ECS Service |
+| `ecs-cluster` | ECS Cluster |
+| `ecs-service` | ECS Service |
 | `efs` | EFS File System |
 | `egress-only-internet-gateway` | Egress Only Internet Gateway |
 | `eip` | Elastic IP |
-| `ekscluster` | EKS Cluster |
+| `eks-cluster` | EKS Cluster |
 | `elastic-beanstalk` | Elastic Beanstalk Application |
 | `elasticache` | ElastiCache Cluster |
-| `elasticacheParameterGroups` | ElastiCache Parameter Group |
-| `elasticacheSubnetGroups` | ElastiCache Subnet Group |
-| `elasticcache-serverless` | ElastiCache Serverless Cluster |
+| `elasticache-parameter-group` | ElastiCache Parameter Group |
+| `elasticache-serverless` | ElastiCache Serverless Cluster |
+| `elasticache-subnet-group` | ElastiCache Subnet Group |
 | `elb` | Classic Load Balancer |
 | `elbv2` | Application/Network Load Balancer |
 | `event-bridge` | EventBridge Bus |
@@ -55,13 +56,13 @@ cloud-nuke supports inspecting and deleting the following AWS resources. The **C
 | `event-bridge-schedule` | EventBridge Schedule |
 | `event-bridge-schedule-group` | EventBridge Schedule Group |
 | `grafana` | Grafana Workspace |
-| `guardduty` | GuardDuty Detector |
-| `iam` | IAM User |
+| `guard-duty` | GuardDuty Detector |
 | `iam-group` | IAM Group |
 | `iam-instance-profile` | IAM Instance Profile |
 | `iam-policy` | IAM Policy |
 | `iam-role` | IAM Role |
 | `iam-service-linked-role` | IAM Service-linked Role |
+| `iam-user` | IAM User |
 | `internet-gateway` | Internet Gateway |
 | `ipam` | EC2 IPAM |
 | `ipam-byoasn` | EC2 IPAM BYOASN |
@@ -71,11 +72,11 @@ cloud-nuke supports inspecting and deleting the following AWS resources. The **C
 | `ipam-scope` | EC2 IPAM Scope |
 | `kinesis-firehose` | Kinesis Firehose |
 | `kinesis-stream` | Kinesis Stream |
-| `kmscustomerkeys` | KMS Customer Managed Key |
+| `kms-customer-key` | KMS Customer Managed Key |
 | `lambda` | Lambda Function |
-| `lambda_layer` | Lambda Layer |
-| `lc` | Launch Configuration |
-| `lt` | Launch Template |
+| `lambda-layer` | Lambda Layer |
+| `launch-configuration` | Launch Configuration |
+| `launch-template` | Launch Template |
 | `macie-member` | Macie Member Account |
 | `managed-prometheus` | Managed Prometheus Workspace |
 | `msk-cluster` | MSK Cluster |
@@ -87,30 +88,31 @@ cloud-nuke supports inspecting and deleting the following AWS resources. The **C
 | `network-firewall-rule-group` | Network Firewall Rule Group |
 | `network-firewall-tls-config` | Network Firewall TLS Config |
 | `network-interface` | Network Interface |
-| `oidcprovider` | OIDC Provider |
-| `opensearchdomain` | OpenSearch Domain |
-| `rds` | RDS DB Instance (incl. Neptune, DocumentDB) |
+| `oidc-provider` | OIDC Provider |
+| `opensearch-domain` | OpenSearch Domain |
 | `rds-cluster` | RDS DB Cluster |
 | `rds-global-cluster` | RDS Global Cluster |
 | `rds-global-cluster-membership` | RDS Global Cluster Membership |
+| `rds-instance` | RDS DB Instance (incl. Neptune, DocumentDB) |
 | `rds-parameter-group` | RDS Parameter Group |
 | `rds-proxy` | RDS Proxy |
 | `rds-snapshot` | RDS Snapshot |
 | `rds-subnet-group` | RDS Subnet Group |
 | `redshift` | Redshift Cluster |
 | `redshift-snapshot-copy-grant` | Redshift Snapshot Copy Grant |
+| `route-table` | Route Table |
 | `route53-cidr-collection` | Route53 CIDR Collection |
 | `route53-hosted-zone` | Route53 Hosted Zone |
 | `route53-traffic-policy` | Route53 Traffic Policy |
 | `s3` | S3 Bucket |
-| `s3-ap` | S3 Access Point |
-| `s3-mrap` | S3 Multi Region Access Point |
-| `s3-olap` | S3 Object Lambda Access Point |
+| `s3-access-point` | S3 Access Point |
+| `s3-multi-region-access-point` | S3 Multi Region Access Point |
+| `s3-object-lambda-access-point` | S3 Object Lambda Access Point |
 | `sagemaker-endpoint` | SageMaker Endpoint |
 | `sagemaker-endpoint-config` | SageMaker Endpoint Configuration |
-| `sagemaker-notebook-smni` | SageMaker Notebook Instance |
+| `sagemaker-notebook-instance` | SageMaker Notebook Instance |
 | `sagemaker-studio` | SageMaker Studio Domain |
-| `secretsmanager` | Secrets Manager Secret |
+| `secrets-manager` | Secrets Manager Secret |
 | `security-group` | Security Group |
 | `security-hub` | Security Hub |
 | `ses-configuration-set` | SES Configuration Set |
@@ -118,8 +120,7 @@ cloud-nuke supports inspecting and deleting the following AWS resources. The **C
 | `ses-identity` | SES Identity |
 | `ses-receipt-filter` | SES Receipt Filter |
 | `ses-receipt-rule-set` | SES Receipt Rule Set |
-| `snap` | EBS Snapshot |
-| `snstopic` | SNS Topic |
+| `sns-topic` | SNS Topic |
 | `sqs` | SQS Queue |
 | `transit-gateway` | Transit Gateway |
 | `transit-gateway-attachment` | Transit Gateway VPC Attachment |
@@ -129,8 +130,9 @@ cloud-nuke supports inspecting and deleting the following AWS resources. The **C
 | `vpc-lattice-service` | VPC Lattice Service |
 | `vpc-lattice-service-network` | VPC Lattice Service Network |
 | `vpc-lattice-target-group` | VPC Lattice Target Group |
+| `vpc-peering-connection` | VPC Peering Connection |
 
-> **WARNING:** The RDS APIs also interact with Neptune and DocumentDB resources. Running `cloud-nuke aws --resource-type rds` without a config file will remove any Neptune and DocumentDB resources in the account.
+> **WARNING:** The RDS APIs also interact with Neptune and DocumentDB resources. Running `cloud-nuke aws --resource-type rds-instance` without a config file will remove any Neptune and DocumentDB resources in the account.
 
 > **NOTE:** Resources created by AWS Backup are managed by AWS Backup and cannot be deleted through standard API calls. These resources are tagged by AWS Backup and are automatically filtered out by cloud-nuke.
 
@@ -140,21 +142,23 @@ This table shows which filtering features are supported for each resource type i
 
 | Resource Type | Config Key | names_regex | time | tags | timeout |
 |---|---|---|---|---|---|
+| access-analyzer | AccessAnalyzer | ✓ | ✓ | | ✓ |
 | acm | ACM | ✓ | ✓ | | ✓ |
 | acmpca | ACMPCA | | ✓ | | ✓ |
 | ami | AMI | ✓ | ✓ | | ✓ |
-| apigateway | APIGateway | ✓ | ✓ | | ✓ |
-| apigatewayv2 | APIGatewayV2 | ✓ | ✓ | | ✓ |
-| accessanalyzer | AccessAnalyzer | ✓ | ✓ | | ✓ |
-| asg | AutoScalingGroup | ✓ | ✓ | ✓ | ✓ |
+| api-gateway | APIGateway | ✓ | ✓ | | ✓ |
+| api-gateway-v2 | APIGatewayV2 | ✓ | ✓ | | ✓ |
 | app-runner-service | AppRunnerService | ✓ | ✓ | | ✓ |
+| asg | AutoScalingGroup | ✓ | ✓ | ✓ | ✓ |
 | backup-vault | BackupVault | ✓ | ✓ | | ✓ |
+| cloudformation-stack | CloudFormationStack | ✓ | ✓ | ✓ | ✓ |
+| cloudfront-distribution | CloudfrontDistribution | | | | ✓ |
+| cloudmap-namespace | CloudMapNamespace | ✓ | ✓ | ✓ | ✓ |
+| cloudmap-service | CloudMapService | ✓ | ✓ | ✓ | ✓ |
+| cloudtrail | CloudtrailTrail | ✓ | | ✓ | ✓ |
 | cloudwatch-alarm | CloudWatchAlarm | ✓ | ✓ | | ✓ |
 | cloudwatch-dashboard | CloudWatchDashboard | ✓ | ✓ | | ✓ |
 | cloudwatch-loggroup | CloudWatchLogGroup | ✓ | ✓ | | ✓ |
-| cloudtrail | CloudtrailTrail | ✓ | | ✓ | ✓ |
-| cloudmap-namespace | CloudMapNamespace | ✓ | ✓ | ✓ | ✓ |
-| cloudmap-service | CloudMapService | ✓ | ✓ | ✓ | ✓ |
 | codedeploy-application | CodeDeployApplications | ✓ | ✓ | | ✓ |
 | config-recorders | ConfigServiceRecorder | ✓ | | | ✓ |
 | config-rules | ConfigServiceRule | ✓ | | | ✓ |
@@ -162,109 +166,109 @@ This table shows which filtering features are supported for each resource type i
 | data-sync-task | DataSyncTask | ✓ | | | ✓ |
 | dynamodb | DynamoDB | ✓ | ✓ | | ✓ |
 | ebs | EBSVolume | ✓ | ✓ | ✓ | ✓ |
-| elastic-beanstalk | ElasticBeanstalk | ✓ | ✓ | | ✓ |
+| ebs-snapshot | Snapshots | | ✓ | ✓ | ✓ |
 | ec2 | EC2 | ✓ | ✓ | ✓ | ✓ |
 | ec2-dedicated-hosts | EC2DedicatedHosts | ✓ | ✓ | | ✓ |
 | ec2-dhcp-option | EC2DhcpOption | | | | ✓ |
+| ec2-endpoint | EC2Endpoint | ✓ | ✓ | ✓ | ✓ |
 | ec2-keypairs | EC2KeyPairs | ✓ | ✓ | ✓ | ✓ |
-| ipam | EC2IPAM | ✓ | ✓ | ✓ | ✓ |
-| ipam-pool | EC2IPAMPool | ✓ | ✓ | ✓ | ✓ |
-| ipam-resource-discovery | EC2IPAMResourceDiscovery | ✓ | ✓ | ✓ | ✓ |
-| ipam-scope | EC2IPAMScope | ✓ | ✓ | ✓ | ✓ |
 | ec2-placement-groups | EC2PlacementGroups | ✓ | ✓ | ✓ | ✓ |
 | ec2-subnet | EC2Subnet | ✓ | ✓ | ✓ | |
-| ec2-endpoint | EC2Endpoint | ✓ | ✓ | ✓ | ✓ |
 | ecr | ECRRepository | ✓ | ✓ | | ✓ |
-| ecscluster | ECSCluster | ✓ | ✓ | ✓ | ✓ |
-| ecsserv | ECSService | ✓ | ✓ | ✓ | ✓ |
-| ekscluster | EKSCluster | ✓ | ✓ | ✓ | ✓ |
+| ecs-cluster | ECSCluster | ✓ | ✓ | ✓ | ✓ |
+| ecs-service | ECSService | ✓ | ✓ | ✓ | ✓ |
+| efs | ElasticFileSystem | ✓ | ✓ | | ✓ |
+| egress-only-internet-gateway | EgressOnlyInternetGateway | ✓ | ✓ | ✓ | ✓ |
+| eip | ElasticIP | ✓ | ✓ | ✓ | ✓ |
+| eks-cluster | EKSCluster | ✓ | ✓ | ✓ | ✓ |
+| elastic-beanstalk | ElasticBeanstalk | ✓ | ✓ | | ✓ |
+| elasticache | Elasticache | ✓ | ✓ | | ✓ |
+| elasticache-parameter-group | ElasticacheParameterGroups | ✓ | | | ✓ |
+| elasticache-serverless | ElasticCacheServerless | ✓ | ✓ | | ✓ |
+| elasticache-subnet-group | ElasticacheSubnetGroups | ✓ | | | ✓ |
 | elb | ELBv1 | ✓ | ✓ | | ✓ |
 | elbv2 | ELBv2 | ✓ | ✓ | | ✓ |
-| efs | ElasticFileSystem | ✓ | ✓ | | ✓ |
-| eip | ElasticIP | ✓ | ✓ | ✓ | ✓ |
-| elasticache | Elasticache | ✓ | ✓ | | ✓ |
-| elasticcache-serverless | ElasticCacheServerless | ✓ | ✓ | | ✓ |
-| elasticacheparametergroups | ElasticacheParameterGroups | ✓ | | | ✓ |
-| elasticachesubnetgroups | ElasticacheSubnetGroups | ✓ | | | ✓ |
 | event-bridge | EventBridge | ✓ | ✓ | | ✓ |
 | event-bridge-archive | EventBridgeArchive | ✓ | ✓ | | ✓ |
 | event-bridge-rule | EventBridgeRule | ✓ | | | ✓ |
 | event-bridge-schedule | EventBridgeSchedule | ✓ | ✓ | | ✓ |
 | event-bridge-schedule-group | EventBridgeScheduleGroup | ✓ | ✓ | | ✓ |
 | grafana | Grafana | ✓ | ✓ | ✓ | ✓ |
-| guardduty | GuardDuty | | ✓ | | ✓ |
+| guard-duty | GuardDuty | | ✓ | | ✓ |
 | iam-group | IAMGroups | ✓ | ✓ | | ✓ |
+| iam-instance-profile | IAMInstanceProfiles | ✓ | ✓ | ✓ | ✓ |
 | iam-policy | IAMPolicies | ✓ | ✓ | ✓ | ✓ |
 | iam-role | IAMRoles | ✓ | ✓ | ✓ | ✓ |
 | iam-service-linked-role | IAMServiceLinkedRoles | ✓ | ✓ | | ✓ |
-| iam | IAMUsers | ✓ | ✓ | ✓ | ✓ |
+| iam-user | IAMUsers | ✓ | ✓ | ✓ | ✓ |
 | internet-gateway | InternetGateway | ✓ | ✓ | ✓ | ✓ |
-| egress-only-internet-gateway | EgressOnlyInternetGateway | ✓ | ✓ | ✓ | ✓ |
-| kmscustomerkeys | KMSCustomerKeys | ✓ | ✓ | | |
-| kinesis-stream | KinesisStream | ✓ | | | ✓ |
+| ipam | EC2IPAM | ✓ | ✓ | ✓ | ✓ |
+| ipam-byoasn | EC2IPAMByoasn | | | | ✓ |
+| ipam-custom-allocation | EC2IPAMCustomAllocation | | | | ✓ |
+| ipam-pool | EC2IPAMPool | ✓ | ✓ | ✓ | ✓ |
+| ipam-resource-discovery | EC2IPAMResourceDiscovery | ✓ | ✓ | ✓ | ✓ |
+| ipam-scope | EC2IPAMScope | ✓ | ✓ | ✓ | ✓ |
 | kinesis-firehose | KinesisFirehose | ✓ | | | ✓ |
+| kinesis-stream | KinesisStream | ✓ | | | ✓ |
+| kms-customer-key | KMSCustomerKeys | ✓ | ✓ | | |
 | lambda | LambdaFunction | ✓ | ✓ | ✓ | ✓ |
-| lc | LaunchConfiguration | ✓ | ✓ | | ✓ |
-| lt | LaunchTemplate | ✓ | ✓ | ✓ | ✓ |
+| lambda-layer | LambdaLayer | ✓ | ✓ | | ✓ |
+| launch-configuration | LaunchConfiguration | ✓ | ✓ | | ✓ |
+| launch-template | LaunchTemplate | ✓ | ✓ | ✓ | ✓ |
 | macie-member | MacieMember | | ✓ | | ✓ |
-| msk-cluster | MSKCluster | ✓ | ✓ | | ✓ |
 | managed-prometheus | ManagedPrometheus | ✓ | ✓ | ✓ | ✓ |
+| msk-cluster | MSKCluster | ✓ | ✓ | | ✓ |
 | nat-gateway | NatGateway | ✓ | ✓ | ✓ | ✓ |
 | network-acl | NetworkACL | ✓ | ✓ | ✓ | ✓ |
+| network-firewall | NetworkFirewall | ✓ | ✓ | ✓ | |
+| network-firewall-policy | NetworkFirewallPolicy | ✓ | ✓ | ✓ | |
+| network-firewall-resource-policy | NetworkFirewallResourcePolicy | ✓ | | | |
+| network-firewall-rule-group | NetworkFirewallRuleGroup | ✓ | ✓ | ✓ | |
+| network-firewall-tls-config | NetworkFirewallTLSConfig | ✓ | ✓ | ✓ | |
 | network-interface | NetworkInterface | ✓ | ✓ | ✓ | ✓ |
-| oidcprovider | OIDCProvider | ✓ | ✓ | | ✓ |
-| opensearchdomain | OpenSearchDomain | ✓ | ✓ | | ✓ |
-| redshift | Redshift | ✓ | ✓ | | ✓ |
+| oidc-provider | OIDCProvider | ✓ | ✓ | | ✓ |
+| opensearch-domain | OpenSearchDomain | ✓ | ✓ | | ✓ |
 | rds-cluster | DBClusters | ✓ | ✓ | ✓ | ✓ |
-| rds | DBInstances | ✓ | ✓ | ✓ | ✓ |
+| rds-global-cluster | DBGlobalClusters | ✓ | | | ✓ |
+| rds-global-cluster-membership | DBGlobalClusterMemberships | ✓ | | | ✓ |
+| rds-instance | DBInstances | ✓ | ✓ | ✓ | ✓ |
 | rds-parameter-group | RdsParameterGroup | ✓ | | | ✓ |
-| rds-subnet-group | DBSubnetGroups | ✓ | | | ✓ |
 | rds-proxy | RDSProxy | ✓ | ✓ | | ✓ |
+| rds-snapshot | RdsSnapshot | ✓ | ✓ | ✓ | ✓ |
+| rds-subnet-group | DBSubnetGroups | ✓ | | | ✓ |
+| redshift | Redshift | ✓ | ✓ | | ✓ |
+| redshift-snapshot-copy-grant | RedshiftSnapshotCopyGrant | ✓ | | | ✓ |
+| route-table | RouteTable | ✓ | ✓ | ✓ | ✓ |
+| route53-cidr-collection | Route53CIDRCollection | ✓ | | | |
+| route53-hosted-zone | Route53HostedZone | ✓ | | | |
+| route53-traffic-policy | Route53TrafficPolicy | ✓ | | | |
 | s3 | s3 | ✓ | ✓ | ✓ | ✓ |
-| s3-ap | s3AccessPoint | ✓ | | | ✓ |
-| s3-olap | S3ObjectLambdaAccessPoint | ✓ | | | ✓ |
-| s3-mrap | S3MultiRegionAccessPoint | ✓ | ✓ | | ✓ |
+| s3-access-point | s3AccessPoint | ✓ | | | ✓ |
+| s3-multi-region-access-point | S3MultiRegionAccessPoint | ✓ | ✓ | | ✓ |
+| s3-object-lambda-access-point | S3ObjectLambdaAccessPoint | ✓ | | | ✓ |
+| sagemaker-endpoint | SageMakerEndpoint | ✓ | ✓ | ✓ | ✓ |
+| sagemaker-endpoint-config | SageMakerEndpointConfig | ✓ | ✓ | ✓ | ✓ |
+| sagemaker-notebook-instance | SageMakerNotebook | ✓ | ✓ | | ✓ |
+| sagemaker-studio | SageMakerStudioDomain | ✓ | ✓ | ✓ | ✓ |
+| secrets-manager | SecretsManager | ✓ | ✓ | ✓ | ✓ |
 | security-group | SecurityGroup | ✓ | ✓ | ✓ | |
+| security-hub | SecurityHub | | ✓ | | ✓ |
 | ses-configuration-set | SesConfigurationset | ✓ | | | ✓ |
 | ses-email-template | SesEmailTemplates | ✓ | ✓ | | ✓ |
 | ses-identity | SesIdentity | ✓ | | | ✓ |
-| ses-receipt-rule-set | SesReceiptRuleSet | ✓ | ✓ | | ✓ |
 | ses-receipt-filter | SesReceiptFilter | ✓ | | | ✓ |
-| snstopic | SNS | ✓ | ✓ | | ✓ |
+| ses-receipt-rule-set | SesReceiptRuleSet | ✓ | ✓ | | ✓ |
+| sns-topic | SNS | ✓ | ✓ | | ✓ |
 | sqs | SQS | ✓ | ✓ | | ✓ |
-| sagemaker-notebook-smni | SageMakerNotebook | ✓ | ✓ | | ✓ |
-| sagemaker-endpoint | SageMakerEndpoint | ✓ | ✓ | ✓ | ✓ |
-| sagemaker-studio | SageMakerStudioDomain | | | | ✓ |
-| secretsmanager | SecretsManager | ✓ | ✓ | ✓ | ✓ |
-| security-hub | SecurityHub | | ✓ | | ✓ |
-| snap | Snapshots | | ✓ | ✓ | ✓ |
 | transit-gateway | TransitGateway | | ✓ | | ✓ |
-| transit-gateway-route-table | TransitGatewayRouteTable | | ✓ | | ✓ |
 | transit-gateway-attachment | TransitGatewaysVpcAttachment | | ✓ | | ✓ |
+| transit-gateway-peering-attachment | TransitGatewayPeeringAttachment | | ✓ | | ✓ |
+| transit-gateway-route-table | TransitGatewayRouteTable | | ✓ | | ✓ |
 | vpc | VPC | ✓ | ✓ | ✓ | |
-| route53-hosted-zone | Route53HostedZone | ✓ | | | |
-| route53-cidr-collection | Route53CIDRCollection | ✓ | | | |
-| route53-traffic-policy | Route53TrafficPolicy | ✓ | | | |
-| network-firewall | NetworkFirewall | ✓ | ✓ | ✓ | |
-| network-firewall-policy | NetworkFirewallPolicy | ✓ | ✓ | ✓ | |
-| network-firewall-rule-group | NetworkFirewallRuleGroup | ✓ | ✓ | ✓ | |
-| network-firewall-tls-config | NetworkFirewallTLSConfig | ✓ | ✓ | ✓ | |
-| network-firewall-resource-policy | NetworkFirewallResourcePolicy | ✓ | | | |
 | vpc-lattice-service | VPCLatticeService | ✓ | ✓ | | ✓ |
 | vpc-lattice-service-network | VPCLatticeServiceNetwork | ✓ | ✓ | | ✓ |
 | vpc-lattice-target-group | VPCLatticeTargetGroup | ✓ | ✓ | | ✓ |
-| cloudfront-distribution | CloudfrontDistribution | | | | ✓ |
-| cloudformation-stack | CloudFormationStack | ✓ | ✓ | ✓ | ✓ |
-| lambda_layer | LambdaLayer | ✓ | ✓ | | ✓ |
-| rds-global-cluster | DBGlobalClusters | ✓ | | | ✓ |
-| rds-global-cluster-membership | DBGlobalClusterMemberships | ✓ | | | ✓ |
-| rds-snapshot | RdsSnapshot | ✓ | ✓ | ✓ | ✓ |
-| redshift-snapshot-copy-grant | RedshiftSnapshotCopyGrant | ✓ | | | ✓ |
-| sagemaker-endpoint-config | SageMakerEndpointConfig | ✓ | ✓ | ✓ | ✓ |
-| iam-instance-profile | IAMInstanceProfiles | ✓ | ✓ | ✓ | ✓ |
-| transit-gateway-peering-attachment | TransitGatewayPeeringAttachment | | ✓ | | ✓ |
-| ipam-byoasn | EC2IPAMByoasn | | | | ✓ |
-| ipam-custom-allocation | EC2IPAMCustomAllocation | | | | ✓ |
+| vpc-peering-connection | VPCPeeringConnection | | ✓ | | ✓ |
 
 ## IsNukable Permission Check
 

--- a/gcp/resources/gcs_bucket.go
+++ b/gcp/resources/gcs_bucket.go
@@ -23,6 +23,8 @@ func NewGCSBuckets() GcpResource {
 			r.Scope.ProjectID = projectID
 			client, err := storage.NewClient(context.Background())
 			if err != nil {
+				// Panic is recovered by GcpResourceAdapter.Init() and stored as initErr,
+				// causing subsequent GetAndSetIdentifiers/Nuke calls to return the error gracefully.
 				panic(fmt.Sprintf("failed to create GCS client: %v", err))
 			}
 			r.Client = client

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -53,11 +53,6 @@ type Resource[C any] struct {
 	// Set based on AWS/GCP API rate limits for this resource type.
 	BatchSize int
 
-	// IsGlobal indicates whether this resource is global (true) or regional (false).
-	// Global resources (e.g., IAM, Route53) are only queried once, not per-region.
-	// Regional resources (e.g., EC2, S3) are queried for each target region.
-	IsGlobal bool
-
 	// InitClient initializes the client from cloud-specific config.
 	// For AWS: cfg is aws.Config
 	// For GCP: cfg is string (projectID)

--- a/util/tag.go
+++ b/util/tag.go
@@ -16,7 +16,9 @@ import (
 func ConvertS3TypesTagsToMap(tags []s3types.Tag) map[string]string {
 	tagMap := make(map[string]string)
 	for _, tag := range tags {
-		tagMap[*tag.Key] = *tag.Value
+		if tag.Key != nil && tag.Value != nil {
+			tagMap[*tag.Key] = *tag.Value
+		}
 	}
 
 	return tagMap
@@ -25,7 +27,9 @@ func ConvertS3TypesTagsToMap(tags []s3types.Tag) map[string]string {
 func ConvertTypesTagsToMap(tags []ec2types.Tag) map[string]string {
 	tagMap := make(map[string]string)
 	for _, tag := range tags {
-		tagMap[*tag.Key] = *tag.Value
+		if tag.Key != nil && tag.Value != nil {
+			tagMap[*tag.Key] = *tag.Value
+		}
 	}
 
 	return tagMap
@@ -33,7 +37,9 @@ func ConvertTypesTagsToMap(tags []ec2types.Tag) map[string]string {
 func ConvertSecretsManagerTagsToMap(tags []secretsmanagertypes.Tag) map[string]string {
 	tagMap := make(map[string]string)
 	for _, tag := range tags {
-		tagMap[*tag.Key] = *tag.Value
+		if tag.Key != nil && tag.Value != nil {
+			tagMap[*tag.Key] = *tag.Value
+		}
 	}
 
 	return tagMap
@@ -42,7 +48,9 @@ func ConvertSecretsManagerTagsToMap(tags []secretsmanagertypes.Tag) map[string]s
 func ConvertAutoScalingTagsToMap(tags []autoscaling.TagDescription) map[string]string {
 	tagMap := make(map[string]string)
 	for _, tag := range tags {
-		tagMap[*tag.Key] = *tag.Value
+		if tag.Key != nil && tag.Value != nil {
+			tagMap[*tag.Key] = *tag.Value
+		}
 	}
 
 	return tagMap
@@ -51,7 +59,9 @@ func ConvertAutoScalingTagsToMap(tags []autoscaling.TagDescription) map[string]s
 func ConvertStringPtrTagsToMap(tags map[string]*string) map[string]string {
 	tagMap := make(map[string]string)
 	for key, value := range tags {
-		tagMap[key] = *value
+		if value != nil {
+			tagMap[key] = *value
+		}
 	}
 
 	return tagMap
@@ -60,7 +70,9 @@ func ConvertStringPtrTagsToMap(tags map[string]*string) map[string]string {
 func ConvertIAMTagsToMap(tags []iam.Tag) map[string]string {
 	tagMap := make(map[string]string)
 	for _, tag := range tags {
-		tagMap[*tag.Key] = *tag.Value
+		if tag.Key != nil && tag.Value != nil {
+			tagMap[*tag.Key] = *tag.Value
+		}
 	}
 
 	return tagMap
@@ -69,7 +81,9 @@ func ConvertIAMTagsToMap(tags []iam.Tag) map[string]string {
 func ConvertRDSTypeTagsToMap(tags []rdstypes.Tag) map[string]string {
 	tagMap := make(map[string]string)
 	for _, tag := range tags {
-		tagMap[*tag.Key] = *tag.Value
+		if tag.Key != nil && tag.Value != nil {
+			tagMap[*tag.Key] = *tag.Value
+		}
 	}
 
 	return tagMap
@@ -87,7 +101,9 @@ func GetEC2ResourceNameTagValue(tags []ec2types.Tag) *string {
 func ConvertNetworkFirewallTagsToMap(tags []networkfirewalltypes.Tag) map[string]string {
 	tagMap := make(map[string]string)
 	for _, tag := range tags {
-		tagMap[*tag.Key] = *tag.Value
+		if tag.Key != nil && tag.Value != nil {
+			tagMap[*tag.Key] = *tag.Value
+		}
 	}
 
 	return tagMap
@@ -107,7 +123,9 @@ func ConvertSageMakerTagsToMap(tags []sagemakertypes.Tag) map[string]string {
 func ConvertRoute53TagsToMap(tags []route53types.Tag) map[string]string {
 	tagMap := make(map[string]string)
 	for _, tag := range tags {
-		tagMap[*tag.Key] = *tag.Value
+		if tag.Key != nil && tag.Value != nil {
+			tagMap[*tag.Key] = *tag.Value
+		}
 	}
 
 	return tagMap
@@ -116,7 +134,9 @@ func ConvertRoute53TagsToMap(tags []route53types.Tag) map[string]string {
 func ConvertCloudFormationTagsToMap(tags []cloudformationtypes.Tag) map[string]string {
 	tagMap := make(map[string]string)
 	for _, tag := range tags {
-		tagMap[*tag.Key] = *tag.Value
+		if tag.Key != nil && tag.Value != nil {
+			tagMap[*tag.Key] = *tag.Value
+		}
 	}
 
 	return tagMap


### PR DESCRIPTION
## Summary

Fixes issues identified during v1.0.0 release readiness review (32 files, net -110 lines):

- Fix ~25 wrong CLI resource IDs in docs (users would get `InvalidResourceTypesSuppliedError`)
- `NukeAllResources` now returns aggregated errors instead of always `nil`
- Pass real context instead of `context.TODO()` in nuke deletion path
- Fix SageMaker Studio `ConfigGetter` to return full config with filters
- GCP `--resource-type` flag now errors instead of being silently ignored
- Add `.env` to `.gitignore`
- Add 5-min timeout to IAM service-linked role deletion loop
- Add nil checks to all tag conversion functions
- Remove dead code: reflection-based `setRegionForRegionalResource`, no-op `PrepareContext`, duplicate constants, unused struct fields
- Remove deprecated `tag`/`tag_value` config fields
- Replace deprecated `ioutil.ReadFile` with `os.ReadFile`
- Catch `ThrottlingException` and `TooManyRequestsException` in rate limiting
- Document `protect_until_expire` in configuration docs

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run` — 0 issues
- [ ] Verify `--resource-type` flag with updated CLI IDs
- [ ] Verify non-zero exit code when deletions fail