### PR TITLE
feat(gcp): redesign region model, add Secret Manager, recover Init panics

### DIFF
--- a/commands/gcp_commands.go
+++ b/commands/gcp_commands.go
@@ -15,7 +15,7 @@ import (
 // These functions implement the CLI commands for GCP operations
 
 // gcpNuke is the main command handler for nuking (deleting) GCP resources.
-// It supports region filtering, resource type filtering, time-based filtering,
+// It supports location filtering, resource type filtering, time-based filtering,
 // and config file overrides.
 func gcpNuke(c *cli.Context) error {
 	defer telemetry.TrackCommandLifecycle("gcp")()
@@ -30,38 +30,14 @@ func gcpNuke(c *cli.Context) error {
 		return err
 	}
 
-	// Load config file if provided
-	configObj, err := loadConfigFile(c.String(FlagConfig))
+	configObj, query, err := generateGcpQuery(c)
 	if err != nil {
-		return errors.WithStackTrace(err)
-	}
-
-	query := &gcp.Query{
-		ProjectID:            c.String(FlagProjectID),
-		Regions:              c.StringSlice(FlagRegion),
-		ExcludeRegions:       c.StringSlice(FlagExcludeRegion),
-		ResourceTypes:        c.StringSlice(FlagResourceType),
-		ExcludeResourceTypes: c.StringSlice(FlagExcludeResourceType),
-		ExcludeFirstSeen:     c.Bool(FlagExcludeFirstSeen),
-	}
-
-	// Apply timeout to config
-	if err := parseAndApplyTimeout(c, &configObj); err != nil {
-		return err
-	}
-
-	// Apply time filters to config
-	if err := parseAndApplyTimeFilters(c, &configObj); err != nil {
 		return err
 	}
 
 	// Get output preferences
 	outputFormat := c.String(FlagOutputFormat)
 	outputFile := c.String(FlagOutputFile)
-
-	if err := query.Validate(); err != nil {
-		return err
-	}
 
 	return gcpNukeHelper(c, configObj, query, outputFormat, outputFile)
 }
@@ -81,38 +57,14 @@ func gcpInspect(c *cli.Context) error {
 		return err
 	}
 
-	query := &gcp.Query{
-		ProjectID:            c.String(FlagProjectID),
-		Regions:              c.StringSlice(FlagRegion),
-		ExcludeRegions:       c.StringSlice(FlagExcludeRegion),
-		ResourceTypes:        c.StringSlice(FlagResourceType),
-		ExcludeResourceTypes: c.StringSlice(FlagExcludeResourceType),
-		ExcludeFirstSeen:     c.Bool(FlagExcludeFirstSeen),
-	}
-
-	// Load config file if provided
-	configObj, err := loadConfigFile(c.String(FlagConfig))
+	configObj, query, err := generateGcpQuery(c)
 	if err != nil {
-		return errors.WithStackTrace(err)
-	}
-
-	// Apply timeout to config
-	if err := parseAndApplyTimeout(c, &configObj); err != nil {
-		return err
-	}
-
-	// Apply time filters to config
-	if err := parseAndApplyTimeFilters(c, &configObj); err != nil {
 		return err
 	}
 
 	// Get output preferences
 	outputFormat := c.String(FlagOutputFormat)
 	outputFile := c.String(FlagOutputFile)
-
-	if err := query.Validate(); err != nil {
-		return err
-	}
 
 	// Retrieve and display resources without deleting them
 	_, err = handleGetGcpResourcesWithFormat(c, configObj, query, outputFormat, outputFile)
@@ -121,6 +73,50 @@ func gcpInspect(c *cli.Context) error {
 
 // Helper Functions
 // These functions contain shared logic used by multiple command handlers
+
+// generateGcpQuery parses CLI flags into a validated gcp.Query and config.Config.
+func generateGcpQuery(c *cli.Context) (config.Config, *gcp.Query, error) {
+	configObj, err := loadConfigFile(c.String(FlagConfig))
+	if err != nil {
+		return config.Config{}, nil, errors.WithStackTrace(err)
+	}
+
+	excludeAfter, err := parseDurationParam(FlagOlderThan, c.String(FlagOlderThan))
+	if err != nil {
+		return config.Config{}, nil, errors.WithStackTrace(err)
+	}
+
+	includeAfter, err := parseDurationParam(FlagNewerThan, c.String(FlagNewerThan))
+	if err != nil {
+		return config.Config{}, nil, errors.WithStackTrace(err)
+	}
+
+	timeout, err := parseTimeoutDurationParam(FlagTimeout, c.String(FlagTimeout))
+	if err != nil {
+		return config.Config{}, nil, errors.WithStackTrace(err)
+	}
+
+	configObj.ApplyTimeFilters(excludeAfter, includeAfter)
+	if timeout != nil {
+		configObj.AddTimeout(timeout)
+	}
+
+	query := &gcp.Query{
+		ProjectID:            c.String(FlagProjectID),
+		Locations:            c.StringSlice(FlagRegion),
+		ExcludeLocations:     c.StringSlice(FlagExcludeRegion),
+		ResourceTypes:        c.StringSlice(FlagResourceType),
+		ExcludeResourceTypes: c.StringSlice(FlagExcludeResourceType),
+		ExcludeFirstSeen:     c.Bool(FlagExcludeFirstSeen),
+		Timeout:              timeout,
+	}
+
+	if err := query.Validate(c.Context); err != nil {
+		return config.Config{}, nil, errors.WithStackTrace(err)
+	}
+
+	return configObj, query, nil
+}
 
 // gcpNukeHelper is the core logic for nuking GCP resources.
 // It retrieves resources, confirms deletion with the user, and executes the nuke operation.
@@ -145,14 +141,14 @@ func gcpNukeHelper(c *cli.Context, configObj config.Config, query *gcp.Query, ou
 	collector.Emit(reporting.ScanComplete{})
 
 	// Confirm with user before proceeding (unless --force or --dry-run is set)
-	shouldProceed, err := confirmNuke(c, len(account.Resources) > 0)
+	shouldProceed, err := confirmNuke(c, account.TotalResourceCount() > 0)
 	if err != nil {
 		return err
 	}
 
 	// Execute the nuke operation if confirmed
 	if shouldProceed {
-		if err := gcp.NukeAllResources(c.Context, account, query.Regions, collector); err != nil {
+		if err := gcp.NukeAllResources(c.Context, account, collector); err != nil {
 			return err
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -155,6 +155,7 @@ type Config struct {
 	CloudFunction    ResourceType `yaml:"CloudFunction"`
 	ArtifactRegistry ResourceType `yaml:"ArtifactRegistry"`
 	GcpPubSubTopic   ResourceType `yaml:"GcpPubSubTopic"`
+	GcpSecretManager ResourceType `yaml:"GcpSecretManager"`
 }
 
 // allResourceTypes returns pointers to the embedded ResourceType for every
@@ -295,6 +296,7 @@ func (c *Config) allResourceTypes() []*ResourceType {
 		&c.CloudFunction,
 		&c.ArtifactRegistry,
 		&c.GcpPubSubTopic,
+		&c.GcpSecretManager,
 	}
 }
 

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -18,6 +18,10 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
+// projectKey is the single map key used for GcpProjectResources.Resources.
+// GCP resources are project-scoped; location is a filter hint, not a scope.
+const projectKey = "project"
+
 // IsNukeable checks whether a resource type should be nuked based on the
 // requested resource types and exclude lists. An empty include list or the
 // special value "all" means nuke everything, minus any excluded types.
@@ -34,67 +38,71 @@ func IsNukeable(resourceType string, resourceTypes []string, excludeResourceType
 }
 
 // GetAllResources lists all GCP resources that can be deleted.
+// Each resource is called exactly once; location filtering is handled internally by each resource's Lister.
 func GetAllResources(ctx context.Context, query *Query, configObj config.Config, collector *reporting.Collector) (*GcpProjectResources, error) {
 	allResources := GcpProjectResources{
+		ProjectID: query.ProjectID,
 		Resources: map[string]GcpResources{},
 	}
 
 	ctx = context.WithValue(ctx, util.ExcludeFirstSeenTagKey, query.ExcludeFirstSeen)
 
-	for _, region := range query.Regions {
-		cfg := resources.GcpConfig{ProjectID: query.ProjectID, Region: region}
-		regionResources := GetAndInitRegisteredResources(cfg, region)
+	cfg := resources.GcpConfig{
+		ProjectID:        query.ProjectID,
+		Locations:        query.Locations,
+		ExcludeLocations: query.ExcludeLocations,
+	}
+	allRegistered := GetAndInitRegisteredResources(cfg)
 
-		for _, res := range regionResources {
-			resourceName := (*res).ResourceName()
+	for _, res := range allRegistered {
+		resourceName := (*res).ResourceName()
 
-			if !IsNukeable(resourceName, query.ResourceTypes, query.ExcludeResourceTypes) {
+		if !IsNukeable(resourceName, query.ResourceTypes, query.ExcludeResourceTypes) {
+			continue
+		}
+
+		// Emit scan progress event
+		collector.Emit(reporting.ScanProgress{
+			ResourceType: resourceName,
+			Region:       query.ProjectID,
+		})
+
+		// Get all resource identifiers
+		identifiers, err := (*res).GetAndSetIdentifiers(ctx, configObj)
+		if err != nil {
+			if isServiceDisabledError(err) && !collections.ListContainsElement(query.ResourceTypes, resourceName) {
+				logging.Debugf("Skipping %s: API is disabled in this project", resourceName)
 				continue
 			}
-
-			// Emit scan progress event
-			collector.Emit(reporting.ScanProgress{
+			logging.Debugf("Error getting identifiers for %s: %v", resourceName, err)
+			collector.Emit(reporting.GeneralError{
 				ResourceType: resourceName,
-				Region:       region,
+				Description:  fmt.Sprintf("Unable to retrieve %s", resourceName),
+				Error:        err.Error(),
 			})
+			continue
+		}
 
-			// Get all resource identifiers
-			identifiers, err := (*res).GetAndSetIdentifiers(ctx, configObj)
-			if err != nil {
-				if isServiceDisabledError(err) && !collections.ListContainsElement(query.ResourceTypes, resourceName) {
-					logging.Debugf("Skipping %s: API is disabled in this project", resourceName)
-					continue
-				}
-				logging.Debugf("Error getting identifiers for %s: %v", resourceName, err)
-				collector.Emit(reporting.GeneralError{
-					ResourceType: resourceName,
-					Description:  fmt.Sprintf("Unable to retrieve %s", resourceName),
-					Error:        err.Error(),
-				})
-				continue
+		// Only append if we have non-empty identifiers
+		if len(identifiers) > 0 {
+			logging.Infof("Found %d %s resources", len(identifiers), resourceName)
+			allResources.Resources[projectKey] = GcpResources{
+				Resources: append(allResources.Resources[projectKey].Resources, res),
 			}
 
-			// Only append if we have non-empty identifiers
-			if len(identifiers) > 0 {
-				logging.Infof("Found %d %s resources", len(identifiers), resourceName)
-				allResources.Resources[region] = GcpResources{
-					Resources: append(allResources.Resources[region].Resources, res),
+			// Emit ResourceFound events for each identifier
+			for _, id := range identifiers {
+				nukable, reason := true, ""
+				if _, err := (*res).IsNukable(id); err != nil {
+					nukable, reason = false, err.Error()
 				}
-
-				// Emit ResourceFound events for each identifier
-				for _, id := range identifiers {
-					nukable, reason := true, ""
-					if _, err := (*res).IsNukable(id); err != nil {
-						nukable, reason = false, err.Error()
-					}
-					collector.Emit(reporting.ResourceFound{
-						ResourceType: resourceName,
-						Region:       region,
-						Identifier:   id,
-						Nukable:      nukable,
-						Reason:       reason,
-					})
-				}
+				collector.Emit(reporting.ResourceFound{
+					ResourceType: resourceName,
+					Region:       query.ProjectID,
+					Identifier:   id,
+					Nukable:      nukable,
+					Reason:       reason,
+				})
 			}
 		}
 	}
@@ -105,16 +113,18 @@ func GetAllResources(ctx context.Context, query *Query, configObj config.Config,
 	return &allResources, nil
 }
 
-// NukeAllResources nukes all GCP resources across the given regions.
-func NukeAllResources(ctx context.Context, account *GcpProjectResources, regions []string, collector *reporting.Collector) error {
+// NukeAllResources nukes all GCP resources in the project.
+func NukeAllResources(ctx context.Context, account *GcpProjectResources, collector *reporting.Collector) error {
 	// Emit NukeStarted event (CLIRenderer will initialize progress bar)
 	collector.Emit(reporting.NukeStarted{Total: account.TotalResourceCount()})
 
 	var allErrors *multierror.Error
 
-	for _, region := range regions {
-		if err := nukeAllResourcesInRegion(ctx, account, region, collector); err != nil {
-			allErrors = multierror.Append(allErrors, err)
+	for _, gcpResources := range account.Resources {
+		for _, gcpResource := range gcpResources.Resources {
+			if err := nukeResource(ctx, gcpResource, account.ProjectID, collector); err != nil {
+				allErrors = multierror.Append(allErrors, err)
+			}
 		}
 	}
 
@@ -124,22 +134,8 @@ func NukeAllResources(ctx context.Context, account *GcpProjectResources, regions
 	return allErrors.ErrorOrNil()
 }
 
-// nukeAllResourcesInRegion nukes all resources in a single region.
-func nukeAllResourcesInRegion(ctx context.Context, account *GcpProjectResources, region string, collector *reporting.Collector) error {
-	var allErrors *multierror.Error
-
-	resourcesInRegion := account.Resources[region]
-	for _, gcpResource := range resourcesInRegion.Resources {
-		if err := nukeResource(ctx, gcpResource, region, collector); err != nil {
-			allErrors = multierror.Append(allErrors, err)
-		}
-	}
-
-	return allErrors.ErrorOrNil()
-}
-
-// nukeResource nukes a single GCP resource type
-func nukeResource(ctx context.Context, gcpResource *GcpResource, region string, collector *reporting.Collector) error {
+// nukeResource nukes a single GCP resource type within a project scope.
+func nukeResource(ctx context.Context, gcpResource *GcpResource, scope string, collector *reporting.Collector) error {
 	// Filter to only nukable resources
 	var nukableIdentifiers []string
 	for _, id := range (*gcpResource).ResourceIdentifiers() {
@@ -164,7 +160,7 @@ func nukeResource(ctx context.Context, gcpResource *GcpResource, region string, 
 		// Emit progress event (CLIRenderer updates its progress bar)
 		collector.Emit(reporting.NukeProgress{
 			ResourceType: (*gcpResource).ResourceName(),
-			Region:       region,
+			Region:       scope,
 			BatchSize:    len(batch),
 		})
 
@@ -178,7 +174,7 @@ func nukeResource(ctx context.Context, gcpResource *GcpResource, region string, 
 			}
 			collector.Emit(reporting.ResourceDeleted{
 				ResourceType: (*gcpResource).ResourceName(),
-				Region:       region,
+				Region:       scope,
 				Identifier:   result.Identifier,
 				Success:      result.Error == nil,
 				Error:        errStr,
@@ -194,13 +190,13 @@ func nukeResource(ctx context.Context, gcpResource *GcpResource, region string, 
 				continue
 			}
 
-			allErrors = multierror.Append(allErrors, fmt.Errorf("[%s] %s: %w", region, (*gcpResource).ResourceName(), err))
+			allErrors = multierror.Append(allErrors, fmt.Errorf("[%s] %s: %w", scope, (*gcpResource).ResourceName(), err))
 
 			// Report to telemetry - aggregated metrics of failures per resources.
 			telemetry.TrackEvent(commonTelemetry.EventContext{
 				EventName: fmt.Sprintf("error:Nuke:%s", (*gcpResource).ResourceName()),
 			}, map[string]interface{}{
-				"region": region,
+				"scope": scope,
 			})
 		}
 

--- a/gcp/query.go
+++ b/gcp/query.go
@@ -1,10 +1,13 @@
 package gcp
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"time"
 
-	"github.com/gruntwork-io/go-commons/collections"
+	resourcemanager "cloud.google.com/go/resourcemanager/apiv3"
+	resourcemanagerpb "cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
 )
 
 // Query represents the desired parameters for scanning GCP resources.
@@ -13,35 +16,75 @@ type Query struct {
 	ProjectID            string
 	ResourceTypes        []string
 	ExcludeResourceTypes []string
-	Regions              []string
-	ExcludeRegions       []string
-	ExcludeAfter         *time.Time
-	IncludeAfter         *time.Time
+	Locations            []string
+	ExcludeLocations     []string
 	Timeout              *time.Duration
 	ExcludeFirstSeen     bool
 }
 
-// Validate ensures the query has valid defaults.
-// If no regions are specified, it defaults to GlobalRegion.
-// ExcludeRegions are filtered out from the region list.
-func (q *Query) Validate() error {
-	if len(q.Regions) == 0 {
-		q.Regions = []string{GlobalRegion}
+// Validate ensures the query has valid defaults and that the project is accessible.
+// An empty Locations means "all locations" — each resource decides its broadest scope.
+// ExcludeLocations are filtered out from the location list if locations are specified.
+func (q *Query) Validate(ctx context.Context) error {
+	if q.ProjectID == "" {
+		return fmt.Errorf("--project-id is required")
 	}
 
-	if len(q.ExcludeRegions) > 0 {
+	if err := validateProjectID(ctx, q.ProjectID, q.Timeout); err != nil {
+		return err
+	}
+
+	return q.validateLocations()
+}
+
+func (q *Query) validateLocations() error {
+	if len(q.ExcludeLocations) > 0 && len(q.Locations) > 0 {
 		var filtered []string
-		for _, region := range q.Regions {
-			if !collections.ListContainsElement(q.ExcludeRegions, region) {
-				filtered = append(filtered, region)
+		for _, loc := range q.Locations {
+			if !containsIgnoreCase(q.ExcludeLocations, loc) {
+				filtered = append(filtered, loc)
 			}
 		}
-		q.Regions = filtered
-	}
-
-	if len(q.Regions) == 0 {
-		return fmt.Errorf("no regions to process after applying exclusions")
+		if len(filtered) == 0 {
+			return fmt.Errorf("all specified --region values were excluded by --exclude-region; nothing to scan")
+		}
+		q.Locations = filtered
 	}
 
 	return nil
+}
+
+// validateProjectID verifies that the GCP project exists and is accessible
+// with the current credentials using the Cloud Resource Manager API.
+func validateProjectID(ctx context.Context, projectID string, timeout *time.Duration) error {
+	t := 30 * time.Second
+	if timeout != nil {
+		t = *timeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, t)
+	defer cancel()
+
+	client, err := resourcemanager.NewProjectsClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create Resource Manager client: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	_, err = client.GetProject(ctx, &resourcemanagerpb.GetProjectRequest{
+		Name: "projects/" + projectID,
+	})
+	if err != nil {
+		return fmt.Errorf("invalid or inaccessible project %q: %w", projectID, err)
+	}
+
+	return nil
+}
+
+func containsIgnoreCase(list []string, target string) bool {
+	for _, s := range list {
+		if strings.EqualFold(s, target) {
+			return true
+		}
+	}
+	return false
 }

--- a/gcp/query_test.go
+++ b/gcp/query_test.go
@@ -1,0 +1,56 @@
+package gcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate_MissingProjectID(t *testing.T) {
+	t.Parallel()
+	q := &Query{}
+	err := q.Validate(context.Background())
+	assert.ErrorContains(t, err, "--project-id is required")
+}
+
+func TestValidateLocations_FiltersExcludedFromIncluded(t *testing.T) {
+	t.Parallel()
+	q := &Query{
+		Locations:        []string{"us-central1", "us-east1"},
+		ExcludeLocations: []string{"us-east1"},
+	}
+	require.NoError(t, q.validateLocations())
+	assert.Equal(t, []string{"us-central1"}, q.Locations)
+}
+
+func TestValidateLocations_ErrorWhenAllExcluded(t *testing.T) {
+	t.Parallel()
+	q := &Query{
+		Locations:        []string{"us-central1"},
+		ExcludeLocations: []string{"us-central1"},
+	}
+	err := q.validateLocations()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nothing to scan")
+}
+
+func TestValidateLocations_ExcludeWithoutIncludeIsValid(t *testing.T) {
+	t.Parallel()
+	q := &Query{
+		ExcludeLocations: []string{"us-central1"},
+	}
+	require.NoError(t, q.validateLocations())
+}
+
+func TestValidateLocations_CaseInsensitiveExclusion(t *testing.T) {
+	t.Parallel()
+	q := &Query{
+		Locations:        []string{"us-central1"},
+		ExcludeLocations: []string{"US-CENTRAL1"},
+	}
+	err := q.validateLocations()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nothing to scan")
+}

--- a/gcp/resource_registry.go
+++ b/gcp/resource_registry.go
@@ -4,29 +4,22 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/gcp/resources"
 )
 
-// GlobalRegion is the region name used for GCP resources that are not region-scoped.
-const GlobalRegion = "global"
-
-// getRegisteredGlobalResources returns all GCP resource types that are global (not region-scoped).
-func getRegisteredGlobalResources() []GcpResource {
+// getRegisteredResources returns all registered GCP resource types.
+// Each resource is registered once — there is no global/regional split.
+func getRegisteredResources() []GcpResource {
 	return []GcpResource{
 		resources.NewGCSBuckets(),
 		resources.NewCloudFunctions(),
 		resources.NewArtifactRegistryRepositories(),
 		resources.NewPubSubTopics(),
+		resources.NewSecretManagerSecrets(),
 	}
 }
 
-// getRegisteredRegionalResources returns all GCP resource types that are region-scoped.
-// Currently empty; regional resources will be added here as they are implemented.
-func getRegisteredRegionalResources() []GcpResource {
-	return []GcpResource{}
-}
-
 // GetAllRegisteredResources returns pointers to all registered GCP resources
-// (both global and regional), without initializing them.
+// without initializing them.
 func GetAllRegisteredResources() []*GcpResource {
-	all := append(getRegisteredGlobalResources(), getRegisteredRegionalResources()...)
+	all := getRegisteredResources()
 	result := make([]*GcpResource, len(all))
 	for i := range all {
 		result[i] = &all[i]
@@ -34,15 +27,10 @@ func GetAllRegisteredResources() []*GcpResource {
 	return result
 }
 
-// GetAndInitRegisteredResources returns initialized GCP resources for the given region.
-// Global resources are returned for GlobalRegion; regional resources for any other region.
-func GetAndInitRegisteredResources(cfg resources.GcpConfig, region string) []*GcpResource {
-	var raw []GcpResource
-	if region == GlobalRegion {
-		raw = getRegisteredGlobalResources()
-	} else {
-		raw = getRegisteredRegionalResources()
-	}
+// GetAndInitRegisteredResources returns initialized GCP resources.
+// Each resource is called exactly once; location filtering is handled by each resource's Lister.
+func GetAndInitRegisteredResources(cfg resources.GcpConfig) []*GcpResource {
+	raw := getRegisteredResources()
 
 	result := make([]*GcpResource, len(raw))
 	for i := range raw {

--- a/gcp/resources/adapter.go
+++ b/gcp/resources/adapter.go
@@ -3,9 +3,12 @@ package resources
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/resource"
+	"github.com/gruntwork-io/go-commons/errors"
 )
 
 const (
@@ -13,11 +16,11 @@ const (
 	DefaultBatchSize   = 50
 )
 
-// GcpConfig holds the configuration needed to initialize a GCP resource,
-// mirroring how AWS uses aws.Config as the init argument.
+// GcpConfig holds the configuration needed to initialize a GCP resource.
 type GcpConfig struct {
-	ProjectID string
-	Region    string
+	ProjectID        string
+	Locations        []string
+	ExcludeLocations []string
 }
 
 // GcpInitClientFunc is the type-safe client initialization function signature.
@@ -46,13 +49,61 @@ func NewGcpResource[C any](r *resource.Resource[C]) GcpResource {
 }
 
 // Init initializes the resource with GCP configuration.
+// Panics from InitClient (e.g., missing credentials) are recovered and stored
+// in Resource.InitializationError so that subsequent GetAndSetIdentifiers/Nuke
+// calls return the error gracefully instead of crashing the process.
 func (g *GcpResourceAdapter[C]) Init(cfg GcpConfig) {
+	defer func() {
+		if r := recover(); r != nil {
+			g.InitializationError = errors.WithStackTrace(fmt.Errorf("panic during Init for %s: %v", g.ResourceTypeName, r))
+			logging.Debugf("%s", g.InitializationError)
+		}
+	}()
 	g.Resource.Init(cfg)
 }
 
 // Nuke deletes the resources with the given identifiers.
 func (g *GcpResourceAdapter[C]) Nuke(ctx context.Context, identifiers []string) ([]resource.NukeResult, error) {
 	return g.Resource.Nuke(ctx, identifiers)
+}
+
+// MatchesLocationFilter checks whether a given location matches the location
+// filter expressed by the Locations and ExcludeLocations in GcpConfig.
+// If no locations are specified, everything matches.
+func MatchesLocationFilter(location string, locations []string, excludeLocations []string) bool {
+	// Check exclusions first
+	for _, exc := range excludeLocations {
+		if strings.EqualFold(exc, location) {
+			return false
+		}
+	}
+
+	// If no include filter, everything matches
+	if len(locations) == 0 {
+		return true
+	}
+
+	// Check if this location is in the include list
+	for _, loc := range locations {
+		if strings.EqualFold(loc, location) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ExtractLocationFromResourceName extracts the location from a GCP fully qualified resource name
+// that contains a /locations/{location}/ segment. Returns empty string if not found.
+// Works for any resource: projects/{p}/locations/{loc}/functions/{f}, .../secrets/{s}, etc.
+func ExtractLocationFromResourceName(name string) string {
+	parts := strings.Split(name, "/")
+	for i, part := range parts {
+		if part == "locations" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return ""
 }
 
 var _ GcpResource = (*GcpResourceAdapter[any])(nil)

--- a/gcp/resources/adapter_test.go
+++ b/gcp/resources/adapter_test.go
@@ -1,0 +1,72 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGcpResourceAdapter_InitRecoversPanic(t *testing.T) {
+	t.Parallel()
+	adapter := NewGcpResource(&resource.Resource[any]{
+		ResourceTypeName: "test-panic-resource",
+		InitClient: func(r *resource.Resource[any], cfg any) {
+			panic("simulated client init failure")
+		},
+	})
+
+	// Init should not panic
+	assert.NotPanics(t, func() {
+		adapter.Init(GcpConfig{ProjectID: "test-project"})
+	})
+}
+
+func TestGcpResourceAdapter_GetAndSetIdentifiersReturnsInitErr(t *testing.T) {
+	t.Parallel()
+	adapter := NewGcpResource(&resource.Resource[any]{
+		ResourceTypeName: "test-panic-identifiers",
+		InitClient: func(r *resource.Resource[any], cfg any) {
+			panic("simulated client init failure")
+		},
+		ConfigGetter: func(c config.Config) config.ResourceType {
+			return config.ResourceType{}
+		},
+		Lister: func(ctx context.Context, client any, scope resource.Scope, cfg config.ResourceType) ([]*string, error) {
+			return nil, nil
+		},
+	})
+
+	adapter.Init(GcpConfig{ProjectID: "test-project"})
+
+	ids, err := adapter.GetAndSetIdentifiers(context.Background(), config.Config{})
+	require.Error(t, err)
+	assert.Nil(t, ids)
+	assert.Contains(t, err.Error(), "panic during Init")
+	assert.Contains(t, err.Error(), "simulated client init failure")
+}
+
+func TestGcpResourceAdapter_NoPanicWorksNormally(t *testing.T) {
+	t.Parallel()
+	adapter := NewGcpResource(&resource.Resource[any]{
+		ResourceTypeName: "test-normal-resource",
+		InitClient: func(r *resource.Resource[any], cfg any) {
+			// No panic - normal initialization
+		},
+		ConfigGetter: func(c config.Config) config.ResourceType {
+			return config.ResourceType{}
+		},
+		Lister: func(ctx context.Context, client any, scope resource.Scope, cfg config.ResourceType) ([]*string, error) {
+			return nil, nil
+		},
+	})
+
+	adapter.Init(GcpConfig{ProjectID: "test-project"})
+
+	ids, err := adapter.GetAndSetIdentifiers(context.Background(), config.Config{})
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}

--- a/gcp/resources/artifact_registry.go
+++ b/gcp/resources/artifact_registry.go
@@ -34,10 +34,13 @@ func NewArtifactRegistryRepositories() GcpResource {
 		BatchSize:        DefaultBatchSize,
 		InitClient: WrapGcpInitClient(func(r *resource.Resource[*artifactregistry.Client], cfg GcpConfig) {
 			r.Scope.ProjectID = cfg.ProjectID
+			r.Scope.Locations = cfg.Locations
+			r.Scope.ExcludeLocations = cfg.ExcludeLocations
 			client, err := artifactregistry.NewClient(context.Background())
 			if err != nil {
-				r.InitializationError = fmt.Errorf("failed to create Artifact Registry client: %w", err)
-				return
+				// Panic is recovered by GcpResourceAdapter.Init() and stored as InitializationError,
+				// causing subsequent GetAndSetIdentifiers/Nuke calls to return the error gracefully.
+				panic(fmt.Sprintf("failed to create Artifact Registry client: %v", err))
 			}
 			r.Client = client
 		}),
@@ -68,6 +71,10 @@ func listArtifactRegistryRepositories(ctx context.Context, client *artifactregis
 		}
 		if err != nil {
 			return nil, fmt.Errorf("error listing artifact registry locations: %w", err)
+		}
+
+		if !MatchesLocationFilter(loc.LocationId, scope.Locations, scope.ExcludeLocations) {
+			continue
 		}
 
 		// List repositories in this location

--- a/gcp/resources/cloud_function.go
+++ b/gcp/resources/cloud_function.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	functions "cloud.google.com/go/functions/apiv2"
@@ -23,8 +24,12 @@ func NewCloudFunctions() GcpResource {
 		BatchSize:        DefaultBatchSize,
 		InitClient: WrapGcpInitClient(func(r *resource.Resource[*functions.FunctionClient], cfg GcpConfig) {
 			r.Scope.ProjectID = cfg.ProjectID
+			r.Scope.Locations = cfg.Locations
+			r.Scope.ExcludeLocations = cfg.ExcludeLocations
 			client, err := functions.NewFunctionClient(context.Background())
 			if err != nil {
+				// Panic is recovered by GcpResourceAdapter.Init() and stored as InitializationError,
+				// causing subsequent GetAndSetIdentifiers/Nuke calls to return the error gracefully.
 				panic(fmt.Sprintf("failed to create Cloud Functions client: %v", err))
 			}
 			r.Client = client
@@ -38,43 +43,69 @@ func NewCloudFunctions() GcpResource {
 }
 
 // listCloudFunctions retrieves all Cloud Functions (Gen2) in the project that match the config filters.
-// It queries across all locations using the wildcard parent: projects/{projectID}/locations/-
+// If scope.Locations is set, it queries specific locations; otherwise it uses the wildcard locations/-.
 func listCloudFunctions(ctx context.Context, client *functions.FunctionClient, scope resource.Scope, cfg config.ResourceType) ([]*string, error) {
 	var result []*string
 
-	// Use the wildcard "-" for location to list functions across ALL regions
-	parent := fmt.Sprintf("projects/%s/locations/-", scope.ProjectID)
-
-	req := &functionspb.ListFunctionsRequest{
-		Parent: parent,
+	// Build the list of parents to query
+	var parents []string
+	if len(scope.Locations) == 0 {
+		// Use the wildcard "-" for location to list functions across ALL locations
+		parents = []string{fmt.Sprintf("projects/%s/locations/-", scope.ProjectID)}
+	} else {
+		for _, loc := range scope.Locations {
+			if !MatchesLocationFilter(loc, nil, scope.ExcludeLocations) {
+				continue
+			}
+			if strings.EqualFold(loc, "global") {
+				logging.Debugf("Skipping Cloud Functions for location 'global' (not supported)")
+				continue
+			}
+			parents = append(parents, fmt.Sprintf("projects/%s/locations/%s", scope.ProjectID, loc))
+		}
 	}
 
-	it := client.ListFunctions(ctx, req)
-	for {
-		fn, err := it.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("error listing cloud functions: %w", err)
+	for _, parent := range parents {
+		req := &functionspb.ListFunctionsRequest{
+			Parent: parent,
 		}
 
-		// fn.Name is the fully qualified name: projects/{project}/locations/{location}/functions/{function}
-		name := fn.Name
+		it := client.ListFunctions(ctx, req)
+		for {
+			fn, err := it.Next()
+			if errors.Is(err, iterator.Done) {
+				break
+			}
+			if err != nil {
+				logging.Debugf("Error listing cloud functions in %s: %v", parent, err)
+				break
+			}
 
-		// Use UpdateTime as the resource timestamp for time-based filtering
-		var resourceTime time.Time
-		if fn.UpdateTime != nil {
-			resourceTime = fn.UpdateTime.AsTime()
-		}
+			// fn.Name is the fully qualified name: projects/{project}/locations/{location}/functions/{function}
+			name := fn.Name
 
-		resourceValue := config.ResourceValue{
-			Name: &name,
-			Time: &resourceTime,
-		}
+			// Post-filter by location when using wildcard query
+			if len(scope.ExcludeLocations) > 0 {
+				loc := ExtractLocationFromResourceName(name)
+				if loc == "" || !MatchesLocationFilter(loc, nil, scope.ExcludeLocations) {
+					continue
+				}
+			}
 
-		if cfg.ShouldInclude(resourceValue) {
-			result = append(result, &name)
+			// Use UpdateTime as the resource timestamp for time-based filtering
+			var resourceTime time.Time
+			if fn.UpdateTime != nil {
+				resourceTime = fn.UpdateTime.AsTime()
+			}
+
+			resourceValue := config.ResourceValue{
+				Name: &name,
+				Time: &resourceTime,
+			}
+
+			if cfg.ShouldInclude(resourceValue) {
+				result = append(result, &name)
+			}
 		}
 	}
 

--- a/gcp/resources/gcs_bucket.go
+++ b/gcp/resources/gcs_bucket.go
@@ -21,9 +21,11 @@ func NewGCSBuckets() GcpResource {
 		BatchSize:        DefaultBatchSize,
 		InitClient: WrapGcpInitClient(func(r *resource.Resource[*storage.Client], cfg GcpConfig) {
 			r.Scope.ProjectID = cfg.ProjectID
+			r.Scope.Locations = cfg.Locations
+			r.Scope.ExcludeLocations = cfg.ExcludeLocations
 			client, err := storage.NewClient(context.Background())
 			if err != nil {
-				// Panic is recovered by GcpResourceAdapter.Init() and stored as initErr,
+				// Panic is recovered by GcpResourceAdapter.Init() and stored as InitializationError,
 				// causing subsequent GetAndSetIdentifiers/Nuke calls to return the error gracefully.
 				panic(fmt.Sprintf("failed to create GCS client: %v", err))
 			}
@@ -49,6 +51,10 @@ func listGCSBuckets(ctx context.Context, client *storage.Client, scope resource.
 		}
 		if err != nil {
 			return nil, fmt.Errorf("error listing buckets: %w", err)
+		}
+
+		if !MatchesLocationFilter(bucket.Location, scope.Locations, scope.ExcludeLocations) {
+			continue
 		}
 
 		resourceValue := config.ResourceValue{

--- a/gcp/resources/pubsub.go
+++ b/gcp/resources/pubsub.go
@@ -27,12 +27,16 @@ const (
 )
 
 // NewPubSubTopics creates a new Pub/Sub topic resource using the generic resource pattern.
+// Pub/Sub topics are project-scoped; the API does not expose location info on topics,
+// so --region/--exclude-region do not filter Pub/Sub results.
 func NewPubSubTopics() GcpResource {
 	return NewGcpResource(&resource.Resource[*pubsub.PublisherClient]{
 		ResourceTypeName: "gcp-pubsub-topic",
 		BatchSize:        DefaultBatchSize,
 		InitClient: WrapGcpInitClient(func(r *resource.Resource[*pubsub.PublisherClient], cfg GcpConfig) {
 			r.Scope.ProjectID = cfg.ProjectID
+			r.Scope.Locations = cfg.Locations
+			r.Scope.ExcludeLocations = cfg.ExcludeLocations
 			client, err := pubsub.NewPublisherClient(context.Background())
 			if err != nil {
 				panic(fmt.Sprintf("failed to create Pub/Sub publisher client: %v", err))

--- a/gcp/resources/secret_manager.go
+++ b/gcp/resources/secret_manager.go
@@ -1,0 +1,314 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/resource"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+	locationpb "google.golang.org/genproto/googleapis/cloud/location"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// SecretManagerClients holds clients for the global and regional Secret Manager endpoints.
+type SecretManagerClients struct {
+	Global   *secretmanager.Client
+	Regional map[string]*secretmanager.Client // location -> client
+}
+
+// NewSecretManagerSecrets creates a new Secret Manager resource.
+func NewSecretManagerSecrets() GcpResource {
+	return NewGcpResource(&resource.Resource[*SecretManagerClients]{
+		ResourceTypeName: "gcp-secret-manager",
+		BatchSize:        DefaultBatchSize,
+		InitClient: WrapGcpInitClient(func(r *resource.Resource[*SecretManagerClients], cfg GcpConfig) {
+			r.Scope.ProjectID = cfg.ProjectID
+			r.Scope.Locations = cfg.Locations
+			r.Scope.ExcludeLocations = cfg.ExcludeLocations
+
+			clients, err := initSecretManagerClients(cfg)
+			if err != nil {
+				// Panic is recovered by GcpResourceAdapter.Init() and stored as InitializationError,
+				// causing subsequent GetAndSetIdentifiers/Nuke calls to return the error gracefully.
+				panic(fmt.Sprintf("failed to create Secret Manager clients: %v", err))
+			}
+			r.Client = clients
+		}),
+		ConfigGetter: func(c config.Config) config.ResourceType {
+			return c.GcpSecretManager
+		},
+		Lister: listSecretManagerSecrets,
+		Nuker:  resource.SequentialDeleter(deleteSecretManagerSecret),
+	})
+}
+
+// initSecretManagerClients creates the appropriate Secret Manager clients based on location filters.
+// A global client is always created first to discover available regional endpoints via ListLocations,
+// then regional clients are created for each location that passes the filter.
+func initSecretManagerClients(cfg GcpConfig) (*SecretManagerClients, error) {
+	ctx := context.Background()
+	clients := &SecretManagerClients{
+		Regional: make(map[string]*secretmanager.Client),
+	}
+
+	// Always create the global client — needed for ListLocations discovery and global secrets.
+	globalClient, err := secretmanager.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create global Secret Manager client: %w", err)
+	}
+
+	// Determine whether the user wants global secrets included.
+	wantGlobal := shouldIncludeGlobalEndpoint(cfg.Locations, cfg.ExcludeLocations)
+	if wantGlobal {
+		clients.Global = globalClient
+	}
+
+	// Discover available regional endpoints via ListLocations on the global client.
+	regionalLocations, err := discoverSecretManagerLocations(ctx, globalClient, cfg)
+
+	// Close the global client if it's only used for discovery, not for querying secrets.
+	if !wantGlobal {
+		_ = globalClient.Close()
+	}
+	if err != nil {
+		logging.Debugf("Failed to discover Secret Manager locations: %v", err)
+		// Fall back to global-only if discovery fails
+		if clients.Global == nil {
+			return nil, fmt.Errorf("failed to discover Secret Manager locations and global endpoint not requested")
+		}
+		return clients, nil
+	}
+
+	// Create a regional client for each discovered location.
+	// If a client fails to create, secrets in that location won't be discovered
+	// (listing is per-client), so there's no list/delete mismatch.
+	for _, loc := range regionalLocations {
+		endpoint := fmt.Sprintf("secretmanager.%s.rep.googleapis.com:443", loc)
+		client, err := secretmanager.NewClient(ctx, option.WithEndpoint(endpoint))
+		if err != nil {
+			logging.Debugf("Failed to create regional Secret Manager client for %s: %v", loc, err)
+			continue
+		}
+		clients.Regional[loc] = client
+	}
+
+	if clients.Global == nil && len(clients.Regional) == 0 {
+		return nil, fmt.Errorf("failed to create any Secret Manager clients")
+	}
+
+	return clients, nil
+}
+
+// discoverSecretManagerLocations uses the ListLocations RPC on the global client to
+// discover available regional endpoints, then filters them by the location config.
+func discoverSecretManagerLocations(ctx context.Context, client *secretmanager.Client, cfg GcpConfig) ([]string, error) {
+	locReq := &locationpb.ListLocationsRequest{
+		Name: fmt.Sprintf("projects/%s", cfg.ProjectID),
+	}
+
+	var locations []string
+	it := client.ListLocations(ctx, locReq)
+	for {
+		loc, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error listing Secret Manager locations: %w", err)
+		}
+
+		if !MatchesLocationFilter(loc.LocationId, cfg.Locations, cfg.ExcludeLocations) {
+			continue
+		}
+		// Skip "global" — it's handled by the global client, not a regional endpoint.
+		if strings.EqualFold(loc.LocationId, "global") {
+			continue
+		}
+		locations = append(locations, loc.LocationId)
+	}
+
+	return locations, nil
+}
+
+func isExcluded(location string, excludeLocations []string) bool {
+	for _, exc := range excludeLocations {
+		if strings.EqualFold(exc, location) {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldIncludeGlobalEndpoint determines whether the global Secret Manager endpoint
+// should be queried based on the location filters.
+//
+// No locations specified → include global (unless explicitly excluded)
+// Locations specified → include global only if "global" is in the list (and not excluded)
+func shouldIncludeGlobalEndpoint(locations []string, excludeLocations []string) bool {
+	if isExcluded("global", excludeLocations) {
+		return false
+	}
+	if len(locations) == 0 {
+		return true
+	}
+	for _, loc := range locations {
+		if strings.EqualFold(loc, "global") {
+			return true
+		}
+	}
+	return false
+}
+
+// listSecretManagerSecrets retrieves all secrets from the configured endpoints.
+func listSecretManagerSecrets(ctx context.Context, clients *SecretManagerClients, scope resource.Scope, cfg config.ResourceType) ([]*string, error) {
+	var result []*string
+	var listErrors int
+	totalEndpoints := len(clients.Regional)
+	if clients.Global != nil {
+		totalEndpoints++
+	}
+
+	// List secrets from the global endpoint (parent: projects/{project})
+	if clients.Global != nil {
+		parent := fmt.Sprintf("projects/%s", scope.ProjectID)
+		secrets, err := listSecretsFromClient(ctx, clients.Global, parent, cfg)
+		if err != nil {
+			logging.Debugf("Error listing global secrets: %v", err)
+			listErrors++
+		} else {
+			result = append(result, secrets...)
+		}
+	}
+
+	// List secrets from each regional endpoint (parent: projects/{project}/locations/{location})
+	for location, client := range clients.Regional {
+		parent := fmt.Sprintf("projects/%s/locations/%s", scope.ProjectID, location)
+		secrets, err := listSecretsFromClient(ctx, client, parent, cfg)
+		if err != nil {
+			logging.Debugf("Error listing secrets in location %s: %v", location, err)
+			listErrors++
+			continue
+		}
+		result = append(result, secrets...)
+	}
+
+	if listErrors > 0 && listErrors == totalEndpoints {
+		logging.Warnf("All %d Secret Manager endpoints failed to list secrets", totalEndpoints)
+	}
+
+	return result, nil
+}
+
+// listSecretsFromClient lists secrets from a single Secret Manager client.
+// Parent is "projects/{project}" for global or "projects/{project}/locations/{location}" for regional.
+func listSecretsFromClient(ctx context.Context, client *secretmanager.Client, parent string, cfg config.ResourceType) ([]*string, error) {
+	var result []*string
+
+	req := &secretmanagerpb.ListSecretsRequest{
+		Parent: parent,
+	}
+
+	it := client.ListSecrets(ctx, req)
+	for {
+		secret, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error listing secrets: %w", err)
+		}
+
+		// secret.Name is fully qualified: projects/{project}/secrets/{secret}
+		// For regional secrets: projects/{project}/locations/{location}/secrets/{secret}
+		fullName := secret.Name
+
+		// Extract short name for config filtering
+		shortName := fullName[strings.LastIndex(fullName, "/")+1:]
+
+		// Use CreateTime for time-based filtering
+		var resourceTime time.Time
+		if secret.CreateTime != nil {
+			resourceTime = secret.CreateTime.AsTime()
+		}
+
+		// Pass labels for tag-based filtering
+		labels := secret.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+
+		resourceValue := config.ResourceValue{
+			Name: &shortName,
+			Time: &resourceTime,
+			Tags: labels,
+		}
+
+		if cfg.ShouldInclude(resourceValue) {
+			result = append(result, &fullName)
+		}
+	}
+
+	return result, nil
+}
+
+// Rate limiting delay between secret deletions
+const secretManagerDeleteDelay = 500 * time.Millisecond
+
+// deleteSecretManagerSecret deletes a single secret.
+// It determines the correct client (global vs regional) from the fully qualified secret name.
+func deleteSecretManagerSecret(ctx context.Context, clients *SecretManagerClients, name *string) error {
+	secretName := *name
+
+	// Determine which client to use based on the secret name format.
+	// Regional: projects/{project}/locations/{location}/secrets/{secret}
+	// Global:   projects/{project}/secrets/{secret}
+	client := pickClientForSecret(clients, secretName)
+	if client == nil {
+		return fmt.Errorf("no client available for secret %s", secretName)
+	}
+
+	req := &secretmanagerpb.DeleteSecretRequest{
+		Name: secretName,
+	}
+
+	if err := client.DeleteSecret(ctx, req); err != nil {
+		if status.Code(err) == codes.NotFound {
+			logging.Debugf("Secret %s already deleted, skipping", secretName)
+			return nil
+		}
+		return fmt.Errorf("error deleting secret %s: %w", secretName, err)
+	}
+
+	logging.Debugf("Deleted Secret Manager secret: %s", secretName)
+
+	select {
+	case <-time.After(secretManagerDeleteDelay):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	return nil
+}
+
+// pickClientForSecret returns the appropriate client for the given secret name.
+func pickClientForSecret(clients *SecretManagerClients, secretName string) *secretmanager.Client {
+	// Parse location from name: projects/{project}/locations/{location}/secrets/{secret}
+	location := ExtractLocationFromResourceName(secretName)
+	if location != "" {
+		if client, ok := clients.Regional[location]; ok {
+			return client
+		}
+		return nil
+	}
+	// Global secret: projects/{project}/secrets/{secret}
+	return clients.Global
+}

--- a/gcp/resources/secret_manager_test.go
+++ b/gcp/resources/secret_manager_test.go
@@ -1,0 +1,68 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractLocationFromResourceName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"global secret", "projects/my-project/secrets/my-secret", ""},
+		{"regional secret", "projects/my-project/locations/us-central1/secrets/my-secret", "us-central1"},
+		{"locations segment with no value", "projects/my-project/locations", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, ExtractLocationFromResourceName(tc.input))
+		})
+	}
+}
+
+func TestShouldIncludeGlobalEndpoint(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		locs     []string
+		exclude  []string
+		expected bool
+	}{
+		{"no locations includes global", nil, nil, true},
+		{"global excluded", nil, []string{"global"}, false},
+		{"specific location excludes global", []string{"us-central1"}, nil, false},
+		{"global in locations", []string{"global", "us-central1"}, nil, true},
+		{"global in both includes and excludes", []string{"global"}, []string{"global"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, shouldIncludeGlobalEndpoint(tc.locs, tc.exclude))
+		})
+	}
+}
+
+func TestMatchesLocationFilter(t *testing.T) {
+	t.Parallel()
+
+	// No filter → match everything
+	assert.True(t, MatchesLocationFilter("us-central1", nil, nil))
+
+	// Include filter
+	assert.True(t, MatchesLocationFilter("us-central1", []string{"us-central1"}, nil))
+	assert.False(t, MatchesLocationFilter("us-east1", []string{"us-central1"}, nil))
+
+	// Exclude filter
+	assert.False(t, MatchesLocationFilter("us-central1", nil, []string{"us-central1"}))
+
+	// Exclude takes precedence over include
+	assert.False(t, MatchesLocationFilter("us-central1", []string{"us-central1"}, []string{"us-central1"}))
+
+	// Case insensitive
+	assert.True(t, MatchesLocationFilter("US-CENTRAL1", []string{"us-central1"}, nil))
+}

--- a/gcp/resources/types.go
+++ b/gcp/resources/types.go
@@ -16,8 +16,10 @@ type GcpResources struct {
 	Resources []*GcpResource
 }
 
-// GcpProjectResources is a struct that represents the resources found in a single GCP project
+// GcpProjectResources represents the resources found in a single GCP project.
+// The map key is "project" (a single flat namespace, not keyed by region).
 type GcpProjectResources struct {
+	ProjectID string
 	Resources map[string]GcpResources
 }
 
@@ -31,8 +33,8 @@ func (g *GcpProjectResources) GetRegion(region string) GcpResources {
 // TotalResourceCount returns the number of resources found, that are eligible for nuking
 func (g *GcpProjectResources) TotalResourceCount() int {
 	total := 0
-	for _, regionResource := range g.Resources {
-		for _, resource := range regionResource.Resources {
+	for _, projectResource := range g.Resources {
+		for _, resource := range projectResource.Resources {
 			total += len((*resource).ResourceIdentifiers())
 		}
 	}
@@ -42,8 +44,8 @@ func (g *GcpProjectResources) TotalResourceCount() int {
 // MapResourceTypeToIdentifiers converts a slice of Resources to a map of resource types to their found identifiers
 func (g *GcpProjectResources) MapResourceTypeToIdentifiers() map[string][]string {
 	identifiers := map[string][]string{}
-	for _, regionResource := range g.Resources {
-		for _, resource := range regionResource.Resources {
+	for _, projectResource := range g.Resources {
+		for _, resource := range projectResource.Resources {
 			resourceType := (*resource).ResourceName()
 			if _, ok := identifiers[resourceType]; !ok {
 				identifiers[resourceType] = []string{}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	cloud.google.com/go/artifactregistry v1.17.1
 	cloud.google.com/go/functions v1.19.7
 	cloud.google.com/go/pubsub v1.49.0
+	cloud.google.com/go/resourcemanager v1.10.7
+	cloud.google.com/go/secretmanager v1.16.0
 	cloud.google.com/go/storage v1.50.0
 	github.com/aws/aws-sdk-go-v2 v1.41.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.5
@@ -76,6 +78,7 @@ require (
 	google.golang.org/genproto v0.0.0-20250603155806-513f23925822
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250811230008-5f3141c8851a
 	google.golang.org/grpc v1.74.2
+	google.golang.org/protobuf v1.36.7
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -153,6 +156,5 @@ require (
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250818200422-3122310a409c // indirect
-	google.golang.org/protobuf v1.36.7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,10 @@ cloud.google.com/go/monitoring v1.24.2 h1:5OTsoJ1dXYIiMiuL+sYscLc9BumrL3CarVLL7d
 cloud.google.com/go/monitoring v1.24.2/go.mod h1:x7yzPWcgDRnPEv3sI+jJGBkwl5qINf+6qY4eq0I9B4U=
 cloud.google.com/go/pubsub v1.49.0 h1:5054IkbslnrMCgA2MAEPcsN3Ky+AyMpEZcii/DoySPo=
 cloud.google.com/go/pubsub v1.49.0/go.mod h1:K1FswTWP+C1tI/nfi3HQecoVeFvL4HUOB1tdaNXKhUY=
+cloud.google.com/go/resourcemanager v1.10.7 h1:oPZKIdjyVTuag+D4HF7HO0mnSqcqgjcuA18xblwA0V0=
+cloud.google.com/go/resourcemanager v1.10.7/go.mod h1:rScGkr6j2eFwxAjctvOP/8sqnEpDbQ9r5CKwKfomqjs=
+cloud.google.com/go/secretmanager v1.16.0 h1:19QT7ZsLJ8FSP1k+4esQvuCD7npMJml6hYzilxVyT+k=
+cloud.google.com/go/secretmanager v1.16.0/go.mod h1://C/e4I8D26SDTz1f3TQcddhcmiC3rMEl0S1Cakvs3Q=
 cloud.google.com/go/storage v1.50.0 h1:3TbVkzTooBvnZsk7WaAQfOsNrdoM8QHusXA1cpk6QJs=
 cloud.google.com/go/storage v1.50.0/go.mod h1:l7XeiD//vx5lfqE3RavfmU9yvk5Pp0Zhcv482poyafY=
 cloud.google.com/go/trace v1.11.6 h1:2O2zjPzqPYAHrn3OKl029qlqG6W8ZdYaOWRyr8NgMT4=

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -16,10 +16,12 @@ const DefaultBatchSize = 50
 
 // Scope represents the cloud provider-specific scope for a resource.
 // For AWS: Region is set (e.g., "us-east-1" or "global" for global resources)
-// For GCP: ProjectID is set, and optionally Region for regional resources
+// For GCP: ProjectID is set, with Locations as an optional filter hint
 type Scope struct {
-	Region    string // AWS region (e.g., "us-east-1") or "global" for global resources
-	ProjectID string // GCP project ID
+	Region           string   // AWS region (e.g., "us-east-1") or "global" for global resources
+	ProjectID        string   // GCP project ID
+	Locations        []string // GCP location filter hints (e.g., ["us-central1", "global"])
+	ExcludeLocations []string // GCP locations to exclude
 }
 
 // String returns a human-readable representation of the scope for logging


### PR DESCRIPTION
## Summary
- Recover panics in `GcpResourceAdapter.Init()` and store as `InitializationError` for graceful degradation
- Validate project ID upfront via Cloud Resource Manager API before scanning
- Consolidate CLI flag parsing into shared `generateGcpQuery()` helper with `Timeout` wiring
- Redesign GCP region model: drop global/regional split, make `--region` a location filter hint each resource handles internally
- Add `MatchesLocationFilter` helper; update Cloud Functions, Artifact Registry, GCS, Pub/Sub to use it
- Add Secret Manager resource with multi-client architecture (global + regional endpoints discovered dynamically via `ListLocations` RPC)

### Why Secret Manager?
Secret Manager is the first GCP resource that has both global and regional endpoints — secrets can live at `projects/{p}/secrets/{s}` (global) or `projects/{p}/locations/{loc}/secrets/{s}` (regional). The previous global/regional registry split couldn't model this: a single resource type needs to query multiple endpoint classes and route deletions to the correct client based on the secret's fully qualified name. This drove the redesign from a registry-level split to per-resource location handling, and Secret Manager serves as the concrete proof that the new model works for mixed-endpoint resources.

Closes #1053

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./gcp/... ./config/... ./resource/... ./commands/...` — all pass
- [x] `scripts/check-resource-naming.sh` — lint passes
- [x] Adapter panic recovery tests pass
- [x] Location filter, query validation, Secret Manager helper unit tests pass