### PR TITLE
feat: add AWS Data Pipeline support

### DIFF
--- a/aws/resource_registry.go
+++ b/aws/resource_registry.go
@@ -89,6 +89,7 @@ func getRegisteredRegionalResources() []AwsResource {
 		resources.NewCodeDeployApplications(),
 		resources.NewConfigServiceRecorders(),
 		resources.NewConfigServiceRules(),
+		resources.NewDataPipeline(),
 		resources.NewDataSyncTask(),
 		resources.NewDataSyncLocation(),
 		resources.NewDynamoDB(),

--- a/aws/resources/data_pipeline.go
+++ b/aws/resources/data_pipeline.go
@@ -1,0 +1,93 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/datapipeline"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/resource"
+	"github.com/gruntwork-io/cloud-nuke/util"
+)
+
+const describePipelinesBatchSize = 25
+
+type DataPipelineAPI interface {
+	ListPipelines(ctx context.Context, params *datapipeline.ListPipelinesInput, optFns ...func(*datapipeline.Options)) (*datapipeline.ListPipelinesOutput, error)
+	DescribePipelines(ctx context.Context, params *datapipeline.DescribePipelinesInput, optFns ...func(*datapipeline.Options)) (*datapipeline.DescribePipelinesOutput, error)
+	DeletePipeline(ctx context.Context, params *datapipeline.DeletePipelineInput, optFns ...func(*datapipeline.Options)) (*datapipeline.DeletePipelineOutput, error)
+}
+
+func NewDataPipeline() AwsResource {
+	return NewAwsResource(&resource.Resource[DataPipelineAPI]{
+		ResourceTypeName: "data-pipeline",
+		BatchSize:        20,
+		InitClient: WrapAwsInitClient(func(r *resource.Resource[DataPipelineAPI], cfg aws.Config) {
+			r.Scope.Region = cfg.Region
+			r.Client = datapipeline.NewFromConfig(cfg)
+		}),
+		ConfigGetter: func(c config.Config) config.ResourceType {
+			return c.DataPipeline
+		},
+		Lister: listDataPipelines,
+		Nuker:  resource.SimpleBatchDeleter(deleteDataPipeline),
+	})
+}
+
+func listDataPipelines(ctx context.Context, client DataPipelineAPI, scope resource.Scope, cfg config.ResourceType) ([]*string, error) {
+	var identifiers []*string
+
+	paginator := datapipeline.NewListPipelinesPaginator(client, &datapipeline.ListPipelinesInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		var pipelineIds []string
+		for _, p := range page.PipelineIdList {
+			pipelineIds = append(pipelineIds, aws.ToString(p.Id))
+		}
+		if len(pipelineIds) == 0 {
+			continue
+		}
+
+		// DescribePipelines accepts max 25 IDs per call
+		for i := 0; i < len(pipelineIds); i += describePipelinesBatchSize {
+			end := min(i+describePipelinesBatchSize, len(pipelineIds))
+
+			descOutput, err := client.DescribePipelines(ctx, &datapipeline.DescribePipelinesInput{
+				PipelineIds: pipelineIds[i:end],
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			for _, desc := range descOutput.PipelineDescriptionList {
+				pipelineID := aws.ToString(desc.PipelineId)
+				name := aws.ToString(desc.Name)
+
+				rv := config.ResourceValue{Name: &name}
+				for _, field := range desc.Fields {
+					if aws.ToString(field.Key) == "@creationTime" {
+						rv.Time, _ = util.ParseTimestamp(field.StringValue)
+						break
+					}
+				}
+
+				if cfg.ShouldInclude(rv) {
+					identifiers = append(identifiers, aws.String(pipelineID))
+				}
+			}
+		}
+	}
+
+	return identifiers, nil
+}
+
+func deleteDataPipeline(ctx context.Context, client DataPipelineAPI, pipelineID *string) error {
+	_, err := client.DeletePipeline(ctx, &datapipeline.DeletePipelineInput{
+		PipelineId: pipelineID,
+	})
+	return err
+}

--- a/aws/resources/data_pipeline_test.go
+++ b/aws/resources/data_pipeline_test.go
@@ -1,0 +1,160 @@
+package resources
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/datapipeline"
+	dptypes "github.com/aws/aws-sdk-go-v2/service/datapipeline/types"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/resource"
+	"github.com/stretchr/testify/require"
+)
+
+type mockDataPipelineClient struct {
+	ListPipelinesPages     []datapipeline.ListPipelinesOutput
+	DescribePipelinesPages []datapipeline.DescribePipelinesOutput
+	listCallIndex          int
+	describeCallIndex      int
+}
+
+func (m *mockDataPipelineClient) ListPipelines(ctx context.Context, params *datapipeline.ListPipelinesInput, optFns ...func(*datapipeline.Options)) (*datapipeline.ListPipelinesOutput, error) {
+	if m.listCallIndex >= len(m.ListPipelinesPages) {
+		return &datapipeline.ListPipelinesOutput{}, nil
+	}
+	output := m.ListPipelinesPages[m.listCallIndex]
+	m.listCallIndex++
+	return &output, nil
+}
+
+func (m *mockDataPipelineClient) DescribePipelines(ctx context.Context, params *datapipeline.DescribePipelinesInput, optFns ...func(*datapipeline.Options)) (*datapipeline.DescribePipelinesOutput, error) {
+	if m.describeCallIndex >= len(m.DescribePipelinesPages) {
+		return &datapipeline.DescribePipelinesOutput{}, nil
+	}
+	output := m.DescribePipelinesPages[m.describeCallIndex]
+	m.describeCallIndex++
+	return &output, nil
+}
+
+func (m *mockDataPipelineClient) DeletePipeline(ctx context.Context, params *datapipeline.DeletePipelineInput, optFns ...func(*datapipeline.Options)) (*datapipeline.DeletePipelineOutput, error) {
+	return &datapipeline.DeletePipelineOutput{}, nil
+}
+
+func TestListDataPipelines(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	nowStr := now.Format(time.RFC3339)
+	laterStr := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	twoItemDescribe := []datapipeline.DescribePipelinesOutput{{
+		PipelineDescriptionList: []dptypes.PipelineDescription{
+			{PipelineId: aws.String("df-001"), Name: aws.String("pipeline1"), Fields: []dptypes.Field{{Key: aws.String("@creationTime"), StringValue: aws.String(nowStr)}}},
+			{PipelineId: aws.String("df-002"), Name: aws.String("pipeline2"), Fields: []dptypes.Field{{Key: aws.String("@creationTime"), StringValue: aws.String(laterStr)}}},
+		},
+	}}
+
+	twoItemList := []datapipeline.ListPipelinesOutput{{
+		PipelineIdList: []dptypes.PipelineIdName{
+			{Id: aws.String("df-001"), Name: aws.String("pipeline1")},
+			{Id: aws.String("df-002"), Name: aws.String("pipeline2")},
+		},
+	}}
+
+	tests := map[string]struct {
+		mock      mockDataPipelineClient
+		configObj config.ResourceType
+		expected  []string
+	}{
+		"emptyFilter": {
+			mock:     mockDataPipelineClient{ListPipelinesPages: twoItemList, DescribePipelinesPages: twoItemDescribe},
+			expected: []string{"df-001", "df-002"},
+		},
+		"nameExclusionFilter": {
+			mock: mockDataPipelineClient{ListPipelinesPages: twoItemList, DescribePipelinesPages: twoItemDescribe},
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					NamesRegExp: []config.Expression{{RE: *regexp.MustCompile("pipeline1")}},
+				},
+			},
+			expected: []string{"df-002"},
+		},
+		"timeAfterExclusionFilter": {
+			mock: mockDataPipelineClient{ListPipelinesPages: twoItemList, DescribePipelinesPages: twoItemDescribe},
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					TimeAfter: aws.Time(now.Add(30 * time.Minute)),
+				},
+			},
+			expected: []string{"df-001"},
+		},
+		"noPipelines": {
+			mock: mockDataPipelineClient{
+				ListPipelinesPages: []datapipeline.ListPipelinesOutput{{PipelineIdList: []dptypes.PipelineIdName{}}},
+			},
+			expected: []string{},
+		},
+		"missingCreationTime": {
+			mock: mockDataPipelineClient{
+				ListPipelinesPages: []datapipeline.ListPipelinesOutput{{
+					PipelineIdList: []dptypes.PipelineIdName{{Id: aws.String("df-001"), Name: aws.String("pipeline1")}},
+				}},
+				DescribePipelinesPages: []datapipeline.DescribePipelinesOutput{{
+					PipelineDescriptionList: []dptypes.PipelineDescription{
+						{PipelineId: aws.String("df-001"), Name: aws.String("pipeline1"), Fields: []dptypes.Field{}},
+					},
+				}},
+			},
+			expected: []string{"df-001"},
+		},
+		"bareTimestamp": {
+			mock: mockDataPipelineClient{
+				ListPipelinesPages: []datapipeline.ListPipelinesOutput{{
+					PipelineIdList: []dptypes.PipelineIdName{{Id: aws.String("df-001"), Name: aws.String("pipeline1")}},
+				}},
+				DescribePipelinesPages: []datapipeline.DescribePipelinesOutput{{
+					PipelineDescriptionList: []dptypes.PipelineDescription{
+						{PipelineId: aws.String("df-001"), Name: aws.String("pipeline1"), Fields: []dptypes.Field{{Key: aws.String("@creationTime"), StringValue: aws.String("2015-01-01T00:00:00")}}},
+					},
+				}},
+			},
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					TimeAfter: aws.Time(time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)),
+				},
+			},
+			expected: []string{"df-001"},
+		},
+		"pagination": {
+			mock: mockDataPipelineClient{
+				ListPipelinesPages: []datapipeline.ListPipelinesOutput{
+					{PipelineIdList: []dptypes.PipelineIdName{{Id: aws.String("df-001"), Name: aws.String("pipeline1")}}, HasMoreResults: true, Marker: aws.String("token1")},
+					{PipelineIdList: []dptypes.PipelineIdName{{Id: aws.String("df-002"), Name: aws.String("pipeline2")}}},
+				},
+				DescribePipelinesPages: []datapipeline.DescribePipelinesOutput{
+					{PipelineDescriptionList: []dptypes.PipelineDescription{{PipelineId: aws.String("df-001"), Name: aws.String("pipeline1"), Fields: []dptypes.Field{{Key: aws.String("@creationTime"), StringValue: aws.String(nowStr)}}}}},
+					{PipelineDescriptionList: []dptypes.PipelineDescription{{PipelineId: aws.String("df-002"), Name: aws.String("pipeline2"), Fields: []dptypes.Field{{Key: aws.String("@creationTime"), StringValue: aws.String(nowStr)}}}}},
+				},
+			},
+			expected: []string{"df-001", "df-002"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mock := tc.mock
+			ids, err := listDataPipelines(context.Background(), &mock, resource.Scope{}, tc.configObj)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, aws.ToStringSlice(ids))
+		})
+	}
+}
+
+func TestDeleteDataPipeline(t *testing.T) {
+	t.Parallel()
+	err := deleteDataPipeline(context.Background(), &mockDataPipelineClient{}, aws.String("df-001"))
+	require.NoError(t, err)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	CodeDeployApplications          ResourceType               `yaml:"CodeDeployApplications"`
 	ConfigServiceRecorder           ResourceType               `yaml:"ConfigServiceRecorder"`
 	ConfigServiceRule               ResourceType               `yaml:"ConfigServiceRule"`
+	DataPipeline                    ResourceType               `yaml:"DataPipeline"`
 	DataSyncLocation                ResourceType               `yaml:"DataSyncLocation"`
 	DataSyncTask                    ResourceType               `yaml:"DataSyncTask"`
 	DBGlobalClusters                ResourceType               `yaml:"DBGlobalClusters"`
@@ -181,6 +182,7 @@ func (c *Config) allResourceTypes() []*ResourceType {
 		&c.CodeDeployApplications,
 		&c.ConfigServiceRecorder,
 		&c.ConfigServiceRule,
+		&c.DataPipeline,
 		&c.DataSyncLocation,
 		&c.DataSyncTask,
 		&c.DBGlobalClusters,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,6 +34,7 @@ func emptyConfig() *Config {
 		CodeDeployApplications:          ResourceType{FilterRule{}, FilterRule{}, "", false},
 		ConfigServiceRecorder:           ResourceType{FilterRule{}, FilterRule{}, "", false},
 		ConfigServiceRule:               ResourceType{FilterRule{}, FilterRule{}, "", false},
+		DataPipeline:                    ResourceType{FilterRule{}, FilterRule{}, "", false},
 		DataSyncLocation:                ResourceType{FilterRule{}, FilterRule{}, "", false},
 		DataSyncTask:                    ResourceType{FilterRule{}, FilterRule{}, "", false},
 		DBGlobalClusters:                ResourceType{FilterRule{}, FilterRule{}, "", false},

--- a/docs/supported-resources.md
+++ b/docs/supported-resources.md
@@ -24,6 +24,7 @@ cloud-nuke supports inspecting and deleting the following AWS resources. The **C
 | `codedeploy-application` | CodeDeploy Application |
 | `config-recorders` | Config Service Recorder |
 | `config-rules` | Config Service Rule |
+| `data-pipeline` | Data Pipeline |
 | `data-sync-location` | DataSync Location |
 | `data-sync-task` | DataSync Task |
 | `dynamodb` | DynamoDB Table |
@@ -158,6 +159,7 @@ This table shows which filtering features are supported for each resource type i
 | codedeploy-application | CodeDeployApplications | ✓ | ✓ | | ✓ |
 | config-recorders | ConfigServiceRecorder | ✓ | | | ✓ |
 | config-rules | ConfigServiceRule | ✓ | | | ✓ |
+| data-pipeline | DataPipeline | ✓ | ✓ | | ✓ |
 | data-sync-location | DataSyncLocation | | | | ✓ |
 | data-sync-task | DataSyncTask | ✓ | | | ✓ |
 | dynamodb | DynamoDB | ✓ | ✓ | | ✓ |

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	cloud.google.com/go/functions v1.19.7
 	cloud.google.com/go/storage v1.50.0
-	github.com/aws/aws-sdk-go-v2 v1.38.3
+	github.com/aws/aws-sdk-go-v2 v1.41.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.5
 	github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.36.12
 	github.com/aws/aws-sdk-go-v2/service/acm v1.30.17
@@ -23,6 +23,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.45.11
 	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.29.17
 	github.com/aws/aws-sdk-go-v2/service/configservice v1.51.11
+	github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.18
 	github.com/aws/aws-sdk-go-v2/service/datasync v1.45.3
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.39.9
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.202.3
@@ -61,7 +62,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.37.13
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.13
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.13.9
-	github.com/aws/smithy-go v1.23.0
+	github.com/aws/smithy-go v1.24.2
 	github.com/go-errors/errors v1.4.2
 	github.com/gruntwork-io/go-commons v0.17.0
 	github.com/hashicorp/go-multierror v1.1.1
@@ -91,8 +92,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.8 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.58 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.27 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.6 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.6 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.19 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.19 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.2 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.31 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/MarvinJWendt/testza v0.3.0/go.mod h1:eFcL4I0idjtIx8P9C6KkAuLgATNKpX4/
 github.com/MarvinJWendt/testza v0.4.2 h1:Vbw9GkSB5erJI2BPnBL9SVGV9myE+XmUSFahBGUhW2Q=
 github.com/MarvinJWendt/testza v0.4.2/go.mod h1:mSdhXiKH8sg/gQehJ63bINcCKp7RtYewEjXsvsVUPbE=
 github.com/atomicgo/cursor v0.0.1/go.mod h1:cBON2QmmrysudxNBFthvMtN32r3jxVRIvzkUiF/RuIk=
-github.com/aws/aws-sdk-go-v2 v1.38.3 h1:B6cV4oxnMs45fql4yRH+/Po/YU+597zgWqvDpYMturk=
-github.com/aws/aws-sdk-go-v2 v1.38.3/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
+github.com/aws/aws-sdk-go-v2 v1.41.3 h1:4kQ/fa22KjDt13QCy1+bYADvdgcxpfH18f0zP542kZA=
+github.com/aws/aws-sdk-go-v2 v1.41.3/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.8 h1:zAxi9p3wsZMIaVCdoiQp2uZ9k1LsZvmAnoTBeZPXom0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.8/go.mod h1:3XkePX5dSaxveLAYY7nsbsZZrKxCyEuE5pM4ziFxyGg=
 github.com/aws/aws-sdk-go-v2/config v1.29.5 h1:4lS2IB+wwkj5J43Tq/AwvnscBerBJtQQ6YS7puzCI1k=
@@ -53,10 +53,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.17.58 h1:/d7FUpAPU8Lf2KUdjniQvfNdlMI
 github.com/aws/aws-sdk-go-v2/credentials v1.17.58/go.mod h1:aVYW33Ow10CyMQGFgC0ptMRIqJWvJ4nxZb0sUiuQT/A=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.27 h1:7lOW8NUwE9UZekS1DYoiPdVAqZ6A+LheHWb+mHbNOq8=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.27/go.mod h1:w1BASFIPOPUae7AgaH4SbjNbfdkxuggLyGfNFTn8ITY=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.6 h1:uF68eJA6+S9iVr9WgX1NaRGyQ/6MdIyc4JNUo6TN1FA=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.6/go.mod h1:qlPeVZCGPiobx8wb1ft0GHT5l+dc6ldnwInDFaMvC7Y=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.6 h1:pa1DEC6JoI0zduhZePp3zmhWvk/xxm4NB8Hy/Tlsgos=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.6/go.mod h1:gxEjPebnhWGJoaDdtDkA0JX46VRg1wcTHYe63OfX5pE=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.19 h1:/sECfyq2JTifMI2JPyZ4bdRN77zJmr6SrS1eL3augIA=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.19/go.mod h1:dMf8A5oAqr9/oxOfLkC/c2LU/uMcALP0Rgn2BD5LWn0=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.19 h1:AWeJMk33GTBf6J20XJe6qZoRSJo0WfUhsMdUKhoODXE=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.19/go.mod h1:+GWrYoaAsV7/4pNHpwh1kiNLXkKaSoppxQq9lbH8Ejw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.2 h1:Pg9URiobXy85kgFev3og2CuOZ8JZUBENF+dcgWBaYNk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.2/go.mod h1:FbtygfRFze9usAadmnGJNc8KsP346kEe+y2/oyhGAGc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.31 h1:8IwBjuLdqIO1dGB+dZ9zJEl8wzY3bVYxcs0Xyu/Lsc0=
@@ -93,6 +93,8 @@ github.com/aws/aws-sdk-go-v2/service/codedeploy v1.29.17 h1:7WObtvA1wCcHVSL4aXVI
 github.com/aws/aws-sdk-go-v2/service/codedeploy v1.29.17/go.mod h1:kYEWlBTLzz/GgRBxxKq7Bw1l53dR5VDQOhIntL8BTp4=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.51.11 h1:BZOPVHrCDo8i/A/dsNCw8gZGbcpzmh9dPKVuGjLRaaI=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.51.11/go.mod h1:A4GZqtbW7Jk85miMZE/5kvxOLvDfM1dRwhXGgy5LhPg=
+github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.18 h1:R7OeAXlqOfxvWspAxuirPLyERtMrzWsl251l3vNtUkE=
+github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.18/go.mod h1:hevITK2Oay66bG/gpZp96Hk9mZTX6WUqMPOh6obI7co=
 github.com/aws/aws-sdk-go-v2/service/datasync v1.45.3 h1:7u/FbTWIHqkhyE1txdgGwH4IGyMN2C3eheBaDoTam/Q=
 github.com/aws/aws-sdk-go-v2/service/datasync v1.45.3/go.mod h1:as9peu4nMWBaqBkHHNRc+6YV0mlc/2DjypcbAmNsyHU=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.39.9 h1:gC1SKYPagK6aiL6BrQOl0U5D3vSLQUw6mMaFe9DzoC8=
@@ -183,8 +185,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.13 h1:3LXNnmtH3TURctC23hnC0p/39Q5
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.13/go.mod h1:7Yn+p66q/jt38qMoVfNvjbm3D89mGBnkwDcijgtih8w=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.13.9 h1:T6N4RwAqT8cDOu5dnNhNaVPbPYQKySnykOLAelt26LQ=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.13.9/go.mod h1:euZAP+7gNAaV0QDx7gvJDsYhpB12U20k1yBWtU/yIvQ=
-github.com/aws/smithy-go v1.23.0 h1:8n6I3gXzWJB2DxBDnfxgBaSX6oe0d/t10qGz7OKqMCE=
-github.com/aws/smithy-go v1.23.0/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
+github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
+github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 h1:aQ3y1lwWyqYPiWZThqv1aFbZMiM9vblcSArJRf2Irls=

--- a/util/time.go
+++ b/util/time.go
@@ -25,6 +25,9 @@ const (
 	// The time format of the `firstSeenTagKey` tag value.
 	firstSeenTimeFormat       = time.RFC3339
 	firstSeenTimeFormatLegacy = time.DateTime
+
+	// ISO 8601 without timezone — used by some AWS APIs (e.g., Data Pipeline).
+	iso8601Bare = "2006-01-02T15:04:05"
 )
 
 func IsFirstSeenTag(key *string) bool {
@@ -32,14 +35,19 @@ func IsFirstSeenTag(key *string) bool {
 }
 
 func ParseTimestamp(timestamp *string) (*time.Time, error) {
-	parsed, err := time.Parse(firstSeenTimeFormat, aws.ToString(timestamp))
+	s := aws.ToString(timestamp)
+
+	parsed, err := time.Parse(firstSeenTimeFormat, s)
 	if err != nil {
 		logging.Debugf("Error parsing the timestamp into a `RFC3339` Time format. Trying parsing the timestamp using the legacy `time.DateTime` format.")
-		parsed, err = time.Parse(firstSeenTimeFormatLegacy, aws.ToString(timestamp))
-		if err != nil {
-			logging.Debugf("Error parsing the timestamp into legacy `time.DateTime` Time format")
-			return nil, errors.WithStackTrace(err)
-		}
+		parsed, err = time.Parse(firstSeenTimeFormatLegacy, s)
+	}
+	if err != nil {
+		logging.Debugf("Error parsing the timestamp into legacy `time.DateTime` Time format. Trying bare ISO 8601 format.")
+		parsed, err = time.Parse(iso8601Bare, s)
+	}
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
 	}
 
 	return &parsed, nil

--- a/util/time_test.go
+++ b/util/time_test.go
@@ -30,6 +30,12 @@ func TestParseTimestamp(t *testing.T) {
 			newTime(time.Date(2024, 4, 12, 15, 18, 5, 0, time.UTC)),
 			false,
 		},
+		{
+			"it should parse bare ISO 8601 value \"2015-01-01T00:00:00\" correctly",
+			args{timestamp: aws.String("2015-01-01T00:00:00")},
+			newTime(time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)),
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `data-pipeline` resource type to discover and delete AWS Data Pipeline resources
- Extends `util.ParseTimestamp` with bare ISO 8601 format fallback (`2015-01-01T00:00:00`) used by the Data Pipeline API
- DescribePipelines calls batched in groups of 25 per AWS API limit
- Config key `DataPipeline` supports `names_regex` and `time` filtering

## Files changed

| File | Change |
|---|---|
| `aws/resources/data_pipeline.go` | New resource implementation |
| `aws/resources/data_pipeline_test.go` | Unit tests (7 subtests + delete) |
| `aws/resource_registry.go` | Register in regional resources |
| `config/config.go` | Add `DataPipeline` field + `allResourceTypes()` |
| `config/config_test.go` | Add to `emptyConfig()` helper |
| `util/time.go` | Add bare ISO 8601 fallback to `ParseTimestamp` |
| `util/time_test.go` | Test bare ISO 8601 parsing |
| `docs/supported-resources.md` | Document new resource |
| `go.mod` / `go.sum` | Add `datapipeline` SDK dependency |

## Test plan

- [x] `go test ./aws/resources -run "TestListDataPipelines|TestDeleteDataPipeline" -v` — all 8 tests pass
- [x] `go test ./util/... -run TestParseTimestamp -v` — all 3 format tests pass
- [x] `go test ./config/... -run "TestAllResourceTypesComplete|TestConfig_Empty" -v` — 129 fields match
- [x] `cloud-nuke inspect --resource-type data-pipeline` against account 087285199408
- [x] `cloud-nuke nuke --resource-type data-pipeline --region us-west-2` to clean up sample pipeline