### PR TITLE
fix(gcp): use InitializationError instead of panic in gcs-bucket and cloud-function

### DIFF
--- a/gcp/resources/cloud_function.go
+++ b/gcp/resources/cloud_function.go
@@ -25,7 +25,8 @@ func NewCloudFunctions() GcpResource {
 			r.Scope.ProjectID = cfg.ProjectID
 			client, err := functions.NewFunctionClient(context.Background())
 			if err != nil {
-				panic(fmt.Sprintf("failed to create Cloud Functions client: %v", err))
+				r.InitializationError = fmt.Errorf("failed to create Cloud Functions client: %w", err)
+				return
 			}
 			r.Client = client
 		}),

--- a/gcp/resources/gcs_bucket.go
+++ b/gcp/resources/gcs_bucket.go
@@ -23,9 +23,8 @@ func NewGCSBuckets() GcpResource {
 			r.Scope.ProjectID = cfg.ProjectID
 			client, err := storage.NewClient(context.Background())
 			if err != nil {
-				// Panic is recovered by GcpResourceAdapter.Init() and stored as initErr,
-				// causing subsequent GetAndSetIdentifiers/Nuke calls to return the error gracefully.
-				panic(fmt.Sprintf("failed to create GCS client: %v", err))
+				r.InitializationError = fmt.Errorf("failed to create GCS client: %w", err)
+				return
 			}
 			r.Client = client
 		}),


### PR DESCRIPTION
## Description

Fixes the client initialization error handling in `gcs-bucket` and `cloud-function` resources. Both were using `panic()` when the GCP client failed to initialize, which would crash the process if the API is disabled. Updated to set `r.InitializationError` and return instead.       

  ## TODOs

  - [x] Run the relevant tests successfully, including pre-commit checks.
  - [x] Include release notes. If this PR is backward incompatible, include a migration guide.

  ## Release Notes (draft)

  Updated `gcs-bucket` and `cloud-function` to gracefully handle client initialization failures instead of panicking.