### PR TITLE
fix: skip requester-managed VPC endpoints during nuke

### DIFF
--- a/aws/resources/ec2_endpoints.go
+++ b/aws/resources/ec2_endpoints.go
@@ -69,6 +69,13 @@ func listEC2Endpoints(ctx context.Context, client EC2EndpointsAPI, scope resourc
 		}
 
 		for _, endpoint := range page.VpcEndpoints {
+			// Skip requester-managed endpoints — these are created by AWS services
+			// and cannot be deleted directly.
+			if aws.ToBool(endpoint.RequesterManaged) {
+				logging.Debugf("[Skip] VPC endpoint %s is requester-managed (created by AWS service)", aws.ToString(endpoint.VpcEndpointId))
+				continue
+			}
+
 			// When defaultOnly is true, skip endpoints not in default VPCs
 			if defaultOnly && !defaultVpcIds[aws.ToString(endpoint.VpcId)] {
 				continue

--- a/aws/resources/ec2_endpoints_test.go
+++ b/aws/resources/ec2_endpoints_test.go
@@ -110,6 +110,44 @@ func TestListEC2Endpoints(t *testing.T) {
 		},
 	}
 
+	t.Run("requesterManagedFilter", func(t *testing.T) {
+		reqManagedEndpoint := "vpce-reqmanaged"
+		nilReqManagedEndpoint := "vpce-nilreqmanaged"
+		mockWithReqManaged := &mockEC2EndpointsClient{
+			DescribeVpcEndpointsOutput: ec2.DescribeVpcEndpointsOutput{
+				VpcEndpoints: []types.VpcEndpoint{
+					{
+						VpcEndpointId:    aws.String(endpoint1),
+						RequesterManaged: aws.Bool(false),
+						Tags: []types.Tag{
+							{Key: aws.String("Name"), Value: aws.String(testName1)},
+							{Key: aws.String(util.FirstSeenTagKey), Value: aws.String(util.FormatTimestamp(now))},
+						},
+					},
+					{
+						VpcEndpointId:    aws.String(reqManagedEndpoint),
+						RequesterManaged: aws.Bool(true),
+						Tags: []types.Tag{
+							{Key: aws.String("Name"), Value: aws.String("requester-managed-ep")},
+							{Key: aws.String(util.FirstSeenTagKey), Value: aws.String(util.FormatTimestamp(now))},
+						},
+					},
+					{
+						// RequesterManaged nil — should be treated as user-managed and included
+						VpcEndpointId: aws.String(nilReqManagedEndpoint),
+						Tags: []types.Tag{
+							{Key: aws.String("Name"), Value: aws.String("nil-requester-managed-ep")},
+							{Key: aws.String(util.FirstSeenTagKey), Value: aws.String(util.FormatTimestamp(now))},
+						},
+					},
+				},
+			},
+		}
+		ids, err := listEC2Endpoints(ctx, mockWithReqManaged, resource.Scope{}, config.ResourceType{}, false)
+		require.NoError(t, err)
+		require.Equal(t, []string{endpoint1, nilReqManagedEndpoint}, aws.ToStringSlice(ids))
+	})
+
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			ids, err := listEC2Endpoints(ctx, mock, resource.Scope{}, tc.configObj, false)


### PR DESCRIPTION
## Summary

- Skip requester-managed VPC endpoints in `listEC2Endpoints()` by checking `RequesterManaged` field
- These endpoints are created by AWS services and cannot be deleted directly, causing errors on every nuke run (e.g. PhxDevOps us-east-1)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./aws/resources/ -run TestListEC2Endpoints` — all pass, including new `requesterManagedFilter` case covering true, false, and nil values
- [x] `go test ./aws/resources/ -run TestDeleteEC2Endpoint` — existing tests pass
- [x] `go test ./aws/resources/ -run TestWaitForEndpointsDeleted` — existing tests pass