### PR TITLE
fix: wait for VPC endpoint deletion and protect default subnets

### DIFF
--- a/aws/resources/ec2_endpoints.go
+++ b/aws/resources/ec2_endpoints.go
@@ -2,6 +2,8 @@ package resources
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -10,6 +12,7 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/resource"
 	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/gruntwork-io/go-commons/retry"
 )
 
 // EC2EndpointsAPI defines the interface for EC2 VPC Endpoints operations.
@@ -29,7 +32,7 @@ func NewEC2Endpoints() AwsResource {
 		}),
 		func(c config.Config) config.EC2ResourceType { return c.EC2Endpoint },
 		listEC2Endpoints,
-		resource.BulkDeleter(deleteEC2Endpoints),
+		resource.ConcurrentDeleteThenWaitAll(deleteEC2Endpoint, waitForEndpointsDeleted),
 		&EC2ResourceOptions[EC2EndpointsAPI]{PermissionVerifier: verifyEC2EndpointPermission},
 	)
 }
@@ -96,14 +99,78 @@ func listEC2Endpoints(ctx context.Context, client EC2EndpointsAPI, scope resourc
 	return result, nil
 }
 
-// deleteEC2Endpoints deletes VPC endpoints using the bulk delete API.
-func deleteEC2Endpoints(ctx context.Context, client EC2EndpointsAPI, ids []string) error {
-	logging.Debugf("Deleting VPC endpoints: %v", ids)
-
-	_, err := client.DeleteVpcEndpoints(ctx, &ec2.DeleteVpcEndpointsInput{
-		VpcEndpointIds: ids,
+// deleteEC2Endpoint deletes a single VPC endpoint.
+func deleteEC2Endpoint(ctx context.Context, client EC2EndpointsAPI, id *string) error {
+	resp, err := client.DeleteVpcEndpoints(ctx, &ec2.DeleteVpcEndpointsInput{
+		VpcEndpointIds: []string{aws.ToString(id)},
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	if resp != nil && len(resp.Unsuccessful) > 0 {
+		item := resp.Unsuccessful[0]
+		msg := "unknown error"
+		if item.Error != nil {
+			msg = aws.ToString(item.Error.Message)
+		}
+		return fmt.Errorf("failed to delete VPC endpoint %s: %s", aws.ToString(id), msg)
+	}
+	return nil
+}
+
+// waitForEndpointsDeleted waits for all VPC Endpoints to finish deleting.
+// VPC Endpoint deletion is asynchronous — the API returns immediately but ENIs
+// aren't released until the endpoint finishes deleting. Downstream resources like
+// subnets will fail with DependencyViolation if we don't wait.
+func waitForEndpointsDeleted(ctx context.Context, client EC2EndpointsAPI, ids []string) error {
+	idSet := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		idSet[id] = true
+	}
+
+	return retry.DoWithRetry(
+		logging.Logger.WithTime(time.Now()),
+		"Waiting for all VPC Endpoints to be deleted",
+		// Wait a maximum of 5 minutes: 10 seconds in between, up to 30 times
+		30, 10*time.Second,
+		func() error {
+			// Query by state filter only — not by ID. AWS removes fully-deleted
+			// endpoints from DescribeVpcEndpoints and returns NotFound if any ID
+			// in the batch is gone, which would cause false-success when other
+			// endpoints are still deleting.
+			input := &ec2.DescribeVpcEndpointsInput{
+				Filters: []types.Filter{
+					{
+						Name: aws.String("vpc-endpoint-state"),
+						Values: []string{
+							"pending",
+							"available",
+							"deleting",
+							"pendingAcceptance",
+						},
+					},
+				},
+			}
+
+			remaining := 0
+			paginator := ec2.NewDescribeVpcEndpointsPaginator(client, input)
+			for paginator.HasMorePages() {
+				page, err := paginator.NextPage(ctx)
+				if err != nil {
+					return retry.FatalError{Underlying: err}
+				}
+				for _, ep := range page.VpcEndpoints {
+					if idSet[aws.ToString(ep.VpcEndpointId)] {
+						remaining++
+					}
+				}
+			}
+			if remaining > 0 {
+				return fmt.Errorf("%d VPC Endpoints still deleting", remaining)
+			}
+			return nil
+		},
+	)
 }
 
 // verifyEC2EndpointPermission performs a dry-run delete to check permissions.

--- a/aws/resources/ec2_endpoints_test.go
+++ b/aws/resources/ec2_endpoints_test.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"testing"
 	"time"
@@ -16,16 +17,34 @@ import (
 )
 
 type mockEC2EndpointsClient struct {
-	DescribeVpcEndpointsOutput ec2.DescribeVpcEndpointsOutput
-	DeleteVpcEndpointsOutput   ec2.DeleteVpcEndpointsOutput
-	DescribeVpcsOutput         ec2.DescribeVpcsOutput
+	DescribeVpcEndpointsOutput  ec2.DescribeVpcEndpointsOutput
+	DescribeVpcEndpointsOutputs []ec2.DescribeVpcEndpointsOutput
+	DescribeVpcEndpointsError   error
+	describeCalls               int
+	DeleteVpcEndpointsOutput    ec2.DeleteVpcEndpointsOutput
+	DeleteVpcEndpointsError     error
+	DescribeVpcsOutput          ec2.DescribeVpcsOutput
 }
 
 func (m *mockEC2EndpointsClient) DescribeVpcEndpoints(ctx context.Context, params *ec2.DescribeVpcEndpointsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointsOutput, error) {
+	if len(m.DescribeVpcEndpointsOutputs) > 0 && len(params.Filters) > 0 {
+		idx := m.describeCalls
+		m.describeCalls++
+		if idx >= len(m.DescribeVpcEndpointsOutputs) {
+			idx = len(m.DescribeVpcEndpointsOutputs) - 1
+		}
+		return &m.DescribeVpcEndpointsOutputs[idx], nil
+	}
+	if len(params.Filters) > 0 && m.DescribeVpcEndpointsError != nil {
+		return nil, m.DescribeVpcEndpointsError
+	}
 	return &m.DescribeVpcEndpointsOutput, nil
 }
 
 func (m *mockEC2EndpointsClient) DeleteVpcEndpoints(ctx context.Context, params *ec2.DeleteVpcEndpointsInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVpcEndpointsOutput, error) {
+	if m.DeleteVpcEndpointsError != nil {
+		return nil, m.DeleteVpcEndpointsError
+	}
 	return &m.DeleteVpcEndpointsOutput, nil
 }
 
@@ -100,10 +119,81 @@ func TestListEC2Endpoints(t *testing.T) {
 	}
 }
 
-func TestDeleteEC2Endpoints(t *testing.T) {
+func TestDeleteEC2Endpoint(t *testing.T) {
 	t.Parallel()
 
-	mock := &mockEC2EndpointsClient{}
-	err := deleteEC2Endpoints(context.Background(), mock, []string{"vpce-12345", "vpce-67890"})
-	require.NoError(t, err)
+	t.Run("success", func(t *testing.T) {
+		mock := &mockEC2EndpointsClient{}
+		require.NoError(t, deleteEC2Endpoint(context.Background(), mock, aws.String("vpce-12345")))
+	})
+
+	t.Run("unsuccessful item", func(t *testing.T) {
+		mock := &mockEC2EndpointsClient{
+			DeleteVpcEndpointsOutput: ec2.DeleteVpcEndpointsOutput{
+				Unsuccessful: []types.UnsuccessfulItem{{
+					ResourceId: aws.String("vpce-12345"),
+					Error:      &types.UnsuccessfulItemError{Message: aws.String("endpoint is in use")},
+				}},
+			},
+		}
+		err := deleteEC2Endpoint(context.Background(), mock, aws.String("vpce-12345"))
+		require.ErrorContains(t, err, "endpoint is in use")
+	})
+
+	t.Run("unsuccessful item with nil error", func(t *testing.T) {
+		mock := &mockEC2EndpointsClient{
+			DeleteVpcEndpointsOutput: ec2.DeleteVpcEndpointsOutput{
+				Unsuccessful: []types.UnsuccessfulItem{{ResourceId: aws.String("vpce-12345")}},
+			},
+		}
+		err := deleteEC2Endpoint(context.Background(), mock, aws.String("vpce-12345"))
+		require.ErrorContains(t, err, "unknown error")
+	})
+
+	t.Run("api error", func(t *testing.T) {
+		mock := &mockEC2EndpointsClient{DeleteVpcEndpointsError: fmt.Errorf("api error")}
+		require.Error(t, deleteEC2Endpoint(context.Background(), mock, aws.String("vpce-12345")))
+	})
+}
+
+func TestWaitForEndpointsDeleted(t *testing.T) {
+	t.Parallel()
+
+	t.Run("already deleted", func(t *testing.T) {
+		mock := &mockEC2EndpointsClient{
+			DescribeVpcEndpointsOutputs: []ec2.DescribeVpcEndpointsOutput{
+				{VpcEndpoints: []types.VpcEndpoint{}},
+			},
+		}
+		require.NoError(t, waitForEndpointsDeleted(context.Background(), mock, []string{"vpce-12345"}))
+	})
+
+	t.Run("deleting then deleted", func(t *testing.T) {
+		mock := &mockEC2EndpointsClient{
+			DescribeVpcEndpointsOutputs: []ec2.DescribeVpcEndpointsOutput{
+				{VpcEndpoints: []types.VpcEndpoint{{VpcEndpointId: aws.String("vpce-12345"), State: "deleting"}}},
+				{VpcEndpoints: []types.VpcEndpoint{}},
+			},
+		}
+		require.NoError(t, waitForEndpointsDeleted(context.Background(), mock, []string{"vpce-12345"}))
+		require.GreaterOrEqual(t, mock.describeCalls, 2)
+	})
+
+	t.Run("ignores unrelated endpoints", func(t *testing.T) {
+		mock := &mockEC2EndpointsClient{
+			DescribeVpcEndpointsOutputs: []ec2.DescribeVpcEndpointsOutput{
+				// Unrelated endpoint still deleting — ours is gone
+				{VpcEndpoints: []types.VpcEndpoint{{VpcEndpointId: aws.String("vpce-other"), State: "deleting"}}},
+			},
+		}
+		require.NoError(t, waitForEndpointsDeleted(context.Background(), mock, []string{"vpce-12345"}))
+	})
+
+	t.Run("api error is fatal", func(t *testing.T) {
+		mock := &mockEC2EndpointsClient{
+			DescribeVpcEndpointsError: fmt.Errorf("throttling"),
+		}
+		require.Error(t, waitForEndpointsDeleted(context.Background(), mock, []string{"vpce-12345"}))
+		require.Equal(t, 0, mock.describeCalls, "FatalError should stop retries after first attempt")
+	})
 }

--- a/aws/resources/ec2_subnet.go
+++ b/aws/resources/ec2_subnet.go
@@ -59,6 +59,13 @@ func listEC2Subnets(ctx context.Context, client EC2SubnetAPI, scope resource.Sco
 		}
 
 		for _, subnet := range page.Subnets {
+			// Skip default subnets when not explicitly targeting them.
+			// The defaults-aws command sets defaultOnly=true to target these;
+			// the regular aws command should leave them alone.
+			if !defaultOnly && aws.ToBool(subnet.DefaultForAz) {
+				continue
+			}
+
 			tagMap := util.ConvertTypesTagsToMap(subnet.Tags)
 
 			// Get first seen time from tags
@@ -99,7 +106,7 @@ func verifyEC2SubnetPermission(ctx context.Context, client EC2SubnetAPI, id *str
 		SubnetId: id,
 		DryRun:   aws.Bool(true),
 	})
-	return err
+	return util.TransformAWSError(err)
 }
 
 // deleteSubnet deletes a single EC2 Subnet.

--- a/aws/resources/ec2_subnet_test.go
+++ b/aws/resources/ec2_subnet_test.go
@@ -86,6 +86,25 @@ func TestListEC2Subnets_WithFilter(t *testing.T) {
 	require.Equal(t, []string{"subnet-001"}, aws.ToStringSlice(ids))
 }
 
+func TestListEC2Subnets_SkipsDefaultSubnets(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEC2SubnetClient{
+		DescribeOutput: ec2.DescribeSubnetsOutput{
+			Subnets: []types.Subnet{
+				{SubnetId: aws.String("subnet-default"), DefaultForAz: aws.Bool(true)},
+				{SubnetId: aws.String("subnet-custom"), DefaultForAz: aws.Bool(false)},
+				{SubnetId: aws.String("subnet-nil")}, // DefaultForAz unset (nil)
+			},
+		},
+	}
+
+	// defaultOnly=false: default subnets are skipped, non-default and nil are kept
+	ids, err := listEC2Subnets(context.Background(), mock, resource.Scope{}, config.ResourceType{}, false)
+	require.NoError(t, err)
+	require.Equal(t, []string{"subnet-custom", "subnet-nil"}, aws.ToStringSlice(ids))
+}
+
 func TestDeleteSubnet(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- **VPC endpoint wait**: Convert `ec2-endpoint` from `BulkDeleter` to `ConcurrentDeleteThenWaitAll` with paginated polling (5 min max). Prevents `DependencyViolation` on downstream subnet deletion caused by lingering ENIs from async endpoint teardown.
- **Unsuccessful check**: Surface per-item `DeleteVpcEndpoints` failures immediately instead of silently timing out in the wait loop.
- **Default subnet protection**: Skip default subnets (`DefaultForAz=true`) in the regular `aws` nuke command. The `defaults-aws` command still targets them.
- **Dry-run fix**: Add `TransformAWSError` to `verifyEC2SubnetPermission` for consistency with other permission verifiers.

## Test plan

- [x] `go build ./...`
- [x] `go test ./aws/resources/ -run TestEC2Endpoint -v` — 8 tests pass (delete success/error/unsuccessful, wait already-deleted/deleting-then-deleted/unrelated-endpoints/fatal-error)
- [x] `go test ./aws/resources/ -run TestListEC2Subnets -v` — 4 tests pass (list, filter, skip-defaults with true/false/nil DefaultForAz)
- [x] Dry-run verified: default subnets no longer listed by `aws` command
- [x] Live run: deleted 6 stale subnets in us-east-1 successfully, then recreated default subnets