### PR TITLE
fix: add defense-in-depth check to prevent default VPC deletion

### DIFF
--- a/aws/resources/ec2_subnet_test.go
+++ b/aws/resources/ec2_subnet_test.go
@@ -103,6 +103,11 @@ func TestListEC2Subnets_SkipsDefaultSubnets(t *testing.T) {
 	ids, err := listEC2Subnets(context.Background(), mock, resource.Scope{}, config.ResourceType{}, false)
 	require.NoError(t, err)
 	require.Equal(t, []string{"subnet-custom", "subnet-nil"}, aws.ToStringSlice(ids))
+
+	// defaultOnly=true (defaults-aws command): default subnets must be INCLUDED
+	ids, err = listEC2Subnets(context.Background(), mock, resource.Scope{}, config.ResourceType{}, true)
+	require.NoError(t, err)
+	require.Contains(t, aws.ToStringSlice(ids), "subnet-default")
 }
 
 func TestDeleteSubnet(t *testing.T) {

--- a/aws/resources/ec2_vpc.go
+++ b/aws/resources/ec2_vpc.go
@@ -76,6 +76,12 @@ func listVPCs(ctx context.Context, client EC2VpcAPI, scope resource.Scope, cfg c
 		}
 
 		for _, vpc := range page.Vpcs {
+			// Defense-in-depth: skip default VPCs when not explicitly targeting them,
+			// even though the API filter should already exclude them.
+			if !defaultOnly && aws.ToBool(vpc.IsDefault) {
+				continue
+			}
+
 			firstSeenTime, err := util.GetOrCreateFirstSeen(ctx, client, vpc.VpcId, util.ConvertTypesTagsToMap(vpc.Tags))
 			if err != nil {
 				logging.Errorf("Unable to retrieve first seen tag for VPC %s: %v", aws.ToString(vpc.VpcId), err)

--- a/aws/resources/ec2_vpc_test.go
+++ b/aws/resources/ec2_vpc_test.go
@@ -219,6 +219,50 @@ func TestListVPCs(t *testing.T) {
 	}
 }
 
+func TestListVPCs_SkipsDefaultVPC(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	mock := &mockEC2VpcClient{
+		DescribeVpcsOutput: ec2.DescribeVpcsOutput{
+			Vpcs: []types.Vpc{
+				{
+					VpcId:     aws.String("vpc-custom"),
+					IsDefault: aws.Bool(false),
+					Tags: []types.Tag{
+						{Key: aws.String(util.FirstSeenTagKey), Value: aws.String(util.FormatTimestamp(now))},
+					},
+				},
+				{
+					VpcId:     aws.String("vpc-default"),
+					IsDefault: aws.Bool(true),
+					Tags: []types.Tag{
+						{Key: aws.String(util.FirstSeenTagKey), Value: aws.String(util.FormatTimestamp(now))},
+					},
+				},
+				{
+					VpcId: aws.String("vpc-nil"), // IsDefault unset (nil) — treated as non-default
+					Tags: []types.Tag{
+						{Key: aws.String(util.FirstSeenTagKey), Value: aws.String(util.FormatTimestamp(now))},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
+
+	// defaultOnly=false: default VPC should be skipped, nil IsDefault treated as non-default
+	ids, err := listVPCs(ctx, mock, resource.Scope{Region: "us-east-1"}, config.ResourceType{}, false)
+	require.NoError(t, err)
+	require.Equal(t, []string{"vpc-custom", "vpc-nil"}, aws.ToStringSlice(ids))
+
+	// defaultOnly=true (defaults-aws command): default VPC must be INCLUDED
+	ids, err = listVPCs(ctx, mock, resource.Scope{Region: "us-east-1"}, config.ResourceType{}, true)
+	require.NoError(t, err)
+	require.Contains(t, aws.ToStringSlice(ids), "vpc-default")
+}
+
 func TestDeleteVPC(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add in-code `IsDefault` skip in `listVPCs()` as defense-in-depth, mirroring the existing pattern in `listEC2Subnets()`
- The API filter `is-default=false` is the primary guard, but if it ever fails, default VPCs could leak into the deletion pipeline
- Add `defaultOnly=true` test coverage for both VPC and subnet listers to prevent regressions that would break the `defaults-aws` command

## Test plan

- [x] `go test ./aws/resources/ -run TestListVPCs -v` — passes
- [x] `go test ./aws/resources/ -run TestListEC2Subnets -v` — passes
- [x] `go test ./aws/resources/ -run TestCleanupVPC -v` — passes
- [x] Run `defaults-aws` against a test account to verify default VPCs are still cleaned up