### PR TITLE
fix: gcs bucket versioned delete

### DIFF
--- a/gcp/resources/gcs_bucket.go
+++ b/gcp/resources/gcs_bucket.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/resource"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 )
 
@@ -79,7 +79,8 @@ func deleteGCSBucket(ctx context.Context, client *storage.Client, name *string) 
 	// Delete the bucket
 	deleteErr := bucket.Delete(ctx)
 	if deleteErr != nil {
-		if strings.Contains(deleteErr.Error(), "bucket is not empty") {
+		var apiErr *googleapi.Error
+		if errors.As(deleteErr, &apiErr) && apiErr.Code == 409 {
 			// Bucket may have versioned objects, try force delete
 			if forceErr := forceEmptyBucket(ctx, bucket, bucketName); forceErr != nil {
 				return fmt.Errorf("error force emptying bucket %s: %w", bucketName, forceErr)


### PR DESCRIPTION
## Description

Fixes #1038.

When deleting GCS buckets with Object Versioning enabled, `cloud-nuke` fails with `googleapi: Error 409: The bucket you tried to delete is not empty., conflict`. The existing **forceEmptyBucket()** fallback logic doesn't trigger because the Google Cloud API now returns a different error message format than what the code checks for.

This PR updates the string matching in **deleteGCSBucket()** to handle both the old and new error message formats using case-insensitive comparison.

### Before Fix (deletion fails)
> 
<img width="1462" height="260" alt="image" src="https://github.com/user-attachments/assets/1fce542b-2778-4a91-a180-50bbef9e32bd" />

### After Fix (deletion succeeds)
> 
<img width="1172" height="482" alt="image" src="https://github.com/user-attachments/assets/f40ae5da-4924-4da3-a92e-f0582d1f8fb4" />


## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated GCS bucket deletion to handle updated Google Cloud API error message for non-empty versioned buckets.
