### PR TITLE
fix(gcp): wire missing CLI flags into GCP query

### DIFF
--- a/commands/cli.go
+++ b/commands/cli.go
@@ -68,6 +68,7 @@ func CreateCli(version string) *cli.App {
 			Action: errors.WithPanicHandling(gcpNuke),
 			Flags: CombineFlags(
 				[]cli.Flag{GCPProjectFlag()},
+				RegionFlags(),
 				CommonResourceTypeFlags(),
 				CommonTimeFlags(),
 				CommonExecutionFlags(),
@@ -80,6 +81,7 @@ func CreateCli(version string) *cli.App {
 			Action: errors.WithPanicHandling(gcpInspect),
 			Flags: CombineFlags(
 				[]cli.Flag{GCPProjectFlag()},
+				RegionFlags(),
 				InspectResourceTypeFlags(),
 				CommonTimeFlags(),
 				CommonOutputFlags(),

--- a/commands/gcp_commands.go
+++ b/commands/gcp_commands.go
@@ -15,10 +15,8 @@ import (
 // These functions implement the CLI commands for GCP operations
 
 // gcpNuke is the main command handler for nuking (deleting) GCP resources.
-// It supports time-based filtering and config file overrides.
-//
-// Note: The --resource-type and --exclude-resource-type flags are currently ignored for GCP.
-// GCP always processes all resource types. This should be implemented in a future PR.
+// It supports region filtering, resource type filtering, time-based filtering,
+// and config file overrides.
 func gcpNuke(c *cli.Context) error {
 	defer telemetry.TrackCommandLifecycle("gcp")()
 
@@ -40,6 +38,8 @@ func gcpNuke(c *cli.Context) error {
 
 	query := &gcp.Query{
 		ProjectID:            c.String(FlagProjectID),
+		Regions:              c.StringSlice(FlagRegion),
+		ExcludeRegions:       c.StringSlice(FlagExcludeRegion),
 		ResourceTypes:        c.StringSlice(FlagResourceType),
 		ExcludeResourceTypes: c.StringSlice(FlagExcludeResourceType),
 	}
@@ -67,9 +67,6 @@ func gcpNuke(c *cli.Context) error {
 
 // gcpInspect is the command handler for non-destructive inspection of GCP resources.
 // It lists resources that would be deleted without actually deleting them.
-//
-// Note: The --resource-type and --exclude-resource-type flags are currently ignored for GCP.
-// GCP always inspects all resource types. This should be implemented in a future PR.
 func gcpInspect(c *cli.Context) error {
 	defer telemetry.TrackCommandLifecycle("gcp-inspect")()
 
@@ -85,6 +82,8 @@ func gcpInspect(c *cli.Context) error {
 
 	query := &gcp.Query{
 		ProjectID:            c.String(FlagProjectID),
+		Regions:              c.StringSlice(FlagRegion),
+		ExcludeRegions:       c.StringSlice(FlagExcludeRegion),
 		ResourceTypes:        c.StringSlice(FlagResourceType),
 		ExcludeResourceTypes: c.StringSlice(FlagExcludeResourceType),
 	}


### PR DESCRIPTION
## Summary

- Add `--region` / `--exclude-region` flags to both `gcp` and `inspect-gcp` command definitions in `cli.go`
- Wire `Regions` and `ExcludeRegions` from CLI flags into the `gcp.Query` struct in both `gcpNuke()` and `gcpInspect()` handlers
- Remove misleading comments claiming `--resource-type` / `--exclude-resource-type` are ignored — they were already wired into `Query` and used by `IsNukeable()` in `gcp/gcp.go`

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] `cloud-nuke gcp --help` shows `--region` and `--exclude-region` flags
- [x] `cloud-nuke inspect-gcp --help` shows `--region` and `--exclude-region` flags
- [ ] GCP region filtering not tested end-to-end (no GCP credentials available)
- [ ] GCP resource-type filtering not tested end-to-end (no GCP credentials available)