### PR TITLE
fix: align DefaultBatchSize constants across packages

### DIFF
--- a/resource/resource.go
+++ b/resource/resource.go
@@ -13,7 +13,7 @@ import (
 )
 
 // DefaultBatchSize is the maximum number of resources per batch
-const DefaultBatchSize = 10
+const DefaultBatchSize = 50
 
 // Scope represents the cloud provider-specific scope for a resource.
 // For AWS: Region is set (e.g., "us-east-1" or "global" for global resources)
@@ -49,7 +49,7 @@ type Resource[C any] struct {
 	ResourceTypeName string
 
 	// BatchSize is the maximum number of resources to delete per batch.
-	// If 0, defaults to DefaultBatchSize (10).
+	// If 0, defaults to DefaultBatchSize (50).
 	// Set based on AWS/GCP API rate limits for this resource type.
 	BatchSize int
 


### PR DESCRIPTION
## Summary
- Align `DefaultBatchSize` in `resource/resource.go` from 10 to 50 to match `aws/resources/adapter.go`
- All AWS resources already use the adapter's value of 50; the resource package fallback of 10 was a confusing inconsistency
- Now if any resource omits `BatchSize`, `MaxBatchSize()` returns the same 50 that every resource explicitly sets

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- No behavioral change for existing resources (all explicitly set `BatchSize: 50` via the adapter constant)