### PR TITLE
fix: exclude AWS Control Tower resources from nuke config

### DIFF
--- a/.github/nuke_config.yml
+++ b/.github/nuke_config.yml
@@ -57,6 +57,8 @@ CloudWatchLogGroup:
     names_regex:
       - "^/aws/lambda/cost-anomaly-alerts-to-slack$"
       - "^/aws/lambda/ecs-deploy-runner-invoker$"
+      # AWS Control Tower managed log group (SCP denies deletion)
+      - "^/aws/lambda/aws-controltower-"
 
 IAMUsers:
   exclude:
@@ -132,12 +134,16 @@ SNS:
   exclude:
     names_regex:
       - "^cost-anomaly-alerts$"
+      # AWS Control Tower managed topic (SCP denies deletion)
+      - "aws-controltower-"
 
 LambdaFunction:
   exclude:
     names_regex:
       - "^ecs-deploy-runner-invoker"
       - "^cost-anomaly-alerts-to-slack$"
+      # AWS Control Tower managed function (SCP denies deletion)
+      - "^aws-controltower-"
 
 ACM:
   exclude:
@@ -176,6 +182,18 @@ CloudTrailTrail:
     names_regex:
       # AWS Control Tower managed trail (cross-account, cannot be deleted)
       - "^aws-controltower-BaselineCloudTrail$"
+
+EventBridge:
+  exclude:
+    names_regex:
+      # AWS Control Tower managed rule (SCP denies deletion)
+      - "aws-controltower-"
+
+ConfigServiceRecorder:
+  exclude:
+    names_regex:
+      # AWS Control Tower managed recorder (SCP denies deletion)
+      - "^aws-controltower-"
 
 Route53HostedZone:
   exclude:


### PR DESCRIPTION
## Summary

- Exclude `aws-controltower-*` resources from deletion in CI nuke runs
- These are AWS-managed Control Tower resources created automatically in enrolled accounts; an Organizations SCP denies their deletion, causing `AccessDeniedException` errors
- Adds exclude regex patterns for: **EventBridge**, **ConfigServiceRecorder**, **CloudWatchLogGroup**, **LambdaFunction**, and **SNS**

## Test plan

- [x] Review regex patterns match resource names from CI error logs
- [x] Next scheduled nuke run completes without Control Tower `AccessDeniedException` errors