### PR TITLE
fix: resolve S3 MRAP and Grafana region errors

### DIFF
--- a/aws/resource_registry.go
+++ b/aws/resource_registry.go
@@ -53,6 +53,7 @@ func getRegisteredGlobalResources() []AwsResource {
 		resources.NewRoute53HostedZone(),
 		resources.NewRoute53CidrCollections(),
 		resources.NewRoute53TrafficPolicies(),
+		resources.NewS3MultiRegionAccessPoints(),
 		resources.NewS3Buckets(),
 	}
 }
@@ -140,7 +141,6 @@ func getRegisteredRegionalResources() []AwsResource {
 		resources.NewRedshiftSnapshotCopyGrants(),
 		resources.NewS3AccessPoints(),
 		resources.NewS3ObjectLambdaAccessPoints(),
-		resources.NewS3MultiRegionAccessPoints(),
 		resources.NewSageMakerNotebookInstances(),
 		resources.NewSageMakerStudio(),
 		resources.NewSageMakerEndpoint(),

--- a/aws/resources/grafana.go
+++ b/aws/resources/grafana.go
@@ -14,10 +14,12 @@ import (
 
 // GrafanaAllowedRegions lists AWS regions where Amazon Managed Grafana is supported.
 // Reference: https://docs.aws.amazon.com/general/latest/gr/grafana.html
+// Regions verified to have working Grafana endpoints as of 2026-03.
+// ap-south-1, ca-central-1, eu-north-1, eu-west-3, and sa-east-1 are listed
+// in the AWS docs but return DNS errors ("no such host") in practice.
 var GrafanaAllowedRegions = []string{
-	"us-east-1", "us-east-2", "us-west-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2",
-	"ap-northeast-1", "ap-northeast-2", "ca-central-1", "eu-central-1", "eu-north-1",
-	"eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1",
+	"us-east-1", "us-east-2", "us-west-2", "ap-southeast-1", "ap-southeast-2",
+	"ap-northeast-1", "ap-northeast-2", "eu-central-1", "eu-west-1", "eu-west-2",
 }
 
 // GrafanaAPI defines the interface for Grafana operations.

--- a/aws/resources/s3_multi_region_access_point.go
+++ b/aws/resources/s3_multi_region_access_point.go
@@ -29,6 +29,7 @@ func NewS3MultiRegionAccessPoints() AwsResource {
 		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[S3ControlMultiRegionAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
+			cfg.Region = "us-west-2" // MRAP control-plane requests must be routed to us-west-2
 			r.Client = s3control.NewFromConfig(cfg)
 		}),
 		ConfigGetter: func(c config.Config) config.ResourceType {


### PR DESCRIPTION
## Summary

Fixes `general_errors` from [run #22782039404](https://github.com/gruntwork-io/cloud-nuke/actions/runs/22782039404):

- **s3-multi-region-access-point**: Move to global resources and pin client to `us-west-2` — the only region that accepts MRAP control-plane requests. Eliminates `PermanentRedirect` in all 17 non-us-west-2 regions.
- **grafana**: Remove 5 regions (`ap-south-1`, `ca-central-1`, `eu-north-1`, `eu-west-3`, `sa-east-1`) from the allowlist — they return DNS errors (`no such host`) despite being listed in AWS docs.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./aws/resources/ -run TestS3MultiRegionAccessPoint` passing
- [x] `go test ./aws/resources/ -run TestListGrafana` passing
- [x] Full `aws/resources` test suite passing (no regressions)
- [x] Verified with real AWS credentials via `inspect-aws` — no errors for either resource type