### PR TITLE
fix: skip App Runner and Grafana in unsupported regions

### DIFF
--- a/aws/resources/apprunner_service.go
+++ b/aws/resources/apprunner_service.go
@@ -2,12 +2,21 @@ package resources
 
 import (
 	"context"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apprunner"
 	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/resource"
 )
+
+// AppRunnerAllowedRegions lists AWS regions where App Runner is supported.
+// Reference: https://docs.aws.amazon.com/general/latest/gr/apprunner.html
+var AppRunnerAllowedRegions = []string{
+	"us-east-1", "us-east-2", "us-west-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2",
+	"ap-northeast-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3",
+}
 
 // AppRunnerServiceAPI defines the interface for App Runner service operations.
 type AppRunnerServiceAPI interface {
@@ -34,6 +43,12 @@ func NewAppRunnerService() AwsResource {
 
 // listAppRunnerServices retrieves all App Runner services that match the config filters.
 func listAppRunnerServices(ctx context.Context, client AppRunnerServiceAPI, scope resource.Scope, cfg config.ResourceType) ([]*string, error) {
+	// Check if region supports App Runner
+	if !slices.Contains(AppRunnerAllowedRegions, scope.Region) {
+		logging.Debugf("Region %s is not allowed for App Runner", scope.Region)
+		return nil, nil
+	}
+
 	var identifiers []*string
 	paginator := apprunner.NewListServicesPaginator(client, &apprunner.ListServicesInput{
 		MaxResults: aws.Int32(20),

--- a/aws/resources/apprunner_service_test.go
+++ b/aws/resources/apprunner_service_test.go
@@ -41,14 +41,17 @@ func TestListAppRunnerServices(t *testing.T) {
 	}
 
 	tests := map[string]struct {
+		region    string
 		configObj config.ResourceType
 		expected  []string
 	}{
 		"emptyFilter": {
+			region:    "us-east-1",
 			configObj: config.ResourceType{},
 			expected:  []string{"arn::svc1", "arn::svc2"},
 		},
 		"nameExclusionFilter": {
+			region: "us-east-1",
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{RE: *regexp.MustCompile("svc1")}},
@@ -57,6 +60,7 @@ func TestListAppRunnerServices(t *testing.T) {
 			expected: []string{"arn::svc2"},
 		},
 		"timeAfterExclusionFilter": {
+			region: "us-east-1",
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now.Add(30 * time.Minute)),
@@ -64,11 +68,21 @@ func TestListAppRunnerServices(t *testing.T) {
 			},
 			expected: []string{"arn::svc1"},
 		},
+		"unsupportedRegion": {
+			region:    "af-south-1",
+			configObj: config.ResourceType{},
+			expected:  []string{},
+		},
+		"emptyRegion": {
+			region:    "",
+			configObj: config.ResourceType{},
+			expected:  []string{},
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			arns, err := listAppRunnerServices(context.Background(), mock, resource.Scope{}, tc.configObj)
+			arns, err := listAppRunnerServices(context.Background(), mock, resource.Scope{Region: tc.region}, tc.configObj)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, aws.ToStringSlice(arns))
 		})

--- a/aws/resources/grafana.go
+++ b/aws/resources/grafana.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/grafana"
@@ -10,6 +11,14 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/resource"
 )
+
+// GrafanaAllowedRegions lists AWS regions where Amazon Managed Grafana is supported.
+// Reference: https://docs.aws.amazon.com/general/latest/gr/grafana.html
+var GrafanaAllowedRegions = []string{
+	"us-east-1", "us-east-2", "us-west-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2",
+	"ap-northeast-1", "ap-northeast-2", "ca-central-1", "eu-central-1", "eu-north-1",
+	"eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1",
+}
 
 // GrafanaAPI defines the interface for Grafana operations.
 type GrafanaAPI interface {
@@ -36,6 +45,12 @@ func NewGrafana() AwsResource {
 
 // listGrafanaWorkspaces retrieves all Grafana Workspaces that match the config filters.
 func listGrafanaWorkspaces(ctx context.Context, client GrafanaAPI, scope resource.Scope, cfg config.ResourceType) ([]*string, error) {
+	// Check if region supports Grafana
+	if !slices.Contains(GrafanaAllowedRegions, scope.Region) {
+		logging.Debugf("Region %s is not allowed for Grafana", scope.Region)
+		return nil, nil
+	}
+
 	var workspaceIDs []*string
 
 	paginator := grafana.NewListWorkspacesPaginator(client, &grafana.ListWorkspacesInput{})

--- a/aws/resources/grafana_test.go
+++ b/aws/resources/grafana_test.go
@@ -32,11 +32,13 @@ func TestListGrafanaWorkspaces(t *testing.T) {
 
 	now := time.Now()
 	tests := map[string]struct {
+		region     string
 		workspaces []types.WorkspaceSummary
 		configObj  config.ResourceType
 		expected   []string
 	}{
 		"emptyFilter": {
+			region: "us-east-1",
 			workspaces: []types.WorkspaceSummary{
 				{Id: aws.String("ws1"), Name: aws.String("ws1"), Created: aws.Time(now), Status: types.WorkspaceStatusActive},
 				{Id: aws.String("ws2"), Name: aws.String("ws2"), Created: aws.Time(now), Status: types.WorkspaceStatusActive},
@@ -45,6 +47,7 @@ func TestListGrafanaWorkspaces(t *testing.T) {
 			expected:  []string{"ws1", "ws2"},
 		},
 		"nameExclusionFilter": {
+			region: "us-east-1",
 			workspaces: []types.WorkspaceSummary{
 				{Id: aws.String("ws1"), Name: aws.String("ws1"), Created: aws.Time(now), Status: types.WorkspaceStatusActive},
 				{Id: aws.String("skip-this"), Name: aws.String("skip-this"), Created: aws.Time(now), Status: types.WorkspaceStatusActive},
@@ -57,6 +60,7 @@ func TestListGrafanaWorkspaces(t *testing.T) {
 			expected: []string{"ws1"},
 		},
 		"skipsInactiveStatus": {
+			region: "us-east-1",
 			workspaces: []types.WorkspaceSummary{
 				{Id: aws.String("active"), Name: aws.String("active"), Created: aws.Time(now), Status: types.WorkspaceStatusActive},
 				{Id: aws.String("creating"), Name: aws.String("creating"), Created: aws.Time(now), Status: types.WorkspaceStatusCreating},
@@ -64,12 +68,25 @@ func TestListGrafanaWorkspaces(t *testing.T) {
 			configObj: config.ResourceType{},
 			expected:  []string{"active"},
 		},
+		"unsupportedRegion": {
+			region: "af-south-1",
+			workspaces: []types.WorkspaceSummary{
+				{Id: aws.String("ws1"), Name: aws.String("ws1"), Created: aws.Time(now), Status: types.WorkspaceStatusActive},
+			},
+			configObj: config.ResourceType{},
+			expected:  []string{},
+		},
+		"emptyRegion": {
+			region:    "",
+			configObj: config.ResourceType{},
+			expected:  []string{},
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			mock := &mockGrafanaClient{ListWorkspacesOutput: grafana.ListWorkspacesOutput{Workspaces: tc.workspaces}}
-			ids, err := listGrafanaWorkspaces(context.Background(), mock, resource.Scope{}, tc.configObj)
+			ids, err := listGrafanaWorkspaces(context.Background(), mock, resource.Scope{Region: tc.region}, tc.configObj)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, aws.ToStringSlice(ids))
 		})


### PR DESCRIPTION
## Summary
- Add region allowlists for App Runner (11 regions) and Grafana (15 regions)
- Listers early-return `nil, nil` in unsupported regions, preventing API errors during the nuke workflow
- Follows the existing SES email receiving pattern

## Test plan
- [x] `go test ./aws/resources/ -run TestListAppRunnerServices -v` — all 5 cases pass
- [x] `go test ./aws/resources/ -run TestListGrafanaWorkspaces -v` — all 6 cases pass
- [x] Verify nuke workflow no longer fails in unsupported regions (e.g. af-south-1)