### PR TITLE
refactor: unify AWS and GCP resource orchestration into shared framework

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -6,16 +6,15 @@ import (
 	"sort"
 	"time"
 
-	"github.com/gruntwork-io/cloud-nuke/util"
-	"github.com/hashicorp/go-multierror"
-
-	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
-
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/reporting"
+	"github.com/gruntwork-io/cloud-nuke/resource"
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/collections"
+	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
+	"github.com/hashicorp/go-multierror"
 )
 
 // GetAllResources - Lists all aws resources
@@ -40,6 +39,8 @@ func GetAllResources(c context.Context, query *Query, configObj config.Config, c
 	}
 
 	c = context.WithValue(c, util.ExcludeFirstSeenTagKey, query.ExcludeFirstSeen)
+	scanCb := awsScanCallbacks(collector)
+
 	for _, region := range query.Regions {
 		cloudNukeSession, errSession := NewSession(region)
 		if errSession != nil {
@@ -54,63 +55,14 @@ func GetAllResources(c context.Context, query *Query, configObj config.Config, c
 
 		awsResource := AwsResources{}
 		registeredResources := GetAndInitRegisteredResources(cloudNukeSession, region)
-		for _, resource := range registeredResources {
-			if IsNukeable((*resource).ResourceName(), query.ResourceTypes) {
+		for _, res := range registeredResources {
+			if !util.IsNukeable((*res).ResourceName(), query.ResourceTypes, nil) {
+				continue
+			}
 
-				(*resource).GetAndSetResourceConfig(configObj)
-
-				// Emit scan progress event
-				collector.Emit(reporting.ScanProgress{
-					ResourceType: (*resource).ResourceName(),
-					Region:       region,
-				})
-
-				start := time.Now()
-				identifiers, err := (*resource).GetAndSetIdentifiers(c, configObj)
-				if err != nil {
-					logging.Errorf("Unable to retrieve %v, %v", (*resource).ResourceName(), err)
-
-					// Reporting resource-level failures encountered during the GetIdentifiers phase
-					telemetry.TrackEvent(commonTelemetry.EventContext{
-						EventName: fmt.Sprintf("error:GetIdentifiers:%s", (*resource).ResourceName()),
-					}, map[string]interface{}{
-						"region": region,
-					})
-
-					collector.Emit(reporting.GeneralError{
-						ResourceType: (*resource).ResourceName(),
-						Description:  fmt.Sprintf("Unable to retrieve %s", (*resource).ResourceName()),
-						Error:        err.Error(),
-					})
-				}
-
-				telemetry.TrackEvent(commonTelemetry.EventContext{
-					EventName: fmt.Sprintf("Done getting %s identifiers", (*resource).ResourceName()),
-				}, map[string]interface{}{
-					"recordCount": len(identifiers),
-					"actionTime":  time.Since(start).Seconds(),
-				})
-
-				// Only append if we have non-empty identifiers
-				if len(identifiers) > 0 {
-					logging.Infof("Found %d %s resources in %s", len(identifiers), (*resource).ResourceName(), region)
-					awsResource.Resources = append(awsResource.Resources, resource)
-
-					// Emit ResourceFound events for each identifier
-					for _, id := range identifiers {
-						nukable, reason := true, ""
-						if _, err := (*resource).IsNukable(id); err != nil {
-							nukable, reason = false, err.Error()
-						}
-						collector.Emit(reporting.ResourceFound{
-							ResourceType: (*resource).ResourceName(),
-							Region:       region,
-							Identifier:   id,
-							Nukable:      nukable,
-							Reason:       reason,
-						})
-					}
-				}
+			identifiers := resource.ScanResource(c, *res, region, configObj, scanCb)
+			if len(identifiers) > 0 {
+				awsResource.Resources = append(awsResource.Resources, res)
 			}
 		}
 
@@ -141,76 +93,21 @@ func IsValidResourceType(resourceType string, allResourceTypes []string) bool {
 	return collections.ListContainsElement(allResourceTypes, resourceType)
 }
 
-// IsNukeable - Checks if we should nuke a resource or not
+// IsNukeable checks whether a resource type should be nuked based on the
+// requested resource types. This is a convenience wrapper around util.IsNukeable
+// for backward compatibility.
 func IsNukeable(resourceType string, resourceTypes []string) bool {
-	if len(resourceTypes) == 0 ||
-		collections.ListContainsElement(resourceTypes, "all") ||
-		collections.ListContainsElement(resourceTypes, resourceType) {
-		return true
-	}
-	return false
+	return util.IsNukeable(resourceType, resourceTypes, nil)
 }
 
 func nukeAllResourcesInRegion(ctx context.Context, account *AwsAccountResources, region string, collector *reporting.Collector) error {
 	var allErrors *multierror.Error
 	resourcesInRegion := account.Resources[region]
+	nukeCb := awsNukeCallbacks(collector)
 
 	for _, awsResource := range resourcesInRegion.Resources {
-		length := len((*awsResource).ResourceIdentifiers())
-
-		// Split api calls into batches
-		logging.Debugf("Terminating %d awsResource in batches", length)
-		batches := util.Split((*awsResource).ResourceIdentifiers(), (*awsResource).MaxBatchSize())
-
-		for i, batch := range batches {
-			// Emit progress event (CLIRenderer updates its progress bar)
-			collector.Emit(reporting.NukeProgress{
-				ResourceType: (*awsResource).ResourceName(),
-				Region:       region,
-				BatchSize:    len(batch),
-			})
-
-			results, err := (*awsResource).Nuke(ctx, batch)
-
-			// Emit ResourceDeleted for each result
-			for _, result := range results {
-				errStr := ""
-				if result.Error != nil {
-					errStr = result.Error.Error()
-				}
-				collector.Emit(reporting.ResourceDeleted{
-					ResourceType: (*awsResource).ResourceName(),
-					Region:       region,
-					Identifier:   result.Identifier,
-					Success:      result.Error == nil,
-					Error:        errStr,
-				})
-			}
-
-			if err != nil {
-				// Handle rate limiting
-				if util.IsThrottlingError(err) {
-					logging.Debug(
-						"Request limit reached. Waiting 1 minute before making new requests",
-					)
-					time.Sleep(1 * time.Minute)
-					continue
-				}
-
-				allErrors = multierror.Append(allErrors, fmt.Errorf("[%s] %s: %w", region, (*awsResource).ResourceName(), err))
-
-				// Report to telemetry - aggregated metrics of failures per resources.
-				telemetry.TrackEvent(commonTelemetry.EventContext{
-					EventName: fmt.Sprintf("error:Nuke:%s", (*awsResource).ResourceName()),
-				}, map[string]interface{}{
-					"region": region,
-				})
-			}
-
-			if i != len(batches)-1 {
-				logging.Debug("Sleeping for 10 seconds before processing next batch...")
-				time.Sleep(10 * time.Second)
-			}
+		if err := resource.NukeInBatches(ctx, *awsResource, region, nukeCb); err != nil {
+			allErrors = multierror.Append(allErrors, err)
 		}
 	}
 
@@ -250,4 +147,79 @@ func NukeAllResources(ctx context.Context, account *AwsAccountResources, regions
 	collector.Emit(reporting.NukeComplete{})
 
 	return allErrors.ErrorOrNil()
+}
+
+// awsScanCallbacks creates scan callbacks wired to the reporting collector and telemetry.
+func awsScanCallbacks(collector *reporting.Collector) resource.ScanCallbacks {
+	return resource.ScanCallbacks{
+		OnScanProgress: func(resourceName, region string) {
+			collector.Emit(reporting.ScanProgress{
+				ResourceType: resourceName,
+				Region:       region,
+			})
+		},
+		OnScanError: func(resourceName, region string, err error) {
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: fmt.Sprintf("error:GetIdentifiers:%s", resourceName),
+			}, map[string]interface{}{
+				"region": region,
+			})
+			collector.Emit(reporting.GeneralError{
+				ResourceType: resourceName,
+				Description:  fmt.Sprintf("Unable to retrieve %s", resourceName),
+				Error:        err.Error(),
+			})
+		},
+		OnScanComplete: func(resourceName string, count int, duration time.Duration) {
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: fmt.Sprintf("Done getting %s identifiers", resourceName),
+			}, map[string]interface{}{
+				"recordCount": count,
+				"actionTime":  duration.Seconds(),
+			})
+		},
+		OnResourceFound: func(resourceName, region, id string, nukable bool, reason string) {
+			collector.Emit(reporting.ResourceFound{
+				ResourceType: resourceName,
+				Region:       region,
+				Identifier:   id,
+				Nukable:      nukable,
+				Reason:       reason,
+			})
+		},
+	}
+}
+
+// awsNukeCallbacks creates nuke callbacks wired to the reporting collector and telemetry.
+func awsNukeCallbacks(collector *reporting.Collector) resource.NukeBatchCallbacks {
+	return resource.NukeBatchCallbacks{
+		OnBatchStart: func(resourceName, region string, batchSize int) {
+			collector.Emit(reporting.NukeProgress{
+				ResourceType: resourceName,
+				Region:       region,
+				BatchSize:    batchSize,
+			})
+		},
+		OnResult: func(resourceName, region string, result resource.NukeResult) {
+			errStr := ""
+			if result.Error != nil {
+				errStr = result.Error.Error()
+			}
+			collector.Emit(reporting.ResourceDeleted{
+				ResourceType: resourceName,
+				Region:       region,
+				Identifier:   result.Identifier,
+				Success:      result.Error == nil,
+				Error:        errStr,
+			})
+		},
+		OnNukeError: func(resourceName, region string, err error) {
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: fmt.Sprintf("error:Nuke:%s", resourceName),
+			}, map[string]interface{}{
+				"region": region,
+			})
+		},
+		IsRetryableError: util.IsThrottlingError,
+	}
 }

--- a/aws/error.go
+++ b/aws/error.go
@@ -10,12 +10,20 @@ func (err CouldNotSelectRegionError) Error() string {
 	return fmt.Sprintf("Unable to determine target region set. Please double check your combination of target and excluded regions. Original error: %v", err.Underlying)
 }
 
+func (err CouldNotSelectRegionError) Unwrap() error {
+	return err.Underlying
+}
+
 type CouldNotDetermineEnabledRegionsError struct {
 	Underlying error
 }
 
 func (err CouldNotDetermineEnabledRegionsError) Error() string {
 	return fmt.Sprintf("Unable to determine enabled regions in target account. Original error: %v", err.Underlying)
+}
+
+func (err CouldNotDetermineEnabledRegionsError) Unwrap() error {
+	return err.Underlying
 }
 
 type InvalidResourceTypesSuppliedError struct {
@@ -41,6 +49,10 @@ func (err InvalidTimeStringPassedError) Error() string {
 	return fmt.Sprintf("Could not parse %s as a valid time duration. Underlying error: %s", err.Entry, err.Underlying)
 }
 
+func (err InvalidTimeStringPassedError) Unwrap() error {
+	return err.Underlying
+}
+
 type QueryCreationError struct {
 	Underlying error
 }
@@ -49,10 +61,18 @@ func (err QueryCreationError) Error() string {
 	return fmt.Sprintf("Error forming a cloud-nuke Query with supplied parameters. Original error: %v", err.Underlying)
 }
 
+func (err QueryCreationError) Unwrap() error {
+	return err.Underlying
+}
+
 type ResourceInspectionError struct {
 	Underlying error
 }
 
 func (err ResourceInspectionError) Error() string {
 	return fmt.Sprintf("Error encountered when querying for account resources. Original error: %v", err.Underlying)
+}
+
+func (err ResourceInspectionError) Unwrap() error {
+	return err.Underlying
 }

--- a/aws/resource.go
+++ b/aws/resource.go
@@ -1,25 +1,17 @@
 package aws
 
 import (
-	"context"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/resource"
 )
 
-// AwsResource is an interface that represents a single AWS resource
+// AwsResource is an interface that represents a single AWS resource.
+// It embeds the provider-agnostic NukeableResource interface and adds AWS-specific Init.
 type AwsResource interface {
+	resource.NukeableResource
 	Init(cfg aws.Config)
-	ResourceName() string
-	ResourceIdentifiers() []string
-	MaxBatchSize() int
-	Nuke(ctx context.Context, identifiers []string) ([]resource.NukeResult, error)
-	GetAndSetIdentifiers(c context.Context, configObj config.Config) ([]string, error)
-	IsNukable(string) (bool, error)
-
-	GetAndSetResourceConfig(config.Config) config.ResourceType
 }
 
 // AwsResources is a struct to hold multiple instances of AwsResource.

--- a/aws/resources/adapter.go
+++ b/aws/resources/adapter.go
@@ -36,7 +36,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/gruntwork-io/cloud-nuke/config"
@@ -44,16 +43,13 @@ import (
 )
 
 const (
-	// DefaultWaitTimeout is the default timeout for AWS resource deletion waiters.
-	DefaultWaitTimeout = 5 * time.Minute
+	// DefaultWaitTimeout is an alias for resource.DefaultWaitTimeout.
+	// Kept here so existing AWS resource files can reference it without a package qualifier.
+	DefaultWaitTimeout = resource.DefaultWaitTimeout
 
-	// DefaultBatchSize is the default batch size for resource deletion operations.
-	DefaultBatchSize = 50
-
-	// firstSeenTagKey is a tag used to track resource creation time for resources
-	// that don't have a native created-at timestamp (e.g., EIP, ECS Clusters).
-	// This supports the `--older-than <duration>` filtering in cloud-nuke.
-	firstSeenTagKey = "cloud-nuke-first-seen"
+	// DefaultBatchSize is an alias for resource.DefaultBatchSize.
+	// Kept here so existing AWS resource files can reference it without a package qualifier.
+	DefaultBatchSize = resource.DefaultBatchSize
 
 	// awsLambdaTimeFormat is the time format used by AWS Lambda for timestamps
 	// such as LastModified and CreatedDate in function and layer responses.

--- a/aws/resources/ami.go
+++ b/aws/resources/ami.go
@@ -55,7 +55,7 @@ func listAMIs(ctx context.Context, client AMIsAPI, scope resource.Scope, cfg con
 				continue
 			}
 
-			createdTime, err := util.ParseTimestamp(image.CreationDate)
+			createdTime, err := util.ParseTimestampPtr(image.CreationDate)
 			if err != nil {
 				return nil, err
 			}

--- a/aws/resources/data_pipeline.go
+++ b/aws/resources/data_pipeline.go
@@ -70,7 +70,7 @@ func listDataPipelines(ctx context.Context, client DataPipelineAPI, scope resour
 				rv := config.ResourceValue{Name: &name}
 				for _, field := range desc.Fields {
 					if aws.ToString(field.Key) == "@creationTime" {
-						rv.Time, _ = util.ParseTimestamp(field.StringValue)
+						rv.Time, _ = util.ParseTimestampPtr(field.StringValue)
 						break
 					}
 				}

--- a/aws/resources/ec2_subnet.go
+++ b/aws/resources/ec2_subnet.go
@@ -83,7 +83,7 @@ func listEC2Subnets(ctx context.Context, client EC2SubnetAPI, scope resource.Sco
 // getEC2SubnetFirstSeenTime extracts the first seen time from tag map.
 func getEC2SubnetFirstSeenTime(tagMap map[string]string) *time.Time {
 	if firstSeenStr, ok := tagMap[util.FirstSeenTagKey]; ok {
-		if t, err := util.ParseTimestamp(aws.String(firstSeenStr)); err == nil {
+		if t, err := util.ParseTimestamp(firstSeenStr); err == nil {
 			return t
 		}
 	}

--- a/aws/resources/ecs_cluster.go
+++ b/aws/resources/ecs_cluster.go
@@ -177,7 +177,7 @@ func getEcsClusterFirstSeenTag(ctx context.Context, client ECSClustersAPI, clust
 
 	for _, tag := range clusterTags.Tags {
 		if util.IsFirstSeenTag(tag.Key) {
-			firstSeenTime, err = util.ParseTimestamp(tag.Value)
+			firstSeenTime, err = util.ParseTimestampPtr(tag.Value)
 			if err != nil {
 				logging.Debugf("Error parsing the `cloud-nuke-first-seen` tag for ECS cluster with ARN %s", aws.ToString(clusterArn))
 				return firstSeenTime, errors.WithStackTrace(err)
@@ -198,7 +198,7 @@ func setEcsClusterFirstSeenTag(ctx context.Context, client ECSClustersAPI, clust
 		ResourceArn: clusterArn,
 		Tags: []types.Tag{
 			{
-				Key:   aws.String(firstSeenTagKey),
+				Key:   aws.String(util.FirstSeenTagKey),
 				Value: aws.String(firstSeenTime),
 			},
 		},

--- a/aws/resources/guardduty.go
+++ b/aws/resources/guardduty.go
@@ -53,7 +53,7 @@ func listGuardDutyDetectors(ctx context.Context, client GuardDutyAPI, scope reso
 				return nil, err
 			}
 
-			createdAt, err := util.ParseTimestamp(detector.CreatedAt)
+			createdAt, err := util.ParseTimestampPtr(detector.CreatedAt)
 			if err != nil {
 				continue
 			}

--- a/aws/resources/opensearch.go
+++ b/aws/resources/opensearch.go
@@ -151,7 +151,7 @@ func setOpenSearchFirstSeenTag(ctx context.Context, client OpenSearchDomainsAPI,
 		ARN: domainARN,
 		TagList: []types.Tag{
 			{
-				Key:   aws.String(firstSeenTagKey),
+				Key:   aws.String(util.FirstSeenTagKey),
 				Value: aws.String(firstSeenTime),
 			},
 		},
@@ -178,7 +178,7 @@ func getOpenSearchFirstSeenTag(ctx context.Context, client OpenSearchDomainsAPI,
 
 	for _, tag := range domainTags.TagList {
 		if util.IsFirstSeenTag(tag.Key) {
-			firstSeenTime, err := util.ParseTimestamp(tag.Value)
+			firstSeenTime, err := util.ParseTimestampPtr(tag.Value)
 			if err != nil {
 				logging.Errorf("Error parsing the `cloud-nuke-first-seen` tag for OpenSearch Domain with ARN %s", aws.ToString(domainARN))
 				return firstSeenTime, errors.WithStackTrace(err)

--- a/aws/resources/opensearch_test.go
+++ b/aws/resources/opensearch_test.go
@@ -58,7 +58,7 @@ func TestOpenSearch_GetAll(t *testing.T) {
 		},
 		ListTagsOutput: opensearch.ListTagsOutput{
 			TagList: []types.Tag{{
-				Key:   aws.String(firstSeenTagKey),
+				Key:   aws.String(util.FirstSeenTagKey),
 				Value: aws.String(util.FormatTimestamp(now)),
 			}},
 		},

--- a/aws/resources/rds.go
+++ b/aws/resources/rds.go
@@ -30,7 +30,7 @@ func NewDBInstances() AwsResource {
 			r.Client = rds.NewFromConfig(cfg)
 		}),
 		ConfigGetter: func(c config.Config) config.ResourceType {
-			return c.DBInstances.ResourceType
+			return c.DBInstances
 		},
 		Lister: listDBInstances,
 		Nuker:  resource.SequentialDeleteThenWaitAll(deleteDBInstance, waitForDBInstancesDeleted),

--- a/aws/resources/rds_cluster.go
+++ b/aws/resources/rds_cluster.go
@@ -30,7 +30,7 @@ func NewDBClusters() AwsResource {
 			r.Client = rds.NewFromConfig(cfg)
 		}),
 		ConfigGetter: func(c config.Config) config.ResourceType {
-			return c.DBClusters.ResourceType
+			return c.DBClusters
 		},
 		Lister: listDBClusters,
 		Nuker:  resource.SequentialDeleteThenWaitAll(deleteDBCluster, waitForDBClustersDeleted),

--- a/aws/resources/security_hub.go
+++ b/aws/resources/security_hub.go
@@ -67,7 +67,7 @@ func listSecurityHubs(ctx context.Context, client SecurityHubAPI, _ resource.Sco
 }
 
 func shouldIncludeSecurityHub(hub *securityhub.DescribeHubOutput, cfg config.ResourceType) bool {
-	subscribedAt, err := util.ParseTimestamp(hub.SubscribedAt)
+	subscribedAt, err := util.ParseTimestampPtr(hub.SubscribedAt)
 	if err != nil {
 		logging.Debugf(
 			"Could not parse subscribedAt timestamp (%s) of security hub. Excluding from delete.", *hub.SubscribedAt)

--- a/aws/resources/sns.go
+++ b/aws/resources/sns.go
@@ -113,7 +113,7 @@ func getFirstSeenSNSTag(ctx context.Context, client SNSTopicAPI, topicArn string
 
 	for _, tag := range response.Tags {
 		if util.IsFirstSeenTag(tag.Key) {
-			return util.ParseTimestamp(tag.Value)
+			return util.ParseTimestampPtr(tag.Value)
 		}
 	}
 

--- a/aws/resources/types.go
+++ b/aws/resources/types.go
@@ -1,25 +1,16 @@
 package resources
 
 import (
-	"context"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/resource"
 )
 
 // AwsResource is an interface that represents a single AWS resource.
+// It embeds the provider-agnostic NukeableResource interface and adds AWS-specific Init.
 // This interface is structurally identical to aws.AwsResource but defined here
 // to avoid a circular import (aws imports resources). Go's structural typing
 // ensures that types satisfying this interface also satisfy aws.AwsResource.
-// This interface is satisfied by AwsResourceAdapter[C] which wraps resource.Resource[C].
 type AwsResource interface {
+	resource.NukeableResource
 	Init(cfg aws.Config)
-	ResourceName() string
-	ResourceIdentifiers() []string
-	MaxBatchSize() int
-	Nuke(ctx context.Context, identifiers []string) ([]resource.NukeResult, error)
-	GetAndSetIdentifiers(c context.Context, configObj config.Config) ([]string, error)
-	IsNukable(string) (bool, error)
-	GetAndSetResourceConfig(config.Config) config.ResourceType
 }

--- a/commands/aws_commands.go
+++ b/commands/aws_commands.go
@@ -99,6 +99,22 @@ func awsInspect(c *cli.Context) error {
 		return handleListResourceTypes()
 	}
 
+	// Parse and set log level
+	if err := parseLogLevel(c); err != nil {
+		return err
+	}
+
+	// Load config file if provided (matches awsNuke behavior)
+	configObj, err := loadConfigFile(c.String(FlagConfig))
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	// Apply timeout to config (matches awsNuke behavior)
+	if err = parseAndApplyTimeout(c, &configObj); err != nil {
+		return err
+	}
+
 	// Build AWS query from CLI flags
 	query, err := generateQuery(c, c.Bool(FlagListUnaliasedKMSKeys), nil, false)
 	if err != nil {
@@ -110,7 +126,7 @@ func awsInspect(c *cli.Context) error {
 	outputFile := c.String(FlagOutputFile)
 
 	// Retrieve and display resources without deleting them
-	_, err = handleGetResourcesWithFormat(c, config.Config{}, query, outputFormat, outputFile)
+	_, err = handleGetResourcesWithFormat(c, configObj, query, outputFormat, outputFile)
 	return err
 }
 

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -83,6 +83,7 @@ func CreateCli(version string) *cli.App {
 				InspectResourceTypeFlags(),
 				CommonTimeFlags(),
 				CommonOutputFlags(),
+				[]cli.Flag{ConfigFlag()},
 			),
 		}, {
 			Name:   "defaults-aws",
@@ -117,6 +118,7 @@ func CreateCli(version string) *cli.App {
 				CommonTimeFlags(),
 				CommonOutputFlags(),
 				[]cli.Flag{
+					ConfigFlag(),
 					&cli.BoolFlag{
 						Name:  FlagListUnaliasedKMSKeys,
 						Usage: "List KMS keys that do not have aliases associated with them.",

--- a/commands/gcp_commands.go
+++ b/commands/gcp_commands.go
@@ -59,7 +59,7 @@ func gcpNuke(c *cli.Context) error {
 	outputFile := c.String(FlagOutputFile)
 
 	if err := query.Validate(); err != nil {
-		return err
+		return errors.WithStackTrace(err)
 	}
 
 	return gcpNukeHelper(c, configObj, query, outputFormat, outputFile)
@@ -83,13 +83,22 @@ func gcpInspect(c *cli.Context) error {
 		return err
 	}
 
+	// Load config file if provided (matches gcpNuke behavior)
+	configObj, err := loadConfigFile(c.String(FlagConfig))
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
 	query := &gcp.Query{
 		ProjectID:            c.String(FlagProjectID),
 		ResourceTypes:        c.StringSlice(FlagResourceType),
 		ExcludeResourceTypes: c.StringSlice(FlagExcludeResourceType),
 	}
 
-	configObj := config.Config{}
+	// Apply timeout to config (matches gcpNuke behavior)
+	if err := parseAndApplyTimeout(c, &configObj); err != nil {
+		return err
+	}
 
 	// Apply time filters to config
 	if err := parseAndApplyTimeFilters(c, &configObj); err != nil {
@@ -101,11 +110,11 @@ func gcpInspect(c *cli.Context) error {
 	outputFile := c.String(FlagOutputFile)
 
 	if err := query.Validate(); err != nil {
-		return err
+		return errors.WithStackTrace(err)
 	}
 
 	// Retrieve and display resources without deleting them
-	_, err := handleGetGcpResourcesWithFormat(c, configObj, query, outputFormat, outputFile)
+	_, err = handleGetGcpResourcesWithFormat(c, configObj, query, outputFormat, outputFile)
 	return err
 }
 
@@ -122,13 +131,16 @@ func gcpNukeHelper(c *cli.Context, configObj config.Config, query *gcp.Query, ou
 	}
 	defer cleanup()
 
+	// Emit scan started event with query parameters
+	collector.Emit(buildGcpScanStarted(query))
+
 	// Retrieve all matching resources (emits ResourceFound events via collector)
 	account, err := gcp.GetAllResources(c.Context, query, configObj, collector)
 	if err != nil {
 		telemetry.TrackEvent(commonTelemetry.EventContext{
 			EventName: "Error getting resources",
 		}, map[string]interface{}{})
-		return errors.WithStackTrace(err)
+		return errors.WithStackTrace(gcp.ResourceInspectionError{Underlying: err})
 	}
 
 	// Signal scan complete - renderer will show found resources table
@@ -161,13 +173,16 @@ func handleGetGcpResourcesWithFormat(c *cli.Context, configObj config.Config, qu
 	}
 	defer cleanup()
 
+	// Emit scan started event with query parameters
+	collector.Emit(buildGcpScanStarted(query))
+
 	// Retrieve all resources matching the filters (emits ResourceFound events via collector)
 	accountResources, err := gcp.GetAllResources(c.Context, query, configObj, collector)
 	if err != nil {
 		telemetry.TrackEvent(commonTelemetry.EventContext{
 			EventName: "Error inspecting resources",
 		}, map[string]interface{}{})
-		return nil, errors.WithStackTrace(err)
+		return nil, errors.WithStackTrace(gcp.ResourceInspectionError{Underlying: err})
 	}
 
 	// Signal scan complete - renderer will show found resources table
@@ -179,6 +194,14 @@ func handleGetGcpResourcesWithFormat(c *cli.Context, configObj config.Config, qu
 // handleListGcpResourceTypes displays all available GCP resource types that can be targeted.
 func handleListGcpResourceTypes() error {
 	return printResourceTypes("GCP Resource Types", gcp.ListResourceTypes())
+}
+
+// buildGcpScanStarted creates a ScanStarted event from a GCP query.
+func buildGcpScanStarted(query *gcp.Query) reporting.ScanStarted {
+	return reporting.ScanStarted{
+		Regions:       query.Regions,
+		ResourceTypes: query.ResourceTypes,
+	}
 }
 
 // setupGcpReporting creates a collector and appropriate renderer for GCP operations.

--- a/config/config.go
+++ b/config/config.go
@@ -8,16 +8,26 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/cloud-nuke/logging"
+	cnutil "github.com/gruntwork-io/cloud-nuke/util"
 	"gopkg.in/yaml.v2"
 )
 
 const (
-	DefaultAwsResourceExclusionTagKey   = "cloud-nuke-excluded"
-	DefaultAwsResourceExclusionTagValue = "true"
-	CloudNukeAfterExclusionTagKey       = "cloud-nuke-after"
-	CloudNukeAfterTimeFormat            = time.RFC3339
-	CloudNukeAfterTimeFormatLegacy      = time.DateTime
+	DefaultResourceExclusionTagKey   = "cloud-nuke-excluded"
+	DefaultResourceExclusionTagValue = "true"
+	CloudNukeAfterExclusionTagKey    = "cloud-nuke-after"
+	CloudNukeAfterTimeFormat         = time.RFC3339
+	CloudNukeAfterTimeFormatLegacy   = time.DateTime
+
+	// Deprecated: Use DefaultResourceExclusionTagKey instead.
+	DefaultAwsResourceExclusionTagKey = DefaultResourceExclusionTagKey
+	// Deprecated: Use DefaultResourceExclusionTagValue instead.
+	DefaultAwsResourceExclusionTagValue = DefaultResourceExclusionTagValue
 )
+
+// defaultExclusionTagValueExpr is a compiled regex for the default exclusion tag value,
+// cached at package level to avoid recompiling on every call to getExclusionTagValue().
+var defaultExclusionTagValueExpr = Expression{RE: *regexp.MustCompile(DefaultResourceExclusionTagValue)}
 
 // Config - the config object we pass around
 type Config struct {
@@ -46,8 +56,8 @@ type Config struct {
 	DataSyncLocation                ResourceType               `yaml:"DataSyncLocation"`
 	DataSyncTask                    ResourceType               `yaml:"DataSyncTask"`
 	DBGlobalClusters                ResourceType               `yaml:"DBGlobalClusters"`
-	DBClusters                      AWSProtectableResourceType `yaml:"DBClusters"`
-	DBInstances                     AWSProtectableResourceType `yaml:"DBInstances"`
+	DBClusters                      ResourceType               `yaml:"DBClusters"`
+	DBInstances                     ResourceType               `yaml:"DBInstances"`
 	DBGlobalClusterMemberships      ResourceType               `yaml:"DBGlobalClusterMemberships"`
 	DBSubnetGroups                  ResourceType               `yaml:"DBSubnetGroups"`
 	DynamoDB                        ResourceType               `yaml:"DynamoDB"`
@@ -186,8 +196,8 @@ func (c *Config) allResourceTypes() []*ResourceType {
 		&c.DataSyncLocation,
 		&c.DataSyncTask,
 		&c.DBGlobalClusters,
-		&c.DBClusters.ResourceType,
-		&c.DBInstances.ResourceType,
+		&c.DBClusters,
+		&c.DBInstances,
 		&c.DBGlobalClusterMemberships,
 		&c.DBSubnetGroups,
 		&c.DynamoDB,
@@ -361,10 +371,6 @@ type KMSCustomerKeyResourceType struct {
 
 type EC2ResourceType struct {
 	DefaultOnly  bool `yaml:"default_only"`
-	ResourceType `yaml:",inline"`
-}
-
-type AWSProtectableResourceType struct {
 	ResourceType `yaml:",inline"`
 }
 
@@ -543,25 +549,17 @@ func (r ResourceType) ShouldIncludeBasedOnTime(time time.Time) bool {
 }
 
 func (r ResourceType) getExclusionTag() string {
-	return DefaultAwsResourceExclusionTagKey
+	return DefaultResourceExclusionTagKey
 }
 
 func (r ResourceType) getExclusionTagValue() *Expression {
-	return &Expression{RE: *regexp.MustCompile(DefaultAwsResourceExclusionTagValue)}
+	return &defaultExclusionTagValueExpr
 }
 
+// ParseTimestamp delegates to util.ParseTimestamp, which tries RFC3339,
+// time.DateTime, and bare ISO 8601 formats.
 func ParseTimestamp(timestamp string) (*time.Time, error) {
-	parsed, err := time.Parse(CloudNukeAfterTimeFormat, timestamp)
-	if err != nil {
-		logging.Debugf("Error parsing the timestamp into a `%v` Time format. Trying parsing the timestamp using the legacy `time.DateTime` format.", CloudNukeAfterTimeFormat)
-		parsed, err = time.Parse(CloudNukeAfterTimeFormatLegacy, timestamp)
-		if err != nil {
-			logging.Debugf("Error parsing the timestamp into legacy `time.DateTime` Time format")
-			return nil, err
-		}
-	}
-
-	return &parsed, nil
+	return cnutil.ParseTimestamp(timestamp)
 }
 
 func (r ResourceType) ShouldIncludeBasedOnTag(tags map[string]string) bool {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,8 +38,8 @@ func emptyConfig() *Config {
 		DataSyncLocation:                ResourceType{FilterRule{}, FilterRule{}, "", false},
 		DataSyncTask:                    ResourceType{FilterRule{}, FilterRule{}, "", false},
 		DBGlobalClusters:                ResourceType{FilterRule{}, FilterRule{}, "", false},
-		DBClusters:                      AWSProtectableResourceType{ResourceType: ResourceType{FilterRule{}, FilterRule{}, "", false}},
-		DBInstances:                     AWSProtectableResourceType{ResourceType: ResourceType{FilterRule{}, FilterRule{}, "", false}},
+		DBClusters:                      ResourceType{FilterRule{}, FilterRule{}, "", false},
+		DBInstances:                     ResourceType{FilterRule{}, FilterRule{}, "", false},
 		DBGlobalClusterMemberships:      ResourceType{FilterRule{}, FilterRule{}, "", false},
 		DBSubnetGroups:                  ResourceType{FilterRule{}, FilterRule{}, "", false},
 		DynamoDB:                        ResourceType{FilterRule{}, FilterRule{}, "", false},
@@ -903,8 +903,6 @@ func TestAllResourceTypesComplete(t *testing.T) {
 		case reflect.TypeOf(ResourceType{}):
 			rtPtr = field.Addr().Pointer()
 		case reflect.TypeOf(EC2ResourceType{}):
-			rtPtr = field.FieldByName("ResourceType").Addr().Pointer()
-		case reflect.TypeOf(AWSProtectableResourceType{}):
 			rtPtr = field.FieldByName("ResourceType").Addr().Pointer()
 		case reflect.TypeOf(KMSCustomerKeyResourceType{}):
 			rtPtr = field.FieldByName("ResourceType").Addr().Pointer()

--- a/gcp/errors.go
+++ b/gcp/errors.go
@@ -2,12 +2,27 @@ package gcp
 
 import (
 	"errors"
+	"fmt"
 
 	"google.golang.org/api/googleapi"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// ResourceInspectionError wraps errors from GCP resource scanning,
+// matching the pattern used by aws.ResourceInspectionError.
+type ResourceInspectionError struct {
+	Underlying error
+}
+
+func (err ResourceInspectionError) Error() string {
+	return fmt.Sprintf("Error encountered when querying for GCP resources. Original error: %v", err.Underlying)
+}
+
+func (err ResourceInspectionError) Unwrap() error {
+	return err.Underlying
+}
 
 // isServiceDisabledError checks whether the error (or any wrapped cause) is a
 // gRPC SERVICE_DISABLED error from googleapis.com. It walks the error chain

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/gcp/resources"
-
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/reporting"
+	"github.com/gruntwork-io/cloud-nuke/resource"
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/collections"
@@ -19,18 +19,10 @@ import (
 )
 
 // IsNukeable checks whether a resource type should be nuked based on the
-// requested resource types and exclude lists. An empty include list or the
-// special value "all" means nuke everything, minus any excluded types.
+// requested resource types and exclude lists. This is a convenience wrapper
+// around util.IsNukeable for backward compatibility.
 func IsNukeable(resourceType string, resourceTypes []string, excludeResourceTypes []string) bool {
-	if collections.ListContainsElement(excludeResourceTypes, resourceType) {
-		return false
-	}
-	if len(resourceTypes) == 0 ||
-		collections.ListContainsElement(resourceTypes, "all") ||
-		collections.ListContainsElement(resourceTypes, resourceType) {
-		return true
-	}
-	return false
+	return util.IsNukeable(resourceType, resourceTypes, excludeResourceTypes)
 }
 
 // GetAllResources lists all GCP resources that can be deleted.
@@ -38,6 +30,8 @@ func GetAllResources(ctx context.Context, query *Query, configObj config.Config,
 	allResources := GcpProjectResources{
 		Resources: map[string]GcpResources{},
 	}
+
+	scanCb := gcpScanCallbacks(collector, query.ResourceTypes)
 
 	for _, region := range query.Regions {
 		cfg := resources.GcpConfig{ProjectID: query.ProjectID, Region: region}
@@ -50,48 +44,10 @@ func GetAllResources(ctx context.Context, query *Query, configObj config.Config,
 				continue
 			}
 
-			// Emit scan progress event
-			collector.Emit(reporting.ScanProgress{
-				ResourceType: resourceName,
-				Region:       region,
-			})
-
-			// Get all resource identifiers
-			identifiers, err := (*res).GetAndSetIdentifiers(ctx, configObj)
-			if err != nil {
-				if isServiceDisabledError(err) && !collections.ListContainsElement(query.ResourceTypes, resourceName) {
-					logging.Debugf("Skipping %s: API is disabled in this project", resourceName)
-					continue
-				}
-				logging.Debugf("Error getting identifiers for %s: %v", resourceName, err)
-				collector.Emit(reporting.GeneralError{
-					ResourceType: resourceName,
-					Description:  fmt.Sprintf("Unable to retrieve %s", resourceName),
-					Error:        err.Error(),
-				})
-				continue
-			}
-
-			// Only append if we have non-empty identifiers
+			identifiers := resource.ScanResource(ctx, *res, region, configObj, scanCb)
 			if len(identifiers) > 0 {
-				logging.Infof("Found %d %s resources", len(identifiers), resourceName)
 				allResources.Resources[region] = GcpResources{
 					Resources: append(allResources.Resources[region].Resources, res),
-				}
-
-				// Emit ResourceFound events for each identifier
-				for _, id := range identifiers {
-					nukable, reason := true, ""
-					if _, err := (*res).IsNukable(id); err != nil {
-						nukable, reason = false, err.Error()
-					}
-					collector.Emit(reporting.ResourceFound{
-						ResourceType: resourceName,
-						Region:       region,
-						Identifier:   id,
-						Nukable:      nukable,
-						Reason:       reason,
-					})
 				}
 			}
 		}
@@ -125,86 +81,12 @@ func NukeAllResources(ctx context.Context, account *GcpProjectResources, regions
 // nukeAllResourcesInRegion nukes all resources in a single region.
 func nukeAllResourcesInRegion(ctx context.Context, account *GcpProjectResources, region string, collector *reporting.Collector) error {
 	var allErrors *multierror.Error
+	nukeCb := gcpNukeCallbacks(collector)
 
 	resourcesInRegion := account.Resources[region]
 	for _, gcpResource := range resourcesInRegion.Resources {
-		if err := nukeResource(ctx, gcpResource, region, collector); err != nil {
+		if err := resource.NukeInBatches(ctx, *gcpResource, region, nukeCb); err != nil {
 			allErrors = multierror.Append(allErrors, err)
-		}
-	}
-
-	return allErrors.ErrorOrNil()
-}
-
-// nukeResource nukes a single GCP resource type
-func nukeResource(ctx context.Context, gcpResource *GcpResource, region string, collector *reporting.Collector) error {
-	// Filter to only nukable resources
-	var nukableIdentifiers []string
-	for _, id := range (*gcpResource).ResourceIdentifiers() {
-		if nukable, reason := (*gcpResource).IsNukable(id); !nukable {
-			logging.Debugf("[Skipping] %s %s because %v", (*gcpResource).ResourceName(), id, reason)
-			continue
-		}
-		nukableIdentifiers = append(nukableIdentifiers, id)
-	}
-
-	if len(nukableIdentifiers) == 0 {
-		return nil
-	}
-
-	// Split API calls into batches
-	logging.Debugf("Terminating %d %s in batches", len(nukableIdentifiers), (*gcpResource).ResourceName())
-	batches := util.Split(nukableIdentifiers, (*gcpResource).MaxBatchSize())
-
-	var allErrors *multierror.Error
-
-	for i, batch := range batches {
-		// Emit progress event (CLIRenderer updates its progress bar)
-		collector.Emit(reporting.NukeProgress{
-			ResourceType: (*gcpResource).ResourceName(),
-			Region:       region,
-			BatchSize:    len(batch),
-		})
-
-		results, err := (*gcpResource).Nuke(ctx, batch)
-
-		// Emit ResourceDeleted for each result
-		for _, result := range results {
-			errStr := ""
-			if result.Error != nil {
-				errStr = result.Error.Error()
-			}
-			collector.Emit(reporting.ResourceDeleted{
-				ResourceType: (*gcpResource).ResourceName(),
-				Region:       region,
-				Identifier:   result.Identifier,
-				Success:      result.Error == nil,
-				Error:        errStr,
-			})
-		}
-
-		if err != nil {
-			if isQuotaExhaustedError(err) {
-				logging.Debug(
-					"Quota exceeded. Waiting 1 minute before making new requests",
-				)
-				time.Sleep(1 * time.Minute)
-				continue
-			}
-
-			allErrors = multierror.Append(allErrors, fmt.Errorf("[%s] %s: %w", region, (*gcpResource).ResourceName(), err))
-
-			// Report to telemetry - aggregated metrics of failures per resources.
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: fmt.Sprintf("error:Nuke:%s", (*gcpResource).ResourceName()),
-			}, map[string]interface{}{
-				"region": region,
-			})
-		}
-
-		if i != len(batches)-1 {
-			logging.Debug("Sleeping for 10 seconds before processing next batch...")
-			time.Sleep(10 * time.Second)
 		}
 	}
 
@@ -219,4 +101,84 @@ func ListResourceTypes() []string {
 	}
 	sort.Strings(resourceTypes)
 	return resourceTypes
+}
+
+// gcpScanCallbacks creates scan callbacks wired to the reporting collector and telemetry.
+// The requestedTypes parameter is used to determine if service-disabled errors should be skipped.
+func gcpScanCallbacks(collector *reporting.Collector, requestedTypes []string) resource.ScanCallbacks {
+	return resource.ScanCallbacks{
+		OnScanProgress: func(resourceName, region string) {
+			collector.Emit(reporting.ScanProgress{
+				ResourceType: resourceName,
+				Region:       region,
+			})
+		},
+		OnScanError: func(resourceName, region string, err error) {
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: fmt.Sprintf("error:GetIdentifiers:%s", resourceName),
+			}, map[string]interface{}{
+				"region": region,
+			})
+			collector.Emit(reporting.GeneralError{
+				ResourceType: resourceName,
+				Description:  fmt.Sprintf("Unable to retrieve %s", resourceName),
+				Error:        err.Error(),
+			})
+		},
+		OnScanComplete: func(resourceName string, count int, duration time.Duration) {
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: fmt.Sprintf("Done getting %s identifiers", resourceName),
+			}, map[string]interface{}{
+				"recordCount": count,
+				"actionTime":  duration.Seconds(),
+			})
+		},
+		OnResourceFound: func(resourceName, region, id string, nukable bool, reason string) {
+			collector.Emit(reporting.ResourceFound{
+				ResourceType: resourceName,
+				Region:       region,
+				Identifier:   id,
+				Nukable:      nukable,
+				Reason:       reason,
+			})
+		},
+		ShouldSkipError: func(resourceName string, err error) bool {
+			// Skip service-disabled errors only when the resource wasn't explicitly requested
+			return isServiceDisabledError(err) && !collections.ListContainsElement(requestedTypes, resourceName)
+		},
+	}
+}
+
+// gcpNukeCallbacks creates nuke callbacks wired to the reporting collector and telemetry.
+func gcpNukeCallbacks(collector *reporting.Collector) resource.NukeBatchCallbacks {
+	return resource.NukeBatchCallbacks{
+		OnBatchStart: func(resourceName, region string, batchSize int) {
+			collector.Emit(reporting.NukeProgress{
+				ResourceType: resourceName,
+				Region:       region,
+				BatchSize:    batchSize,
+			})
+		},
+		OnResult: func(resourceName, region string, result resource.NukeResult) {
+			errStr := ""
+			if result.Error != nil {
+				errStr = result.Error.Error()
+			}
+			collector.Emit(reporting.ResourceDeleted{
+				ResourceType: resourceName,
+				Region:       region,
+				Identifier:   result.Identifier,
+				Success:      result.Error == nil,
+				Error:        errStr,
+			})
+		},
+		OnNukeError: func(resourceName, region string, err error) {
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: fmt.Sprintf("error:Nuke:%s", resourceName),
+			}, map[string]interface{}{
+				"region": region,
+			})
+		},
+		IsRetryableError: isQuotaExhaustedError,
+	}
 }

--- a/gcp/query.go
+++ b/gcp/query.go
@@ -2,7 +2,6 @@ package gcp
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/gruntwork-io/go-commons/collections"
 )
@@ -15,14 +14,12 @@ type Query struct {
 	ExcludeResourceTypes []string
 	Regions              []string
 	ExcludeRegions       []string
-	ExcludeAfter         *time.Time
-	IncludeAfter         *time.Time
-	Timeout              *time.Duration
 }
 
 // Validate ensures the query has valid defaults.
 // If no regions are specified, it defaults to GlobalRegion.
 // ExcludeRegions are filtered out from the region list.
+// Validates that requested resource types exist.
 func (q *Query) Validate() error {
 	if len(q.Regions) == 0 {
 		q.Regions = []string{GlobalRegion}
@@ -40,6 +37,37 @@ func (q *Query) Validate() error {
 
 	if len(q.Regions) == 0 {
 		return fmt.Errorf("no regions to process after applying exclusions")
+	}
+
+	// Validate resource types and exclude resource types
+	needsValidation := (len(q.ResourceTypes) > 0 && !collections.ListContainsElement(q.ResourceTypes, "all")) ||
+		len(q.ExcludeResourceTypes) > 0
+	if needsValidation {
+		validTypes := ListResourceTypes()
+
+		if len(q.ResourceTypes) > 0 && !collections.ListContainsElement(q.ResourceTypes, "all") {
+			var invalidTypes []string
+			for _, rt := range q.ResourceTypes {
+				if !collections.ListContainsElement(validTypes, rt) {
+					invalidTypes = append(invalidTypes, rt)
+				}
+			}
+			if len(invalidTypes) > 0 {
+				return fmt.Errorf("invalid resource type(s) %v specified. Use --list-resource-types to see valid types", invalidTypes)
+			}
+		}
+
+		if len(q.ExcludeResourceTypes) > 0 {
+			var invalidTypes []string
+			for _, rt := range q.ExcludeResourceTypes {
+				if !collections.ListContainsElement(validTypes, rt) {
+					invalidTypes = append(invalidTypes, rt)
+				}
+			}
+			if len(invalidTypes) > 0 {
+				return fmt.Errorf("invalid exclude resource type(s) %v specified. Use --list-resource-types to see valid types", invalidTypes)
+			}
+		}
 	}
 
 	return nil

--- a/gcp/resources/adapter.go
+++ b/gcp/resources/adapter.go
@@ -3,14 +3,12 @@ package resources
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/gruntwork-io/cloud-nuke/resource"
 )
 
 const (
-	DefaultWaitTimeout = 5 * time.Minute
-	DefaultBatchSize   = 50
+	DefaultWaitTimeout = resource.DefaultWaitTimeout
 )
 
 // GcpConfig holds the configuration needed to initialize a GCP resource,

--- a/gcp/resources/cloud_function.go
+++ b/gcp/resources/cloud_function.go
@@ -20,7 +20,7 @@ import (
 func NewCloudFunctions() GcpResource {
 	return NewGcpResource(&resource.Resource[*functions.FunctionClient]{
 		ResourceTypeName: "cloud-function",
-		BatchSize:        DefaultBatchSize,
+		BatchSize:        resource.DefaultBatchSize,
 		InitClient: WrapGcpInitClient(func(r *resource.Resource[*functions.FunctionClient], cfg GcpConfig) {
 			r.Scope.ProjectID = cfg.ProjectID
 			client, err := functions.NewFunctionClient(context.Background())
@@ -71,6 +71,7 @@ func listCloudFunctions(ctx context.Context, client *functions.FunctionClient, s
 		resourceValue := config.ResourceValue{
 			Name: &name,
 			Time: &resourceTime,
+			Tags: fn.Labels,
 		}
 
 		if cfg.ShouldInclude(resourceValue) {

--- a/gcp/resources/gcs_bucket.go
+++ b/gcp/resources/gcs_bucket.go
@@ -18,7 +18,7 @@ import (
 func NewGCSBuckets() GcpResource {
 	return NewGcpResource(&resource.Resource[*storage.Client]{
 		ResourceTypeName: "gcs-bucket",
-		BatchSize:        DefaultBatchSize,
+		BatchSize:        resource.DefaultBatchSize,
 		InitClient: WrapGcpInitClient(func(r *resource.Resource[*storage.Client], cfg GcpConfig) {
 			r.Scope.ProjectID = cfg.ProjectID
 			client, err := storage.NewClient(context.Background())
@@ -54,6 +54,7 @@ func listGCSBuckets(ctx context.Context, client *storage.Client, scope resource.
 		resourceValue := config.ResourceValue{
 			Name: &bucket.Name,
 			Time: &bucket.Created,
+			Tags: bucket.Labels,
 		}
 
 		if cfg.ShouldInclude(resourceValue) {
@@ -105,7 +106,10 @@ func deleteGCSBucket(ctx context.Context, client *storage.Client, name *string) 
 }
 
 // emptyBucket deletes all objects in a bucket.
+// Returns an error if any object deletions fail, so the caller knows the bucket may not be fully empty.
 func emptyBucket(ctx context.Context, bucket *storage.BucketHandle, bucketName string) error {
+	var deleteErrors int
+	var lastErr error
 	it := bucket.Objects(ctx, nil)
 	for {
 		obj, err := it.Next()
@@ -118,15 +122,23 @@ func emptyBucket(ctx context.Context, bucket *storage.BucketHandle, bucketName s
 
 		if err := bucket.Object(obj.Name).Delete(ctx); err != nil {
 			logging.Debugf("Error deleting object %s in bucket %s: %v", obj.Name, bucketName, err)
+			lastErr = err
+			deleteErrors++
 			// Continue trying to delete other objects
 		}
+	}
+	if deleteErrors > 0 {
+		return fmt.Errorf("failed to delete %d objects in bucket %s (last error: %w)", deleteErrors, bucketName, lastErr)
 	}
 	return nil
 }
 
 // forceEmptyBucket deletes all object versions and delete markers in a bucket.
+// Continues on individual object deletion errors and returns the aggregate result.
 func forceEmptyBucket(ctx context.Context, bucket *storage.BucketHandle, bucketName string) error {
 	it := bucket.Objects(ctx, &storage.Query{Versions: true})
+	var deleteErrors int
+	var lastErr error
 	for {
 		obj, err := it.Next()
 		if errors.Is(err, iterator.Done) {
@@ -137,9 +149,14 @@ func forceEmptyBucket(ctx context.Context, bucket *storage.BucketHandle, bucketN
 		}
 
 		if err := bucket.Object(obj.Name).Generation(obj.Generation).Delete(ctx); err != nil {
-			return fmt.Errorf("error deleting object version %s (gen %d) in bucket %s: %w",
+			logging.Debugf("Error deleting object version %s (gen %d) in bucket %s: %v",
 				obj.Name, obj.Generation, bucketName, err)
+			deleteErrors++
+			lastErr = err
 		}
+	}
+	if deleteErrors > 0 {
+		return fmt.Errorf("failed to delete %d object versions in bucket %s (last error: %w)", deleteErrors, bucketName, lastErr)
 	}
 	return nil
 }

--- a/gcp/resources/types.go
+++ b/gcp/resources/types.go
@@ -1,23 +1,15 @@
 package resources
 
 import (
-	"context"
-
-	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/resource"
 )
 
 // GcpResource is an interface that represents a single GCP resource.
+// It embeds the provider-agnostic NukeableResource interface and adds GCP-specific Init.
 // This interface is satisfied by GcpResourceAdapter[C] which wraps resource.Resource[C].
 type GcpResource interface {
+	resource.NukeableResource
 	Init(cfg GcpConfig)
-	ResourceName() string
-	ResourceIdentifiers() []string
-	MaxBatchSize() int
-	Nuke(ctx context.Context, identifiers []string) ([]resource.NukeResult, error)
-	GetAndSetIdentifiers(ctx context.Context, configObj config.Config) ([]string, error)
-	IsNukable(identifier string) (bool, error)
-	GetAndSetResourceConfig(configObj config.Config) config.ResourceType
 }
 
 // GcpResources is a struct to hold multiple instances of GcpResource.

--- a/reporting/events.go
+++ b/reporting/events.go
@@ -14,9 +14,8 @@ type ScanProgress struct {
 
 func (ScanProgress) EventType() string { return "scan_progress" }
 
-// ScanStarted is emitted at the beginning of AWS resource scanning.
+// ScanStarted is emitted at the beginning of resource scanning (both AWS and GCP).
 // Used by CLI renderer to display query parameters.
-// Note: GCP does not emit this event as it has no interesting query parameters to display.
 type ScanStarted struct {
 	Regions              []string
 	ResourceTypes        []string

--- a/resource/batch_deleter.go
+++ b/resource/batch_deleter.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/util"
 )
 
 const (
@@ -59,7 +59,7 @@ func SimpleBatchDeleter[C any](deleteFn DeleteFunc[C]) NukerFunc[C] {
 				defer wg.Done()
 				defer func() { <-sem }()
 
-				idStr := aws.ToString(identifier)
+				idStr := util.DerefString(identifier)
 				err := deleteFn(ctx, client, identifier)
 
 				mu.Lock()
@@ -83,7 +83,7 @@ func SequentialDeleter[C any](deleteFn DeleteFunc[C]) NukerFunc[C] {
 
 		results := make([]NukeResult, 0, len(identifiers))
 		for _, id := range identifiers {
-			idStr := aws.ToString(id)
+			idStr := util.DerefString(id)
 			err := deleteFn(ctx, client, id)
 			results = append(results, NukeResult{Identifier: idStr, Error: err})
 		}
@@ -123,7 +123,7 @@ func BulkResultDeleter[C any](deleteFn BulkResultDeleteFunc[C]) NukerFunc[C] {
 
 		ids := make([]string, len(identifiers))
 		for i, id := range identifiers {
-			ids[i] = aws.ToString(id)
+			ids[i] = util.DerefString(id)
 		}
 
 		return deleteFn(ctx, client, ids)
@@ -159,7 +159,7 @@ func MultiStepDeleter[C any](steps ...DeleteFunc[C]) NukerFunc[C] {
 
 		results := make([]NukeResult, 0, len(identifiers))
 		for _, id := range identifiers {
-			idStr := aws.ToString(id)
+			idStr := util.DerefString(id)
 			var stepErr error
 
 			for i, step := range steps {
@@ -204,7 +204,7 @@ func SequentialDeleteThenWaitAll[C any](deleteFn DeleteFunc[C], waitAllFn WaitAl
 
 		// Phase 1: Delete all resources sequentially
 		for _, id := range identifiers {
-			idStr := aws.ToString(id)
+			idStr := util.DerefString(id)
 			err := deleteFn(ctx, client, id)
 
 			if err != nil {
@@ -263,7 +263,7 @@ func ConcurrentDeleteThenWaitAll[C any](deleteFn DeleteFunc[C], waitAllFn WaitAl
 				defer wg.Done()
 				defer func() { <-sem }()
 
-				idStr := aws.ToString(identifier)
+				idStr := util.DerefString(identifier)
 				err := deleteFn(ctx, client, identifier)
 				deleteResults[idx] = deleteResult{idStr: idStr, err: err}
 

--- a/resource/orchestration.go
+++ b/resource/orchestration.go
@@ -1,0 +1,169 @@
+package resource
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/hashicorp/go-multierror"
+)
+
+// ScanCallbacks contains hooks called during the scan loop.
+// Callers wire these to reporting/telemetry without creating a dependency.
+type ScanCallbacks struct {
+	// OnScanProgress is called before scanning each resource type
+	OnScanProgress func(resourceName, region string)
+	// OnScanError is called when GetAndSetIdentifiers fails
+	OnScanError func(resourceName, region string, err error)
+	// OnScanComplete is called after scanning each resource type (success or failure)
+	OnScanComplete func(resourceName string, count int, duration time.Duration)
+	// OnResourceFound is called for each discovered resource identifier
+	OnResourceFound func(resourceName, region, id string, nukable bool, reason string)
+	// ShouldSkipError returns true if the error should cause the resource to be silently skipped.
+	// Used for GCP service-disabled errors when the resource wasn't explicitly requested.
+	// Receives the resource name and the error.
+	ShouldSkipError func(resourceName string, err error) bool
+}
+
+// ScanResource scans a single resource type: calls GetAndSetResourceConfig,
+// GetAndSetIdentifiers, and invokes callbacks. Returns identifiers found (nil if none/error).
+func ScanResource(ctx context.Context, res NukeableResource, region string, configObj config.Config, cb ScanCallbacks) []string {
+	resourceName := res.ResourceName()
+
+	res.GetAndSetResourceConfig(configObj)
+
+	if cb.OnScanProgress != nil {
+		cb.OnScanProgress(resourceName, region)
+	}
+
+	start := time.Now()
+	identifiers, err := res.GetAndSetIdentifiers(ctx, configObj)
+	duration := time.Since(start)
+
+	if err != nil {
+		if cb.ShouldSkipError != nil && cb.ShouldSkipError(resourceName, err) {
+			logging.Debugf("Skipping %s: %v", resourceName, err)
+			return nil
+		}
+
+		logging.Errorf("Unable to retrieve %s: %v", resourceName, err)
+		if cb.OnScanError != nil {
+			cb.OnScanError(resourceName, region, err)
+		}
+	}
+
+	if cb.OnScanComplete != nil {
+		cb.OnScanComplete(resourceName, len(identifiers), duration)
+	}
+
+	if len(identifiers) > 0 {
+		logging.Infof("Found %d %s resources in %s", len(identifiers), resourceName, region)
+
+		if cb.OnResourceFound != nil {
+			for _, id := range identifiers {
+				nukable, reason := true, ""
+				if _, nukErr := res.IsNukable(id); nukErr != nil {
+					nukable, reason = false, nukErr.Error()
+				}
+				cb.OnResourceFound(resourceName, region, id, nukable, reason)
+			}
+		}
+	}
+
+	return identifiers
+}
+
+const (
+	// DefaultMaxThrottleRetries is the maximum number of times to retry a batch after a throttle/quota error.
+	DefaultMaxThrottleRetries = 3
+	// DefaultBatchDelay is the sleep duration between batches.
+	DefaultBatchDelay = 10 * time.Second
+	// DefaultThrottleDelay is the sleep duration after a throttle/quota error.
+	DefaultThrottleDelay = 1 * time.Minute
+)
+
+// NukeBatchCallbacks contains hooks called during the nuke batch loop.
+type NukeBatchCallbacks struct {
+	// OnBatchStart is called before nuking each batch
+	OnBatchStart func(resourceName, region string, batchSize int)
+	// OnResult is called for each individual nuke result
+	OnResult func(resourceName, region string, result NukeResult)
+	// OnNukeError is called when a batch nuke returns an error (after retries exhausted)
+	OnNukeError func(resourceName, region string, err error)
+	// IsRetryableError returns true if the error should be retried (throttle/quota errors)
+	IsRetryableError func(err error) bool
+}
+
+// NukeInBatches filters non-nukable identifiers, splits into batches, and nukes them with throttle retries.
+// This is the shared nuke loop used by both AWS and GCP.
+func NukeInBatches(ctx context.Context, res NukeableResource, region string, cb NukeBatchCallbacks) error {
+	// Filter to only nukable identifiers
+	var identifiers []string
+	for _, id := range res.ResourceIdentifiers() {
+		nukable, reason := res.IsNukable(id)
+		if !nukable {
+			logging.Debugf("[Skipping] %s %s: %v", res.ResourceName(), id, reason)
+			continue
+		}
+		identifiers = append(identifiers, id)
+	}
+	if len(identifiers) == 0 {
+		return nil
+	}
+
+	resourceName := res.ResourceName()
+	logging.Debugf("Terminating %d %s in batches", len(identifiers), resourceName)
+	batches := util.Split(identifiers, res.MaxBatchSize())
+
+	var allErrors *multierror.Error
+	throttleRetries := 0
+
+	for i := 0; i < len(batches); i++ {
+		batch := batches[i]
+
+		if cb.OnBatchStart != nil {
+			cb.OnBatchStart(resourceName, region, len(batch))
+		}
+
+		results, err := res.Nuke(ctx, batch)
+
+		// Report individual results
+		if cb.OnResult != nil {
+			for _, result := range results {
+				cb.OnResult(resourceName, region, result)
+			}
+		}
+
+		if err != nil {
+			// Handle throttle/quota errors with retry limit
+			if cb.IsRetryableError != nil && cb.IsRetryableError(err) && throttleRetries < DefaultMaxThrottleRetries {
+				throttleRetries++
+				logging.Debugf(
+					"Rate limited (retry %d/%d). Waiting before making new requests",
+					throttleRetries, DefaultMaxThrottleRetries,
+				)
+				time.Sleep(DefaultThrottleDelay)
+				i--
+				continue
+			}
+
+			allErrors = multierror.Append(allErrors, fmt.Errorf("[%s] %s: %w", region, resourceName, err))
+
+			if cb.OnNukeError != nil {
+				cb.OnNukeError(resourceName, region, err)
+			}
+		} else {
+			throttleRetries = 0
+		}
+
+		if i != len(batches)-1 {
+			logging.Debug("Sleeping for 10 seconds before processing next batch...")
+			time.Sleep(DefaultBatchDelay)
+		}
+	}
+
+	return allErrors.ErrorOrNil()
+}

--- a/resource/orchestration_test.go
+++ b/resource/orchestration_test.go
@@ -1,0 +1,160 @@
+package resource
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockNukeableResource implements NukeableResource for testing.
+// Set getErr to make GetAndSetIdentifiers fail.
+// Set nukableIDs (non-nil) to control per-ID IsNukable behavior.
+type mockNukeableResource struct {
+	name        string
+	identifiers []string
+	batchSize   int
+	nukeErr     error
+	nukeCalled  int
+	getErr      error
+	nukableIDs  map[string]bool // nil = all nukable
+}
+
+func (m *mockNukeableResource) ResourceName() string          { return m.name }
+func (m *mockNukeableResource) ResourceIdentifiers() []string { return m.identifiers }
+func (m *mockNukeableResource) MaxBatchSize() int {
+	if m.batchSize > 0 {
+		return m.batchSize
+	}
+	return DefaultBatchSize
+}
+func (m *mockNukeableResource) Nuke(ctx context.Context, ids []string) ([]NukeResult, error) {
+	m.nukeCalled++
+	results := make([]NukeResult, len(ids))
+	for i, id := range ids {
+		results[i] = NukeResult{Identifier: id, Error: m.nukeErr}
+	}
+	if m.nukeErr != nil {
+		return results, m.nukeErr
+	}
+	return results, nil
+}
+func (m *mockNukeableResource) GetAndSetIdentifiers(ctx context.Context, cfg config.Config) ([]string, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	return m.identifiers, nil
+}
+func (m *mockNukeableResource) IsNukable(id string) (bool, error) {
+	if m.nukableIDs != nil {
+		if m.nukableIDs[id] {
+			return true, nil
+		}
+		return false, errors.New("not nukable")
+	}
+	return true, nil
+}
+func (m *mockNukeableResource) GetAndSetResourceConfig(cfg config.Config) config.ResourceType {
+	return config.ResourceType{}
+}
+
+// --- ScanResource tests ---
+
+func TestScanResource(t *testing.T) {
+	res := &mockNukeableResource{name: "test", identifiers: []string{"id-1", "id-2"}}
+
+	var found []string
+	cb := ScanCallbacks{
+		OnResourceFound: func(_, _, id string, _ bool, _ string) { found = append(found, id) },
+	}
+
+	ids := ScanResource(context.Background(), res, "us-east-1", config.Config{}, cb)
+
+	assert.Equal(t, []string{"id-1", "id-2"}, ids)
+	assert.Equal(t, []string{"id-1", "id-2"}, found)
+}
+
+func TestScanResource_ErrorCallsOnScanError(t *testing.T) {
+	res := &mockNukeableResource{name: "failing", getErr: errors.New("access denied")}
+
+	var capturedErr error
+	cb := ScanCallbacks{
+		OnScanError: func(_, _ string, err error) { capturedErr = err },
+	}
+
+	ids := ScanResource(context.Background(), res, "us-east-1", config.Config{}, cb)
+
+	assert.Nil(t, ids)
+	require.Error(t, capturedErr)
+	assert.Contains(t, capturedErr.Error(), "access denied")
+}
+
+func TestScanResource_ErrorSkipped(t *testing.T) {
+	res := &mockNukeableResource{name: "disabled", getErr: errors.New("API disabled")}
+
+	scanErrorCalled := false
+	cb := ScanCallbacks{
+		OnScanError:     func(_, _ string, _ error) { scanErrorCalled = true },
+		ShouldSkipError: func(_ string, _ error) bool { return true },
+	}
+
+	ids := ScanResource(context.Background(), res, "us-east-1", config.Config{}, cb)
+
+	assert.Nil(t, ids)
+	assert.False(t, scanErrorCalled)
+}
+
+// --- NukeInBatches tests ---
+
+func TestNukeInBatches(t *testing.T) {
+	res := &mockNukeableResource{name: "test", identifiers: []string{"a", "b", "c"}, batchSize: 2}
+
+	var resultCount int
+	cb := NukeBatchCallbacks{
+		OnResult: func(_, _ string, _ NukeResult) { resultCount++ },
+	}
+
+	require.NoError(t, NukeInBatches(context.Background(), res, "us-east-1", cb))
+	assert.Equal(t, 3, resultCount)
+}
+
+func TestNukeInBatches_NothingToNuke(t *testing.T) {
+	tests := map[string]*mockNukeableResource{
+		"empty":        {name: "empty", identifiers: []string{}},
+		"all_filtered": {name: "denied", identifiers: []string{"d1", "d2"}, nukableIDs: map[string]bool{}},
+	}
+	for name, res := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, NukeInBatches(context.Background(), res, "us-east-1", NukeBatchCallbacks{}))
+			assert.Equal(t, 0, res.nukeCalled)
+		})
+	}
+}
+
+func TestNukeInBatches_Error(t *testing.T) {
+	res := &mockNukeableResource{name: "failing", identifiers: []string{"id-1"}, nukeErr: errors.New("delete failed")}
+
+	err := NukeInBatches(context.Background(), res, "us-east-1", NukeBatchCallbacks{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete failed")
+}
+
+func TestNukeInBatches_FiltersNonNukable(t *testing.T) {
+	res := &mockNukeableResource{
+		name:        "mixed",
+		identifiers: []string{"allowed-1", "denied-1", "allowed-2", "denied-2"},
+		nukableIDs:  map[string]bool{"allowed-1": true, "allowed-2": true},
+	}
+
+	var nukedIDs []string
+	cb := NukeBatchCallbacks{
+		OnResult: func(_, _ string, r NukeResult) { nukedIDs = append(nukedIDs, r.Identifier) },
+	}
+
+	require.NoError(t, NukeInBatches(context.Background(), res, "us-east-1", cb))
+	assert.Equal(t, []string{"allowed-1", "allowed-2"}, nukedIDs)
+}

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -3,8 +3,8 @@ package resource
 import (
 	"context"
 	"fmt"
+	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/util"
@@ -12,8 +12,13 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-// DefaultBatchSize is the maximum number of resources per batch
-const DefaultBatchSize = 50
+const (
+	// DefaultBatchSize is the maximum number of resources per batch
+	DefaultBatchSize = 50
+
+	// DefaultWaitTimeout is the default timeout for resource deletion waiters.
+	DefaultWaitTimeout = 5 * time.Minute
+)
 
 // Scope represents the cloud provider-specific scope for a resource.
 // For AWS: Region is set (e.g., "us-east-1" or "global" for global resources)
@@ -32,6 +37,19 @@ func (s Scope) String() string {
 		return s.ProjectID
 	}
 	return s.Region
+}
+
+// NukeableResource is the provider-agnostic interface for resources that can be nuked.
+// Both AwsResource and GcpResource embed this interface plus their provider-specific Init().
+// This enables shared orchestration code across providers.
+type NukeableResource interface {
+	ResourceName() string
+	ResourceIdentifiers() []string
+	MaxBatchSize() int
+	Nuke(ctx context.Context, identifiers []string) ([]NukeResult, error)
+	GetAndSetIdentifiers(ctx context.Context, configObj config.Config) ([]string, error)
+	IsNukable(string) (bool, error)
+	GetAndSetResourceConfig(config.Config) config.ResourceType
 }
 
 // Resource is the universal struct for all nukeable resources.
@@ -85,16 +103,29 @@ type Resource[C any] struct {
 
 	// nukables tracks which resources can be nuked (nil value = nukable)
 	nukables map[string]error
+
+	// initErr stores any error that occurred during Init (including recovered panics).
+	// When set, GetAndSetIdentifiers and Nuke return this error gracefully.
+	initErr error
 }
 
 // Init initializes the resource with cloud-specific configuration.
 // For AWS: cfg should be aws.Config
 // For GCP: cfg should be resources.GcpConfig
 // Must be called before GetAndSetIdentifiers or Nuke.
+// Panics from InitClient are recovered and stored as initErr,
+// causing subsequent GetAndSetIdentifiers/Nuke calls to return the error gracefully.
 func (r *Resource[C]) Init(cfg any) {
 	r.nukables = make(map[string]error)
 	if r.InitClient != nil {
-		r.InitClient(r, cfg)
+		func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					r.initErr = fmt.Errorf("%s: client initialization panicked: %v", r.ResourceTypeName, rec)
+				}
+			}()
+			r.InitClient(r, cfg)
+		}()
 	}
 }
 
@@ -126,6 +157,9 @@ func (r *Resource[C]) GetAndSetResourceConfig(configObj config.Config) config.Re
 
 // GetAndSetIdentifiers discovers resources and stores their identifiers (implements AwsResource/GcpResource interface)
 func (r *Resource[C]) GetAndSetIdentifiers(ctx context.Context, configObj config.Config) ([]string, error) {
+	if r.initErr != nil {
+		return nil, r.initErr
+	}
 	if r.Lister == nil {
 		return nil, fmt.Errorf("%s: Lister function not configured", r.ResourceTypeName)
 	}
@@ -147,13 +181,16 @@ func (r *Resource[C]) GetAndSetIdentifiers(ctx context.Context, configObj config
 		})
 	}
 
-	r.identifiers = aws.ToStringSlice(identifiers)
+	r.identifiers = util.DerefStringSlice(identifiers)
 	return r.identifiers, nil
 }
 
 // Nuke deletes the resources with the given identifiers (implements AwsResource/GcpResource interface)
 // Returns the results of each deletion attempt. The caller is responsible for reporting.
 func (r *Resource[C]) Nuke(ctx context.Context, identifiers []string) ([]NukeResult, error) {
+	if r.initErr != nil {
+		return nil, r.initErr
+	}
 	if len(identifiers) == 0 {
 		return nil, nil
 	}
@@ -183,6 +220,9 @@ func (r *Resource[C]) Nuke(ctx context.Context, identifiers []string) ([]NukeRes
 // Returns (true, nil) if nukable, (false, error) if not.
 // If the identifier was never verified, returns (true, nil) - assuming nukable by default.
 func (r *Resource[C]) IsNukable(id string) (bool, error) {
+	if r.initErr != nil {
+		return false, r.initErr
+	}
 	err, ok := r.nukables[id]
 	if !ok {
 		// Not in the map - for resources without permission verification,

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -5,13 +5,14 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type mockClient struct{}
+
+func strPtr(s string) *string { return &s }
 
 func TestResource_MaxBatchSize(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
@@ -46,7 +47,7 @@ func TestResource_GetAndSetIdentifiers(t *testing.T) {
 	r := &Resource[*mockClient]{
 		ResourceTypeName: "test",
 		Lister: func(ctx context.Context, client *mockClient, scope Scope, resourceCfg config.ResourceType) ([]*string, error) {
-			return []*string{aws.String("id-1"), aws.String("id-2")}, nil
+			return []*string{strPtr("id-1"), strPtr("id-2")}, nil
 		},
 		ConfigGetter: func(c config.Config) config.ResourceType {
 			return config.ResourceType{}
@@ -128,7 +129,7 @@ func TestResource_PermissionVerification(t *testing.T) {
 	r := &Resource[*mockClient]{
 		ResourceTypeName: "test",
 		Lister: func(ctx context.Context, client *mockClient, scope Scope, resourceCfg config.ResourceType) ([]*string, error) {
-			return []*string{aws.String("allowed"), aws.String("denied")}, nil
+			return []*string{strPtr("allowed"), strPtr("denied")}, nil
 		},
 		ConfigGetter: func(c config.Config) config.ResourceType {
 			return config.ResourceType{}
@@ -171,37 +172,33 @@ func TestResource_IsNukable(t *testing.T) {
 
 // Batch Deleter Tests
 
+func assertAllSucceeded(t *testing.T, results []NukeResult, expectedLen int) {
+	t.Helper()
+	assert.Len(t, results, expectedLen)
+	for _, r := range results {
+		assert.NoError(t, r.Error)
+	}
+}
+
 func TestSimpleBatchDeleter(t *testing.T) {
-	deleteCount := 0
-	deleter := SimpleBatchDeleter(func(ctx context.Context, client *mockClient, id *string) error {
-		deleteCount++
+	count := 0
+	deleter := SimpleBatchDeleter(func(_ context.Context, _ *mockClient, _ *string) error {
+		count++
 		return nil
 	})
-
-	ids := []*string{aws.String("1"), aws.String("2"), aws.String("3")}
-	results := deleter(context.Background(), &mockClient{}, Scope{}, "test", ids)
-
-	assert.Len(t, results, 3)
-	for _, result := range results {
-		assert.NoError(t, result.Error)
-	}
-	assert.Equal(t, 3, deleteCount)
+	results := deleter(context.Background(), &mockClient{}, Scope{}, "test", []*string{strPtr("1"), strPtr("2"), strPtr("3")})
+	assertAllSucceeded(t, results, 3)
+	assert.Equal(t, 3, count)
 }
 
 func TestSequentialDeleter(t *testing.T) {
-	order := []string{}
-	deleter := SequentialDeleter(func(ctx context.Context, client *mockClient, id *string) error {
+	var order []string
+	deleter := SequentialDeleter(func(_ context.Context, _ *mockClient, id *string) error {
 		order = append(order, *id)
 		return nil
 	})
-
-	ids := []*string{aws.String("a"), aws.String("b"), aws.String("c")}
-	results := deleter(context.Background(), &mockClient{}, Scope{}, "test", ids)
-
-	assert.Len(t, results, 3)
-	for _, result := range results {
-		assert.NoError(t, result.Error)
-	}
+	results := deleter(context.Background(), &mockClient{}, Scope{}, "test", []*string{strPtr("a"), strPtr("b"), strPtr("c")})
+	assertAllSucceeded(t, results, 3)
 	assert.Equal(t, []string{"a", "b", "c"}, order)
 }
 
@@ -213,7 +210,7 @@ func TestSequentialDeleter_AccumulatesErrors(t *testing.T) {
 		return nil
 	})
 
-	ids := []*string{aws.String("ok"), aws.String("fail"), aws.String("also-ok")}
+	ids := []*string{strPtr("ok"), strPtr("fail"), strPtr("also-ok")}
 	results := deleter(context.Background(), &mockClient{}, Scope{}, "test", ids)
 
 	assert.Len(t, results, 3)
@@ -236,7 +233,7 @@ func TestMultiStepDeleter(t *testing.T) {
 		},
 	)
 
-	results := deleter(context.Background(), &mockClient{}, Scope{}, "test", []*string{aws.String("x")})
+	results := deleter(context.Background(), &mockClient{}, Scope{}, "test", []*string{strPtr("x")})
 
 	assert.Len(t, results, 1)
 	assert.NoError(t, results[0].Error)
@@ -255,11 +252,47 @@ func TestMultiStepDeleter_StopsOnFailure(t *testing.T) {
 		},
 	)
 
-	results := deleter(context.Background(), &mockClient{}, Scope{}, "test", []*string{aws.String("x")})
+	results := deleter(context.Background(), &mockClient{}, Scope{}, "test", []*string{strPtr("x")})
 
 	assert.Len(t, results, 1)
 	assert.Error(t, results[0].Error)
 	assert.False(t, step2Called)
+}
+
+func TestResource_Init_PanicRecovery(t *testing.T) {
+	r := &Resource[*mockClient]{
+		ResourceTypeName: "panicky-resource",
+		InitClient: func(r *Resource[*mockClient], cfg any) {
+			panic("failed to create client: missing credentials")
+		},
+	}
+
+	// Init should NOT panic
+	assert.NotPanics(t, func() { r.Init("test-config") })
+
+	// GetAndSetIdentifiers should return the recovered error
+	r.ConfigGetter = func(c config.Config) config.ResourceType { return config.ResourceType{} }
+	r.Lister = func(ctx context.Context, client *mockClient, scope Scope, cfg config.ResourceType) ([]*string, error) {
+		return nil, nil
+	}
+	_, err := r.GetAndSetIdentifiers(context.Background(), config.Config{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client initialization panicked")
+	assert.Contains(t, err.Error(), "missing credentials")
+
+	// Nuke should also return the recovered error
+	r.Nuker = func(ctx context.Context, client *mockClient, scope Scope, resourceType string, ids []*string) []NukeResult {
+		return nil
+	}
+	_, err = r.Nuke(context.Background(), []string{"id-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client initialization panicked")
+
+	// IsNukable should return (false, initErr)
+	nukable, err := r.IsNukable("any-id")
+	assert.False(t, nukable)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client initialization panicked")
 }
 
 func TestScope_String(t *testing.T) {

--- a/util/filter.go
+++ b/util/filter.go
@@ -1,0 +1,17 @@
+package util
+
+import "github.com/gruntwork-io/go-commons/collections"
+
+// IsNukeable checks whether a resource type should be included based on include/exclude lists.
+// An empty includeTypes list or the special value "all" means include everything.
+func IsNukeable(resourceType string, includeTypes []string, excludeTypes []string) bool {
+	if collections.ListContainsElement(excludeTypes, resourceType) {
+		return false
+	}
+	if len(includeTypes) == 0 ||
+		collections.ListContainsElement(includeTypes, "all") ||
+		collections.ListContainsElement(includeTypes, resourceType) {
+		return true
+	}
+	return false
+}

--- a/util/string_utils.go
+++ b/util/string_utils.go
@@ -26,11 +26,16 @@ func Split(identifiers []string, limit int) [][]string {
 func Difference(a, b []*string) []*string {
 	mb := make(map[string]bool, len(b))
 	for _, x := range b {
-		mb[*x] = true
+		if x != nil {
+			mb[*x] = true
+		}
 	}
 
 	var diff []*string
 	for _, x := range a {
+		if x == nil {
+			continue
+		}
 		if _, found := mb[*x]; !found {
 			diff = append(diff, x)
 		}
@@ -52,6 +57,24 @@ func Truncate(s string, maxLen int) string {
 // "sit" more nicely within their specified table cells in the terminal
 func RemoveNewlines(s string) string {
 	return strings.ReplaceAll(s, "\n", " ")
+}
+
+// DerefString safely dereferences a string pointer, returning empty string for nil.
+func DerefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// DerefStringSlice converts a slice of string pointers to a slice of strings.
+// Nil pointers are converted to empty strings.
+func DerefStringSlice(ptrs []*string) []string {
+	result := make([]string, len(ptrs))
+	for i, p := range ptrs {
+		result[i] = DerefString(p)
+	}
+	return result
 }
 
 // ToStringPtrSlice converts a slice of strings to a slice of string pointers.

--- a/util/string_utils_test.go
+++ b/util/string_utils_test.go
@@ -20,3 +20,31 @@ func TestRemoveNewlines(t *testing.T) {
 	assert.Equal(t, "a b c", RemoveNewlines("a\nb\nc"))
 	assert.Equal(t, "", RemoveNewlines(""))
 }
+
+func TestDerefString(t *testing.T) {
+	t.Parallel()
+	s := "hello"
+	assert.Equal(t, "hello", DerefString(&s))
+	assert.Equal(t, "", DerefString(nil))
+}
+
+func TestDerefStringSlice(t *testing.T) {
+	t.Parallel()
+	a, b := "a", "b"
+	assert.Equal(t, []string{"a", "b"}, DerefStringSlice([]*string{&a, &b}))
+	assert.Equal(t, []string{"a", ""}, DerefStringSlice([]*string{&a, nil}))
+	assert.Equal(t, []string{}, DerefStringSlice([]*string{}))
+}
+
+func TestDifference_NilSafe(t *testing.T) {
+	t.Parallel()
+	a, b, c := "a", "b", "c"
+
+	// Normal case
+	diff := Difference([]*string{&a, &b, &c}, []*string{&b})
+	assert.Len(t, diff, 2)
+
+	// Nil elements in slices should not panic
+	diff = Difference([]*string{&a, nil, &c}, []*string{&b, nil})
+	assert.Len(t, diff, 2) // "a" and "c" (nil is skipped)
+}

--- a/util/tag.go
+++ b/util/tag.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"github.com/aws/aws-sdk-go-v2/aws"
 	autoscaling "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	cloudformationtypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -13,72 +14,64 @@ import (
 	secretsmanagertypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 )
 
-func ConvertS3TypesTagsToMap(tags []s3types.Tag) map[string]string {
-	tagMap := make(map[string]string)
+// ConvertTagsToMap converts a slice of any tag-like struct to a map[string]string.
+// keyFn and valFn extract the key and value from each tag element.
+func ConvertTagsToMap[T any](tags []T, keyFn func(T) string, valFn func(T) string) map[string]string {
+	result := make(map[string]string, len(tags))
 	for _, tag := range tags {
-		if tag.Key != nil && tag.Value != nil {
-			tagMap[*tag.Key] = *tag.Value
-		}
+		result[keyFn(tag)] = valFn(tag)
 	}
+	return result
+}
 
-	return tagMap
+func ConvertS3TypesTagsToMap(tags []s3types.Tag) map[string]string {
+	return ConvertTagsToMap(tags,
+		func(t s3types.Tag) string { return aws.ToString(t.Key) },
+		func(t s3types.Tag) string { return aws.ToString(t.Value) },
+	)
 }
 
 func ConvertTypesTagsToMap(tags []ec2types.Tag) map[string]string {
-	tagMap := make(map[string]string)
-	for _, tag := range tags {
-		if tag.Key != nil && tag.Value != nil {
-			tagMap[*tag.Key] = *tag.Value
-		}
-	}
-
-	return tagMap
+	return ConvertTagsToMap(tags,
+		func(t ec2types.Tag) string { return aws.ToString(t.Key) },
+		func(t ec2types.Tag) string { return aws.ToString(t.Value) },
+	)
 }
-func ConvertSecretsManagerTagsToMap(tags []secretsmanagertypes.Tag) map[string]string {
-	tagMap := make(map[string]string)
-	for _, tag := range tags {
-		if tag.Key != nil && tag.Value != nil {
-			tagMap[*tag.Key] = *tag.Value
-		}
-	}
 
-	return tagMap
+func ConvertSecretsManagerTagsToMap(tags []secretsmanagertypes.Tag) map[string]string {
+	return ConvertTagsToMap(tags,
+		func(t secretsmanagertypes.Tag) string { return aws.ToString(t.Key) },
+		func(t secretsmanagertypes.Tag) string { return aws.ToString(t.Value) },
+	)
 }
 
 func ConvertAutoScalingTagsToMap(tags []autoscaling.TagDescription) map[string]string {
-	tagMap := make(map[string]string)
-	for _, tag := range tags {
-		tagMap[*tag.Key] = *tag.Value
-	}
-
-	return tagMap
+	return ConvertTagsToMap(tags,
+		func(t autoscaling.TagDescription) string { return aws.ToString(t.Key) },
+		func(t autoscaling.TagDescription) string { return aws.ToString(t.Value) },
+	)
 }
 
 func ConvertStringPtrTagsToMap(tags map[string]*string) map[string]string {
-	tagMap := make(map[string]string)
+	tagMap := make(map[string]string, len(tags))
 	for key, value := range tags {
-		tagMap[key] = *value
+		tagMap[key] = aws.ToString(value)
 	}
-
 	return tagMap
 }
 
 func ConvertIAMTagsToMap(tags []iam.Tag) map[string]string {
-	tagMap := make(map[string]string)
-	for _, tag := range tags {
-		tagMap[*tag.Key] = *tag.Value
-	}
-
-	return tagMap
+	return ConvertTagsToMap(tags,
+		func(t iam.Tag) string { return aws.ToString(t.Key) },
+		func(t iam.Tag) string { return aws.ToString(t.Value) },
+	)
 }
 
 func ConvertRDSTypeTagsToMap(tags []rdstypes.Tag) map[string]string {
-	tagMap := make(map[string]string)
-	for _, tag := range tags {
-		tagMap[*tag.Key] = *tag.Value
-	}
-
-	return tagMap
+	return ConvertTagsToMap(tags,
+		func(t rdstypes.Tag) string { return aws.ToString(t.Key) },
+		func(t rdstypes.Tag) string { return aws.ToString(t.Value) },
+	)
 }
 
 func GetEC2ResourceNameTagValue(tags []ec2types.Tag) *string {
@@ -86,44 +79,34 @@ func GetEC2ResourceNameTagValue(tags []ec2types.Tag) *string {
 	if name, ok := tagMap["Name"]; ok {
 		return &name
 	}
-
 	return nil
 }
 
 func ConvertNetworkFirewallTagsToMap(tags []networkfirewalltypes.Tag) map[string]string {
-	tagMap := make(map[string]string)
-	for _, tag := range tags {
-		tagMap[*tag.Key] = *tag.Value
-	}
-
-	return tagMap
+	return ConvertTagsToMap(tags,
+		func(t networkfirewalltypes.Tag) string { return aws.ToString(t.Key) },
+		func(t networkfirewalltypes.Tag) string { return aws.ToString(t.Value) },
+	)
 }
 
 // ConvertSageMakerTagsToMap converts SageMaker tags to a map[string]string
 func ConvertSageMakerTagsToMap(tags []sagemakertypes.Tag) map[string]string {
-	result := make(map[string]string)
-	for _, tag := range tags {
-		if tag.Key != nil && tag.Value != nil {
-			result[*tag.Key] = *tag.Value
-		}
-	}
-	return result
+	return ConvertTagsToMap(tags,
+		func(t sagemakertypes.Tag) string { return aws.ToString(t.Key) },
+		func(t sagemakertypes.Tag) string { return aws.ToString(t.Value) },
+	)
 }
 
 func ConvertRoute53TagsToMap(tags []route53types.Tag) map[string]string {
-	tagMap := make(map[string]string)
-	for _, tag := range tags {
-		tagMap[*tag.Key] = *tag.Value
-	}
-
-	return tagMap
+	return ConvertTagsToMap(tags,
+		func(t route53types.Tag) string { return aws.ToString(t.Key) },
+		func(t route53types.Tag) string { return aws.ToString(t.Value) },
+	)
 }
 
 func ConvertCloudFormationTagsToMap(tags []cloudformationtypes.Tag) map[string]string {
-	tagMap := make(map[string]string)
-	for _, tag := range tags {
-		tagMap[*tag.Key] = *tag.Value
-	}
-
-	return tagMap
+	return ConvertTagsToMap(tags,
+		func(t cloudformationtypes.Tag) string { return aws.ToString(t.Key) },
+		func(t cloudformationtypes.Tag) string { return aws.ToString(t.Value) },
+	)
 }

--- a/util/time.go
+++ b/util/time.go
@@ -34,23 +34,28 @@ func IsFirstSeenTag(key *string) bool {
 	return aws.ToString(key) == FirstSeenTagKey
 }
 
-func ParseTimestamp(timestamp *string) (*time.Time, error) {
-	s := aws.ToString(timestamp)
-
-	parsed, err := time.Parse(firstSeenTimeFormat, s)
+// ParseTimestamp tries to parse a timestamp string using multiple formats:
+// RFC3339, time.DateTime (legacy), and bare ISO 8601 (without timezone).
+func ParseTimestamp(timestamp string) (*time.Time, error) {
+	parsed, err := time.Parse(firstSeenTimeFormat, timestamp)
 	if err != nil {
 		logging.Debugf("Error parsing the timestamp into a `RFC3339` Time format. Trying parsing the timestamp using the legacy `time.DateTime` format.")
-		parsed, err = time.Parse(firstSeenTimeFormatLegacy, s)
+		parsed, err = time.Parse(firstSeenTimeFormatLegacy, timestamp)
 	}
 	if err != nil {
 		logging.Debugf("Error parsing the timestamp into legacy `time.DateTime` Time format. Trying bare ISO 8601 format.")
-		parsed, err = time.Parse(iso8601Bare, s)
+		parsed, err = time.Parse(iso8601Bare, timestamp)
 	}
 	if err != nil {
 		return nil, errors.WithStackTrace(err)
 	}
 
 	return &parsed, nil
+}
+
+// ParseTimestampPtr is a convenience wrapper around ParseTimestamp for *string values.
+func ParseTimestampPtr(timestamp *string) (*time.Time, error) {
+	return ParseTimestamp(aws.ToString(timestamp))
 }
 
 func FormatTimestamp(timestamp time.Time) string {
@@ -74,7 +79,7 @@ func GetOrCreateFirstSeen(ctx context.Context, client interface{}, identifier *s
 	// check the first seen already exists in the given map
 	for key, value := range tags {
 		if IsFirstSeenTag(aws.String(key)) {
-			firstSeenTime, err = ParseTimestamp(aws.String(value))
+			firstSeenTime, err = ParseTimestamp(value)
 			if err != nil {
 				return nil, errors.WithStackTrace(err)
 			}

--- a/util/time_test.go
+++ b/util/time_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestParseTimestamp(t *testing.T) {
 	type args struct {
-		timestamp *string
+		timestamp string
 	}
 	tests := []struct {
 		name    string
@@ -20,19 +20,19 @@ func TestParseTimestamp(t *testing.T) {
 	}{
 		{
 			"it should parse legacy firstSeenTag value \"2023-12-19 10:38:44\" correctly",
-			args{timestamp: aws.String("2023-12-19 10:38:44")},
+			args{timestamp: "2023-12-19 10:38:44"},
 			newTime(time.Date(2023, 12, 19, 10, 38, 44, 0, time.UTC)),
 			false,
 		},
 		{
 			"it should parse RFC3339 firstSeenTag value \"2024-04-12T15:18:05Z\" correctly",
-			args{timestamp: aws.String("2024-04-12T15:18:05Z")},
+			args{timestamp: "2024-04-12T15:18:05Z"},
 			newTime(time.Date(2024, 4, 12, 15, 18, 5, 0, time.UTC)),
 			false,
 		},
 		{
 			"it should parse bare ISO 8601 value \"2015-01-01T00:00:00\" correctly",
-			args{timestamp: aws.String("2015-01-01T00:00:00")},
+			args{timestamp: "2015-01-01T00:00:00"},
 			newTime(time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)),
 			false,
 		},
@@ -48,6 +48,23 @@ func TestParseTimestamp(t *testing.T) {
 				t.Errorf("ParseTimestamp() = %v, want %v", got, &tt.want)
 			}
 		})
+	}
+}
+
+func TestParseTimestampPtr(t *testing.T) {
+	got, err := ParseTimestampPtr(aws.String("2024-04-12T15:18:05Z"))
+	if err != nil {
+		t.Fatalf("ParseTimestampPtr() unexpected error: %v", err)
+	}
+	want := time.Date(2024, 4, 12, 15, 18, 5, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("ParseTimestampPtr() = %v, want %v", got, want)
+	}
+
+	// nil input should parse empty string and fail
+	_, err = ParseTimestampPtr(nil)
+	if err == nil {
+		t.Error("ParseTimestampPtr(nil) expected error, got nil")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extracts shared `NukeableResource` interface and `ScanResource`/`NukeInBatches` orchestration into `resource/` package, replacing duplicated scan/nuke loops in both providers
- Removes AWS SDK dependency (`aws.ToString`) from provider-neutral `resource/` package
- Adds panic recovery in `Resource.Init()` so client creation failures return errors instead of crashing
- Fixes GCP `emptyBucket`/`forceEmptyBucket` error aggregation inconsistency
- Fixes inspect commands (AWS + GCP) to load config files and expose `--config` flag
- Adds throttle retry limits (max 3) to prevent infinite loops on persistent rate-limiting
- Adds GCP `ResourceInspectionError`, query resource-type validation, and `ScanStarted` event emission
- Renames `DefaultAwsResourceExclusionTagKey` to provider-neutral `DefaultResourceExclusionTagKey`
- Consolidates duplicated `DefaultBatchSize`/`DefaultWaitTimeout` constants into `resource/` package

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./resource/... ./util/... ./config/...` passes (unit tests for changed packages)
- [ ] `go test ./...` passes (full suite, no regressions)
- [ ] Smoke test: `cloud-nuke inspect-aws --resource-type s3` works as before
- [ ] Smoke test: `cloud-nuke inspect-gcp --resource-type gcs-bucket` with config YAML applies filters correctly
- [ ] Verify broken GCP credentials surface a graceful error, not a panic