### PR TITLE
chore: broaden KMS key cleanup to delete all except dedicated-test-key

### DIFF
--- a/.github/nuke_config.yml
+++ b/.github/nuke_config.yml
@@ -234,9 +234,10 @@ IAMPolicies:
       - "^eks-service-catalog-[a-zA-Z0-9]{6}-k8s-cluster-autoscaler"
       - "^eks-service-catalog-[a-zA-Z0-9]{6}-k8s-external-dns"
 KMSCustomerKeys:
-  include:
+  exclude:
     names_regex:
-      - "^cloud-nuke-test-.*$"
+      # Shared test key referenced by multiple repos (terragrunt, terraform-aws-security, terraform-aws-eks, etc.)
+      - "^dedicated-test-key$"
 VPC:
   exclude:
     names_regex:


### PR DESCRIPTION
## Summary
- Switch KMS config from include filter (`cloud-nuke-test-*` only) to exclude filter (protect `dedicated-test-key` only)
- 77 orphaned customer-managed KMS keys exist across all 17 regions, costing ~$7/day (~$210/mo projected)
- Keys are test leftovers: `gwtest-macie-*`, `cloudtrail-*-trail`, `openvpn-server-*`, etc.
- `dedicated-test-key` is preserved as it's referenced by multiple repos (terragrunt, terraform-aws-security, terraform-aws-eks)

## Test plan
- [x] Verified none of the 77 keys have recent encrypt/decrypt usage
- [x] Confirmed `dedicated-test-key` is referenced across multiple Gruntwork repos
- [x] Dry-run cloud-nuke confirms all 77 keys are detected as nukable
- [ ] Monitor next scheduled nuke run