### PR TITLE
chore: remove SecretsManager allowlist from nuke config

### DIFF
--- a/.github/nuke_config.yml
+++ b/.github/nuke_config.yml
@@ -45,17 +45,7 @@ S3:
       - "^test-s3-test-tg.*"
 
 SecretsManager:
-  include:
-    names_regex:
-      - "^test-name-[a-zA-Z0-9]{6}$"
-      - "^test-cloud-nuke-.*"
-      - ".*-lambda-docker-[a-zA-Z0-9]{6}$"
-      - "^test[a-zA-Z0-9]{6}-db-secret$"
-      - "^GruntworkSampleAppFrontendCA[a-zA-Z0-9]{6}$"
-      - "^GruntworkSampleAppBackendCA[a-zA-Z0-9]{6}$"
-      - "^RDSDBConfig[a-zA-Z0-9]{6}$"
-      - "ECRDeployRunnerTestSSHKey-[a-zA-Z0-9]{6}$"
-      - "ECRDeployRunnerTestGitPAT-[a-zA-Z0-9]{6}$"
+  # Delete all secrets - no filtering needed
 
 NATGateway:
   exclude:


### PR DESCRIPTION
## Summary
- Remove the SecretsManager `include` regex allowlist from `nuke_config.yml`
- cloud-nuke will now target all Secrets Manager secrets instead of only matching a narrow set of test patterns
- The old allowlist let ~123 stale secrets accumulate across 17 regions (~$49/mo waste)

## Test plan
- [x] Manually ran `cloud-nuke aws --resource-type secrets-manager --force` in phxdevops — all 247 secrets deleted successfully
- [x] Verified 0 secrets remain via `inspect-aws`