### PR TITLE
refactor: remove deprecated interfaces and dead code

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -57,13 +57,7 @@ func GetAllResources(c context.Context, query *Query, configObj config.Config, c
 		for _, resource := range registeredResources {
 			if IsNukeable((*resource).ResourceName(), query.ResourceTypes) {
 
-				// PrepareContext sets up the resource context for execution, utilizing the context 'c' and the resource individual configuration.
-				// This function should be called after configuring the timeout to ensure proper execution context.
-				resourceConfig := (*resource).GetAndSetResourceConfig(configObj)
-				err := (*resource).PrepareContext(c, resourceConfig)
-				if err != nil {
-					return nil, err
-				}
+				(*resource).GetAndSetResourceConfig(configObj)
 
 				// Emit scan progress event
 				collector.Emit(reporting.ScanProgress{

--- a/aws/resource.go
+++ b/aws/resource.go
@@ -19,7 +19,6 @@ type AwsResource interface {
 	GetAndSetIdentifiers(c context.Context, configObj config.Config) ([]string, error)
 	IsNukable(string) (bool, error)
 
-	PrepareContext(context.Context, config.ResourceType) error
 	GetAndSetResourceConfig(config.Config) config.ResourceType
 }
 

--- a/aws/resource_registry.go
+++ b/aws/resource_registry.go
@@ -1,13 +1,9 @@
 package aws
 
 import (
-	"reflect"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/gruntwork-io/cloud-nuke/aws/resources"
 )
-
-const Global = "global"
 
 // GetAllRegisteredResources - returns a list of all registered resources without initialization.
 // This is useful for listing all resources without initializing them.
@@ -21,7 +17,7 @@ func GetAllRegisteredResources() []*AwsResource {
 // GetAndInitRegisteredResources - returns a list of all registered resources with initialization.
 func GetAndInitRegisteredResources(session aws.Config, region string) []*AwsResource {
 	var registeredResources []AwsResource
-	if region == Global {
+	if region == GlobalRegion {
 		registeredResources = getRegisteredGlobalResources()
 	} else {
 		registeredResources = getRegisteredRegionalResources()
@@ -201,22 +197,7 @@ func toAwsResourcesPointer(resources []AwsResource) []*AwsResource {
 func initRegisteredResources(resources []*AwsResource, session aws.Config, region string) []*AwsResource {
 	for _, resource := range resources {
 		(*resource).Init(session)
-
-		// Note: only regional resources have the field `Region`, which is used for logging purposes only
-		setRegionForRegionalResource(resource, region)
 	}
 
 	return resources
-}
-
-func setRegionForRegionalResource(regionResource *AwsResource, region string) {
-	// Use reflection to set the Region field if the resource type has it
-	resourceValue := reflect.ValueOf(*regionResource) // Dereference the pointer
-	resourceValue = resourceValue.Elem()              // Get the underlying value
-	regionField := resourceValue.FieldByName("Region")
-
-	if regionField.IsValid() && regionField.CanSet() {
-		// The field is valid and can be set
-		regionField.SetString(region)
-	}
 }

--- a/aws/resources/adapter.go
+++ b/aws/resources/adapter.go
@@ -142,14 +142,6 @@ func (a *AwsResourceAdapter[C]) Nuke(ctx context.Context, identifiers []string) 
 	return a.Resource.Nuke(ctx, identifiers)
 }
 
-// PrepareContext is a no-op for generic resources.
-// The generic Resource pattern passes context directly to Nuke() and Lister functions,
-// eliminating the need for context preparation. This method exists solely for
-// compatibility with the AwsResource interface.
-func (a *AwsResourceAdapter[C]) PrepareContext(_ context.Context, _ config.ResourceType) error {
-	return nil
-}
-
 // Compile-time interface satisfaction check.
 // This ensures AwsResourceAdapter correctly implements AwsResource at compile time.
 var _ AwsResource = (*AwsResourceAdapter[any])(nil)

--- a/aws/resources/cloudfront_distribution.go
+++ b/aws/resources/cloudfront_distribution.go
@@ -32,7 +32,6 @@ func NewCloudfrontDistributions() AwsResource {
 	return NewAwsResource(&resource.Resource[CloudfrontDistributionAPI]{
 		ResourceTypeName: "cloudfront-distribution",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[CloudfrontDistributionAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = cloudfront.NewFromConfig(cfg)

--- a/aws/resources/iam.go
+++ b/aws/resources/iam.go
@@ -47,7 +47,6 @@ func NewIAMUsers() AwsResource {
 	return NewAwsResource(&resource.Resource[IAMUsersAPI]{
 		ResourceTypeName: "iam-user",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[IAMUsersAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = iam.NewFromConfig(cfg)

--- a/aws/resources/iam_group.go
+++ b/aws/resources/iam_group.go
@@ -28,7 +28,6 @@ func NewIAMGroups() AwsResource {
 	return NewAwsResource(&resource.Resource[IAMGroupsAPI]{
 		ResourceTypeName: "iam-group",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[IAMGroupsAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = iam.NewFromConfig(cfg)

--- a/aws/resources/iam_instance_profile.go
+++ b/aws/resources/iam_instance_profile.go
@@ -24,7 +24,6 @@ func NewIAMInstanceProfiles() AwsResource {
 	return NewAwsResource(&resource.Resource[IAMInstanceProfilesAPI]{
 		ResourceTypeName: "iam-instance-profile",
 		BatchSize:        20,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[IAMInstanceProfilesAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = iam.NewFromConfig(cfg)

--- a/aws/resources/iam_instance_profile_test.go
+++ b/aws/resources/iam_instance_profile_test.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -95,16 +94,6 @@ func TestIAMInstanceProfiles_ListIAMInstanceProfiles(t *testing.T) {
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{
 					TimeAfter: aws.Time(now),
-				}},
-			expected: []string{testName1},
-		},
-		"tagExclusion": {
-			configObj: config.ResourceType{
-				ExcludeRule: config.FilterRule{
-					Tag: aws.String("somearn"),
-					TagValue: &config.Expression{
-						RE: *regexp.MustCompile("^" + "some" + strings.ToLower(testArn2) + "$"),
-					},
 				}},
 			expected: []string{testName1},
 		},

--- a/aws/resources/iam_policy.go
+++ b/aws/resources/iam_policy.go
@@ -33,7 +33,6 @@ func NewIAMPolicies() AwsResource {
 	return NewAwsResource(&resource.Resource[IAMPoliciesAPI]{
 		ResourceTypeName: "iam-policy",
 		BatchSize:        20,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[IAMPoliciesAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = iam.NewFromConfig(cfg)

--- a/aws/resources/iam_role.go
+++ b/aws/resources/iam_role.go
@@ -33,7 +33,6 @@ func NewIAMRoles() AwsResource {
 	return NewAwsResource(&resource.Resource[IAMRolesAPI]{
 		ResourceTypeName: "iam-role",
 		BatchSize:        20,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[IAMRolesAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = iam.NewFromConfig(cfg)

--- a/aws/resources/iam_service_linked_role.go
+++ b/aws/resources/iam_service_linked_role.go
@@ -27,7 +27,6 @@ func NewIAMServiceLinkedRoles() AwsResource {
 	return NewAwsResource(&resource.Resource[IAMServiceLinkedRolesAPI]{
 		ResourceTypeName: "iam-service-linked-role",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[IAMServiceLinkedRolesAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = iam.NewFromConfig(cfg)

--- a/aws/resources/oidc_provider.go
+++ b/aws/resources/oidc_provider.go
@@ -29,7 +29,6 @@ func NewOIDCProviders() AwsResource {
 	return NewAwsResource(&resource.Resource[OIDCProvidersAPI]{
 		ResourceTypeName: "oidc-provider",
 		BatchSize:        10,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[OIDCProvidersAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = iam.NewFromConfig(cfg)

--- a/aws/resources/rds_global_cluster.go
+++ b/aws/resources/rds_global_cluster.go
@@ -26,7 +26,6 @@ func NewDBGlobalClusters() AwsResource {
 	return NewAwsResource(&resource.Resource[DBGlobalClustersAPI]{
 		ResourceTypeName: "rds-global-cluster",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[DBGlobalClustersAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = rds.NewFromConfig(cfg)

--- a/aws/resources/route53_cidr_collection.go
+++ b/aws/resources/route53_cidr_collection.go
@@ -25,7 +25,6 @@ func NewRoute53CidrCollections() AwsResource {
 	return NewAwsResource(&resource.Resource[Route53CidrCollectionAPI]{
 		ResourceTypeName: "route53-cidr-collection",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[Route53CidrCollectionAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = route53.NewFromConfig(cfg)

--- a/aws/resources/route53_hostedzone.go
+++ b/aws/resources/route53_hostedzone.go
@@ -29,7 +29,6 @@ func NewRoute53HostedZone() AwsResource {
 	return NewAwsResource(&resource.Resource[Route53HostedZoneAPI]{
 		ResourceTypeName: "route53-hosted-zone",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[Route53HostedZoneAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = route53.NewFromConfig(cfg)

--- a/aws/resources/route53_traffic_policy.go
+++ b/aws/resources/route53_traffic_policy.go
@@ -23,7 +23,6 @@ func NewRoute53TrafficPolicies() AwsResource {
 	return NewAwsResource(&resource.Resource[Route53TrafficPolicyAPI]{
 		ResourceTypeName: "route53-traffic-policy",
 		BatchSize:        DefaultBatchSize,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[Route53TrafficPolicyAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = route53.NewFromConfig(cfg)

--- a/aws/resources/s3.go
+++ b/aws/resources/s3.go
@@ -59,7 +59,6 @@ func NewS3Buckets() AwsResource {
 	return NewAwsResource(&resource.Resource[S3API]{
 		ResourceTypeName: "s3",
 		BatchSize:        500,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[S3API], cfg aws.Config) {
 			r.Scope.Region = "global"
 			r.Client = s3.NewFromConfig(cfg)

--- a/aws/resources/s3_multi_region_access_point.go
+++ b/aws/resources/s3_multi_region_access_point.go
@@ -26,7 +26,6 @@ func NewS3MultiRegionAccessPoints() AwsResource {
 		ResourceTypeName: "s3-multi-region-access-point",
 		// S3 Control API has tight rate limits; keep batch size low to avoid throttling.
 		BatchSize: 5,
-		IsGlobal:         true,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[S3ControlMultiRegionAPI], cfg aws.Config) {
 			r.Scope.Region = "global"
 			cfg.Region = "us-west-2" // MRAP control-plane requests must be routed to us-west-2

--- a/aws/resources/sagemaker_endpoint.go
+++ b/aws/resources/sagemaker_endpoint.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
@@ -103,24 +102,6 @@ func shouldExcludeByTags(endpointName *string, tagMap map[string]string, cfg con
 			if pattern.RE.MatchString(tagValue) {
 				logging.Debugf("Excluding endpoint %s due to tag '%s' with value '%s' matching pattern '%s'",
 					*endpointName, tag, tagValue, pattern.RE.String())
-				return true
-			}
-		}
-	}
-
-	// Check the deprecated Tag/TagValue approach
-	if cfg.ExcludeRule.Tag != nil {
-		tagName := *cfg.ExcludeRule.Tag
-		if tagValue, hasTag := tagMap[tagName]; hasTag {
-			if cfg.ExcludeRule.TagValue != nil {
-				if cfg.ExcludeRule.TagValue.RE.MatchString(tagValue) {
-					logging.Debugf("Excluding endpoint %s due to deprecated tag '%s' with value '%s' matching pattern '%s'",
-						*endpointName, tagName, tagValue, cfg.ExcludeRule.TagValue.RE.String())
-					return true
-				}
-			} else if strings.EqualFold(tagValue, "true") {
-				logging.Debugf("Excluding endpoint %s due to deprecated tag '%s' with default value 'true'",
-					*endpointName, tagName)
 				return true
 			}
 		}

--- a/aws/resources/types.go
+++ b/aws/resources/types.go
@@ -9,6 +9,9 @@ import (
 )
 
 // AwsResource is an interface that represents a single AWS resource.
+// This interface is structurally identical to aws.AwsResource but defined here
+// to avoid a circular import (aws imports resources). Go's structural typing
+// ensures that types satisfying this interface also satisfy aws.AwsResource.
 // This interface is satisfied by AwsResourceAdapter[C] which wraps resource.Resource[C].
 type AwsResource interface {
 	Init(cfg aws.Config)
@@ -18,6 +21,5 @@ type AwsResource interface {
 	Nuke(ctx context.Context, identifiers []string) ([]resource.NukeResult, error)
 	GetAndSetIdentifiers(c context.Context, configObj config.Config) ([]string, error)
 	IsNukable(string) (bool, error)
-	PrepareContext(context.Context, config.ResourceType) error
 	GetAndSetResourceConfig(config.Config) config.ResourceType
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -363,8 +363,7 @@ type EC2ResourceType struct {
 }
 
 type AWSProtectableResourceType struct {
-	ResourceType             `yaml:",inline"`
-	IncludeDeletionProtected bool `yaml:"include_deletion_protected"`
+	ResourceType `yaml:",inline"`
 }
 
 type ResourceType struct {
@@ -378,8 +377,6 @@ type FilterRule struct {
 	NamesRegExp  []Expression          `yaml:"names_regex"`
 	TimeAfter    *time.Time            `yaml:"time_after"`
 	TimeBefore   *time.Time            `yaml:"time_before"`
-	Tag          *string               `yaml:"tag"`       // Deprecated ~ A tag to filter resources by. (e.g., If set under ExcludedRule, resources with this tag will be excluded).
-	TagValue     *Expression           `yaml:"tag_value"` // Deprecated
 	Tags         map[string]Expression `yaml:"tags"`
 	TagsOperator string                `yaml:"tags_operator"` // "AND" or "OR" - defaults to "OR" for backward compatibility
 }
@@ -415,7 +412,7 @@ func GetConfig(filePath string) (*Config, error) {
 		return nil, err
 	}
 
-	yamlFile, err := ioutil.ReadFile(absolutePath)
+	yamlFile, err := os.ReadFile(absolutePath)
 	if err != nil {
 		return nil, err
 	}
@@ -544,18 +541,10 @@ func (r ResourceType) ShouldIncludeBasedOnTime(time time.Time) bool {
 }
 
 func (r ResourceType) getExclusionTag() string {
-	if r.ExcludeRule.Tag != nil {
-		return *r.ExcludeRule.Tag
-	}
-
 	return DefaultAwsResourceExclusionTagKey
 }
 
 func (r ResourceType) getExclusionTagValue() *Expression {
-	if r.ExcludeRule.TagValue != nil {
-		return r.ExcludeRule.TagValue
-	}
-
 	return &Expression{RE: *regexp.MustCompile(DefaultAwsResourceExclusionTagValue)}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -328,34 +328,8 @@ func TestAddIncludeAndExcludeAfterTime(t *testing.T) {
 }
 
 func TestGetExclusionTag(t *testing.T) {
-	tests := []struct {
-		name        string
-		want        string
-		ExcludeRule FilterRule
-	}{
-		{
-			name: "empty config returns default tag",
-			want: DefaultAwsResourceExclusionTagKey,
-		},
-		{
-			name: "custom exclusion tag is returned",
-			ExcludeRule: FilterRule{
-				Tag: aws.String("my-custom-tag"),
-			},
-			want: "my-custom-tag",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			testConfig := &Config{}
-			testConfig.ACM = ResourceType{
-				ExcludeRule: tt.ExcludeRule,
-			}
-
-			require.Equal(t, tt.want, testConfig.ACM.getExclusionTag())
-		})
-	}
+	testConfig := &Config{}
+	require.Equal(t, DefaultAwsResourceExclusionTagKey, testConfig.ACM.getExclusionTag())
 }
 
 func TestShouldIncludeBasedOnTag(t *testing.T) {
@@ -372,90 +346,26 @@ func TestShouldIncludeBasedOnTag(t *testing.T) {
 		expect bool
 	}{
 		{
-			name:   "should include resource with default exclude tag",
+			name:   "should exclude resource with default exclude tag set to true",
 			given:  arg{},
 			when:   map[string]string{DefaultAwsResourceExclusionTagKey: "true"},
 			expect: false,
 		},
 		{
-			name: "should include resource with custom exclude tag",
-			given: arg{
-				ExcludeRule: FilterRule{
-					Tag: aws.String("my-custom-skip-tag"),
-				},
-				ProtectUntilExpire: false,
-			},
-			when:   map[string]string{"my-custom-skip-tag": "true"},
-			expect: false,
-		},
-		{
-			name: "should include resource with custom exclude tag and empty value",
-			given: arg{
-				ExcludeRule: FilterRule{
-					Tag: aws.String("my-custom-skip-tag"),
-					TagValue: &Expression{
-						RE: *regexp.MustCompile(""),
-					},
-				},
-				ProtectUntilExpire: false,
-			},
-			when:   map[string]string{"my-custom-skip-tag": ""},
-			expect: false,
-		},
-		{
-			name: "should include resource with custom exclude tag and empty value (using regular expression)",
-			given: arg{
-				ExcludeRule: FilterRule{
-					Tag: aws.String("my-custom-skip-tag"),
-					TagValue: &Expression{
-						RE: *regexp.MustCompile(".*"),
-					},
-				},
-				ProtectUntilExpire: false,
-			},
-			when:   map[string]string{"my-custom-skip-tag": ""},
-			expect: false,
-		},
-		{
-			name: "should include resource with custom exclude tag and prefix value (using regular expression)",
-			given: arg{
-				ExcludeRule: FilterRule{
-					Tag: aws.String("my-custom-skip-tag"),
-					TagValue: &Expression{
-						RE: *regexp.MustCompile("protected-.*"),
-					},
-				},
-				ProtectUntilExpire: false,
-			},
-			when:   map[string]string{"my-custom-skip-tag": "protected-database"},
-			expect: false,
-		},
-		{
-			name: "should include resource when exclude tag is not set to true",
-			given: arg{
-				ExcludeRule: FilterRule{
-					Tag: aws.String(DefaultAwsResourceExclusionTagKey),
-				},
-				ProtectUntilExpire: false,
-			},
+			name:   "should include resource when exclude tag is not set to true",
+			given:  arg{},
 			when:   map[string]string{DefaultAwsResourceExclusionTagKey: "false"},
 			expect: true,
 		},
 		{
-			name: "should include resource when no tags are set",
-			given: arg{
-				ExcludeRule: FilterRule{
-					Tag: aws.String(DefaultAwsResourceExclusionTagKey),
-				},
-				ProtectUntilExpire: false,
-			},
+			name:   "should include resource when no tags are set",
+			given:  arg{},
 			when:   map[string]string{},
 			expect: true,
 		},
 		{
-			name: "should include resource when protection expires in the future",
+			name: "should exclude resource when protection expires in the future",
 			given: arg{
-				ExcludeRule:        FilterRule{},
 				ProtectUntilExpire: true,
 			},
 			when:   map[string]string{CloudNukeAfterExclusionTagKey: timeIn2h.Format(time.RFC3339)},
@@ -464,7 +374,6 @@ func TestShouldIncludeBasedOnTag(t *testing.T) {
 		{
 			name: "should include resource when protection expired in the past",
 			given: arg{
-				ExcludeRule:        FilterRule{},
 				ProtectUntilExpire: true,
 			},
 			when:   map[string]string{CloudNukeAfterExclusionTagKey: time.Now().Format(time.RFC3339)},

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -53,11 +53,6 @@ type Resource[C any] struct {
 	// Set based on AWS/GCP API rate limits for this resource type.
 	BatchSize int
 
-	// IsGlobal indicates whether this resource is global (true) or regional (false).
-	// Global resources (e.g., IAM, Route53) are only queried once, not per-region.
-	// Regional resources (e.g., EC2, S3) are queried for each target region.
-	IsGlobal bool
-
 	// InitClient initializes the client from cloud-specific config.
 	// For AWS: cfg is aws.Config
 	// For GCP: cfg is string (projectID)


### PR DESCRIPTION
## Summary

- Remove `PrepareContext` from the `AwsResource` interface and all implementations — context is now passed directly to Lister/Nuker via the generic resource pattern
- Remove `IsGlobal` field from `resource.Resource` — region is set in each resource's `InitClient` function instead
- Remove deprecated `FilterRule.Tag` / `FilterRule.TagValue` fields — replaced by the `Tags` map
- Remove unused `IncludeDeletionProtected` from `AWSProtectableResourceType`
- Remove `Global` const and `setRegionForRegionalResource` helper from resource registry (superseded by `GlobalRegion`)
- Clean up related test code for removed fields

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Verify existing tests pass in CI