### PR TITLE
feat: add --config support to inspect commands

### DIFF
--- a/commands/aws_commands.go
+++ b/commands/aws_commands.go
@@ -99,6 +99,22 @@ func awsInspect(c *cli.Context) error {
 		return handleListResourceTypes()
 	}
 
+	// Parse and set log level
+	if err := parseLogLevel(c); err != nil {
+		return err
+	}
+
+	// Load config file if provided
+	configObj, err := loadConfigFile(c.String(FlagConfig))
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	// Apply timeout to config
+	if err = parseAndApplyTimeout(c, &configObj); err != nil {
+		return err
+	}
+
 	// Build AWS query from CLI flags
 	query, err := generateQuery(c, c.Bool(FlagListUnaliasedKMSKeys), nil, false)
 	if err != nil {
@@ -110,7 +126,7 @@ func awsInspect(c *cli.Context) error {
 	outputFile := c.String(FlagOutputFile)
 
 	// Retrieve and display resources without deleting them
-	_, err = handleGetResourcesWithFormat(c, config.Config{}, query, outputFormat, outputFile)
+	_, err = handleGetResourcesWithFormat(c, configObj, query, outputFormat, outputFile)
 	return err
 }
 

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -83,6 +83,7 @@ func CreateCli(version string) *cli.App {
 				InspectResourceTypeFlags(),
 				CommonTimeFlags(),
 				CommonOutputFlags(),
+				[]cli.Flag{ConfigFlag()},
 			),
 		}, {
 			Name:   "defaults-aws",
@@ -117,6 +118,7 @@ func CreateCli(version string) *cli.App {
 				CommonTimeFlags(),
 				CommonOutputFlags(),
 				[]cli.Flag{
+					ConfigFlag(),
 					&cli.BoolFlag{
 						Name:  FlagListUnaliasedKMSKeys,
 						Usage: "List KMS keys that do not have aliases associated with them.",

--- a/commands/gcp_commands.go
+++ b/commands/gcp_commands.go
@@ -89,7 +89,16 @@ func gcpInspect(c *cli.Context) error {
 		ExcludeResourceTypes: c.StringSlice(FlagExcludeResourceType),
 	}
 
-	configObj := config.Config{}
+	// Load config file if provided
+	configObj, err := loadConfigFile(c.String(FlagConfig))
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	// Apply timeout to config
+	if err := parseAndApplyTimeout(c, &configObj); err != nil {
+		return err
+	}
 
 	// Apply time filters to config
 	if err := parseAndApplyTimeFilters(c, &configObj); err != nil {
@@ -105,7 +114,7 @@ func gcpInspect(c *cli.Context) error {
 	}
 
 	// Retrieve and display resources without deleting them
-	_, err := handleGetGcpResourcesWithFormat(c, configObj, query, outputFormat, outputFile)
+	_, err = handleGetGcpResourcesWithFormat(c, configObj, query, outputFormat, outputFile)
 	return err
 }
 


### PR DESCRIPTION
## Summary

- Add `--config` flag to `inspect-aws` and `inspect-gcp` CLI command definitions so they actually accept config files
- Load config via `loadConfigFile()` in both inspect handlers, matching the nuke command behavior
- Apply timeout and time filters from config consistently
- This makes inspect a true preview of what nuke would target with the same config

Previously, inspect commands either didn't accept `--config` or silently ignored it by using an empty `config.Config{}`.

## Changed files

| File | Change |
|------|--------|
| `commands/cli.go` | Add `ConfigFlag()` to `inspect-aws` and `inspect-gcp` flag lists |
| `commands/aws_commands.go` | Load config file, apply timeout and log level in `awsInspect` |
| `commands/gcp_commands.go` | Load config file, apply timeout and time filters in `gcpInspect` |

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] `cloud-nuke inspect-aws --config` flag appears in `--help`
- [x] `cloud-nuke inspect-gcp --config` flag appears in `--help`
- [x] `inspect-aws` without `--config` works (backward compatible — empty config, finds 1 lambda)
- [x] `inspect-aws --config test-config.yml` filters resources per config (lambda restricted to non-existent name → 0 found)
- [x] GCP inspect not tested (no GCP credentials available)