### PR TITLE
refactor: convert nuke_config from allowlist to blocklist

### DIFF
--- a/.github/nuke_config.yml
+++ b/.github/nuke_config.yml
@@ -165,6 +165,18 @@ InternetGateway:
       - "^gruntwork.*"
       - "^gw-.*"
 
+BackupVault:
+  exclude:
+    names_regex:
+      # AWS-managed EFS automatic backup vault (resource policy explicitly denies deletion)
+      - "^aws/efs/automatic-backup-vault$"
+
+CloudTrailTrail:
+  exclude:
+    names_regex:
+      # AWS Control Tower managed trail (cross-account, cannot be deleted)
+      - "^aws-controltower-BaselineCloudTrail$"
+
 Route53HostedZone:
   exclude:
     names_regex:


### PR DESCRIPTION
## Summary

Convert `nuke_config.yml` from `include` (allowlist) to `exclude` (blocklist) for 6 resource types, update cost-anomaly resource naming, and add excludes for undeletable AWS-managed resources.

### Allowlist → Blocklist conversion
- **S3**: 43 test patterns → 25 infrastructure exclusions (TF state, operational, websites, shared infra)
- **CloudWatchLogGroup**: 41 test patterns → 2 infrastructure exclusions
- **IAMGroups**: 36 test patterns → no filter (delete all, no infra groups exist)
- **IAMRoles**: 50 test patterns + 3 excludes → 18 infrastructure exclusions (OIDC, CI/CD, SSO, cross-account, SSM QuickSetup)
- **IAMPolicies**: 26 test patterns → 11 infrastructure exclusions
- **MSKCluster**: 3 test patterns → no filter (delete all, no MSK clusters exist)

### Cost anomaly alerting excludes
- Updated resource names from `cost-anomaly-to-slack` to `cost-anomaly-alerts-to-slack` (Lambda, IAM Role, CloudWatch)
- Added SecretsManager exclude for `cost-anomaly-alerts/*`

### Undeletable AWS-managed resource excludes
- **BackupVault**: `aws/efs/automatic-backup-vault` — resource policy explicitly denies deletion
- **CloudTrailTrail**: `aws-controltower-BaselineCloudTrail` — cross-account Control Tower trail

## Why

The old allowlist approach only deleted resources matching specific test naming patterns. Orphaned test resources with non-matching names were silently preserved. The blocklist defaults to "delete everything" and explicitly protects only infrastructure resources.

## Validation

Exclude lists validated against live resources in the phxdevops account:
- S3: ~350 test buckets successfully deleted, 0 infrastructure at risk
- IAM Roles: ~915 test roles correctly targeted, 0 infrastructure at risk
- IAM Policies: 1,904 test policies correctly targeted, 0 infrastructure at risk

## Test plan

- [x] Review exclude patterns against known infrastructure resources
- [x] Dry-run S3 cleanup to verify no infrastructure targeted
- [x] Live S3 cleanup completed successfully (~350 buckets deleted)
- [x] Verify CI/CD, SSO, and cost-anomaly resources are protected
- [x] Add excludes for AWS-managed resources that fail on deletion