### PR TITLE
feat(gcp): add Pub/Sub topic resource with first-seen label and exclude-first-seen flag support 

### DIFF
--- a/commands/cli.go
+++ b/commands/cli.go
@@ -73,7 +73,13 @@ func CreateCli(version string) *cli.App {
 				CommonTimeFlags(),
 				CommonExecutionFlags(),
 				CommonOutputFlags(),
-				[]cli.Flag{ConfigFlag()},
+				[]cli.Flag{
+					ConfigFlag(),
+					&cli.BoolFlag{
+						Name:  FlagExcludeFirstSeen,
+						Usage: "Set a flag for excluding first-seen-tag",
+					},
+				},
 			),
 		}, {
 			Name:   "inspect-gcp",
@@ -85,7 +91,13 @@ func CreateCli(version string) *cli.App {
 				InspectResourceTypeFlags(),
 				CommonTimeFlags(),
 				CommonOutputFlags(),
-				[]cli.Flag{ConfigFlag()},
+				[]cli.Flag{
+					ConfigFlag(),
+					&cli.BoolFlag{
+						Name:  FlagExcludeFirstSeen,
+						Usage: "Set a flag for excluding first-seen-tag",
+					},
+				},
 			),
 		}, {
 			Name:   "defaults-aws",

--- a/commands/gcp_commands.go
+++ b/commands/gcp_commands.go
@@ -42,6 +42,7 @@ func gcpNuke(c *cli.Context) error {
 		ExcludeRegions:       c.StringSlice(FlagExcludeRegion),
 		ResourceTypes:        c.StringSlice(FlagResourceType),
 		ExcludeResourceTypes: c.StringSlice(FlagExcludeResourceType),
+		ExcludeFirstSeen:     c.Bool(FlagExcludeFirstSeen),
 	}
 
 	// Apply timeout to config
@@ -86,6 +87,7 @@ func gcpInspect(c *cli.Context) error {
 		ExcludeRegions:       c.StringSlice(FlagExcludeRegion),
 		ResourceTypes:        c.StringSlice(FlagResourceType),
 		ExcludeResourceTypes: c.StringSlice(FlagExcludeResourceType),
+		ExcludeFirstSeen:     c.Bool(FlagExcludeFirstSeen),
 	}
 
 	// Load config file if provided

--- a/config/config.go
+++ b/config/config.go
@@ -154,6 +154,7 @@ type Config struct {
 	GCSBucket        ResourceType `yaml:"GCSBucket"`
 	CloudFunction    ResourceType `yaml:"CloudFunction"`
 	ArtifactRegistry ResourceType `yaml:"ArtifactRegistry"`
+	GcpPubSubTopic   ResourceType `yaml:"GcpPubSubTopic"`
 }
 
 // allResourceTypes returns pointers to the embedded ResourceType for every
@@ -293,6 +294,7 @@ func (c *Config) allResourceTypes() []*ResourceType {
 		&c.GCSBucket,
 		&c.CloudFunction,
 		&c.ArtifactRegistry,
+		&c.GcpPubSubTopic,
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -141,6 +141,7 @@ func emptyConfig() *Config {
 		GCSBucket:        ResourceType{FilterRule{}, FilterRule{}, "", false},
 		CloudFunction:    ResourceType{FilterRule{}, FilterRule{}, "", false},
 		ArtifactRegistry: ResourceType{FilterRule{}, FilterRule{}, "", false},
+		GcpPubSubTopic:   ResourceType{FilterRule{}, FilterRule{}, "", false},
 	}
 }
 

--- a/docs/supported-resources.md
+++ b/docs/supported-resources.md
@@ -281,6 +281,7 @@ cloud-nuke supports inspecting and deleting the following GCP resources. The **C
 | `artifact-registry` | Artifact Registry Repository |
 | `cloud-function` | Cloud Functions (Gen2) |
 | `gcs-bucket` | Google Cloud Storage Bucket |
+| `gcp-pubsub-topic` | Pub/Sub Topic |
 
 ### GCP Config Support Matrix
 
@@ -289,6 +290,7 @@ cloud-nuke supports inspecting and deleting the following GCP resources. The **C
 | artifact-registry | ArtifactRegistry | ✓ | ✓ | ✓ |
 | cloud-function | CloudFunction | ✓ | ✓ | ✓ |
 | gcs-bucket | GCSBucket | ✓ | ✓ | ✓ |
+| gcp-pubsub-topic | GcpPubSubTopic | ✓ | ✓ | ✓ |
 
 ## IsNukable Permission Check
 

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -39,6 +39,8 @@ func GetAllResources(ctx context.Context, query *Query, configObj config.Config,
 		Resources: map[string]GcpResources{},
 	}
 
+	ctx = context.WithValue(ctx, util.ExcludeFirstSeenTagKey, query.ExcludeFirstSeen)
+
 	for _, region := range query.Regions {
 		cfg := resources.GcpConfig{ProjectID: query.ProjectID, Region: region}
 		regionResources := GetAndInitRegisteredResources(cfg, region)

--- a/gcp/query.go
+++ b/gcp/query.go
@@ -18,6 +18,7 @@ type Query struct {
 	ExcludeAfter         *time.Time
 	IncludeAfter         *time.Time
 	Timeout              *time.Duration
+	ExcludeFirstSeen     bool
 }
 
 // Validate ensures the query has valid defaults.

--- a/gcp/resource_registry.go
+++ b/gcp/resource_registry.go
@@ -13,6 +13,7 @@ func getRegisteredGlobalResources() []GcpResource {
 		resources.NewGCSBuckets(),
 		resources.NewCloudFunctions(),
 		resources.NewArtifactRegistryRepositories(),
+		resources.NewPubSubTopics(),
 	}
 }
 

--- a/gcp/resources/pubsub.go
+++ b/gcp/resources/pubsub.go
@@ -1,0 +1,174 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	pubsub "cloud.google.com/go/pubsub/apiv1"
+	"cloud.google.com/go/pubsub/apiv1/pubsubpb"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/resource"
+	"github.com/gruntwork-io/cloud-nuke/util"
+	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+const (
+	// firstSeenLabelKey is the GCP label key used to track when cloud-nuke first discovered a topic.
+	// GCP label keys must match [a-z][a-z0-9_-]{0,62}.
+	firstSeenLabelKey = "cloud-nuke-first-seen"
+)
+
+// NewPubSubTopics creates a new Pub/Sub topic resource using the generic resource pattern.
+func NewPubSubTopics() GcpResource {
+	return NewGcpResource(&resource.Resource[*pubsub.PublisherClient]{
+		ResourceTypeName: "gcp-pubsub-topic",
+		BatchSize:        DefaultBatchSize,
+		InitClient: WrapGcpInitClient(func(r *resource.Resource[*pubsub.PublisherClient], cfg GcpConfig) {
+			r.Scope.ProjectID = cfg.ProjectID
+			client, err := pubsub.NewPublisherClient(context.Background())
+			if err != nil {
+				panic(fmt.Sprintf("failed to create Pub/Sub publisher client: %v", err))
+			}
+			r.Client = client
+		}),
+		ConfigGetter: func(c config.Config) config.ResourceType {
+			return c.GcpPubSubTopic
+		},
+		Lister: listPubSubTopics,
+		Nuker:  resource.SequentialDeleter(deletePubSubTopic),
+	})
+}
+
+// listPubSubTopics retrieves all Pub/Sub topics in the project that match the config filters.
+//
+// Since the Pub/Sub API does not expose a creation timestamp for topics, this function
+// uses a first-seen label approach similar to AWS:
+//   - On first discovery, a "cloud-nuke-first-seen" label is set on the topic with the
+//     current Unix epoch timestamp as the value.
+//   - On subsequent runs, the stored timestamp is used for --older-than / --newer-than filtering.
+//   - Topics are never deleted on the first run when time-based filters are active.
+func listPubSubTopics(ctx context.Context, client *pubsub.PublisherClient, scope resource.Scope, cfg config.ResourceType) ([]*string, error) {
+	excludeFirstSeen, err := util.GetBoolFromContext(ctx, util.ExcludeFirstSeenTagKey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read exclude-first-seen-tag from context: %w", err)
+	}
+
+	var result []*string
+
+	req := &pubsubpb.ListTopicsRequest{
+		Project: fmt.Sprintf("projects/%s", scope.ProjectID),
+	}
+
+	it := client.ListTopics(ctx, req)
+	for {
+		topic, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error listing Pub/Sub topics: %w", err)
+		}
+
+		// topic.Name format: projects/{project}/topics/{topic}
+		shortName := topic.Name[strings.LastIndex(topic.Name, "/")+1:]
+
+		labels := topic.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+
+		// Get or create the first-seen timestamp via label.
+		// Returns nil if --exclude-first-seen-tag is set (time filter is skipped).
+		// On failure, log and skip this topic rather than aborting the entire listing —
+		// a label update error on one topic should not prevent other topics from being processed.
+		firstSeenTime, err := getOrCreatePubSubFirstSeen(ctx, client, topic, labels, excludeFirstSeen)
+		if err != nil {
+			logging.Errorf("Unable to get or set first-seen label for Pub/Sub topic %s: %v", topic.Name, err)
+			continue
+		}
+
+		resourceValue := config.ResourceValue{
+			Name: &shortName,
+			Time: firstSeenTime,
+			Tags: labels,
+		}
+
+		if cfg.ShouldInclude(resourceValue) {
+			name := topic.Name
+			result = append(result, &name)
+		}
+	}
+
+	return result, nil
+}
+
+// getOrCreatePubSubFirstSeen checks for the first-seen label on a topic.
+// If it exists, it parses and returns the stored timestamp.
+// If not, it sets the label with the current Unix epoch and returns the current time.
+// GCP label values only support lowercase letters, digits, hyphens, and underscores,
+// so Unix epoch seconds (e.g. "1705312200") are used instead of RFC3339.
+func getOrCreatePubSubFirstSeen(ctx context.Context, client *pubsub.PublisherClient, topic *pubsubpb.Topic, labels map[string]string, excludeFirstSeen bool) (*time.Time, error) {
+	if excludeFirstSeen {
+		return nil, nil
+	}
+
+	if val, ok := labels[firstSeenLabelKey]; ok {
+		epoch, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse first-seen label value %q: %w", val, err)
+		}
+		t := time.Unix(epoch, 0).UTC()
+		return &t, nil
+	}
+
+	// Label not set — set it now with the current Unix epoch
+	now := time.Now().UTC()
+	newLabels := make(map[string]string, len(labels)+1)
+	for k, v := range labels {
+		newLabels[k] = v
+	}
+	newLabels[firstSeenLabelKey] = strconv.FormatInt(now.Unix(), 10)
+
+	_, err := client.UpdateTopic(ctx, &pubsubpb.UpdateTopicRequest{
+		Topic: &pubsubpb.Topic{
+			Name:   topic.Name,
+			Labels: newLabels,
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{"labels"},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to set first-seen label on topic %s: %w", topic.Name, err)
+	}
+
+	return &now, nil
+}
+
+// deletePubSubTopic deletes a single Pub/Sub topic.
+func deletePubSubTopic(ctx context.Context, client *pubsub.PublisherClient, name *string) error {
+	topicName := *name
+
+	req := &pubsubpb.DeleteTopicRequest{
+		Topic: topicName,
+	}
+
+	if err := client.DeleteTopic(ctx, req); err != nil {
+		if status.Code(err) == codes.NotFound {
+			logging.Debugf("Pub/Sub topic %s already deleted, skipping", topicName)
+			return nil
+		}
+		return fmt.Errorf("error deleting Pub/Sub topic %s: %w", topicName, err)
+	}
+
+	logging.Debugf("Deleted Pub/Sub topic: %s", topicName)
+	return nil
+}

--- a/gcp/resources/pubsub_test.go
+++ b/gcp/resources/pubsub_test.go
@@ -1,0 +1,17 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPubSubTopics_ResourceName(t *testing.T) {
+	ps := NewPubSubTopics()
+	assert.Equal(t, "gcp-pubsub-topic", ps.ResourceName())
+}
+
+func TestPubSubTopics_MaxBatchSize(t *testing.T) {
+	ps := NewPubSubTopics()
+	assert.Equal(t, 50, ps.MaxBatchSize())
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	cloud.google.com/go/artifactregistry v1.17.1
 	cloud.google.com/go/functions v1.19.7
+	cloud.google.com/go/pubsub v1.49.0
 	cloud.google.com/go/storage v1.50.0
 	github.com/aws/aws-sdk-go-v2 v1.41.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.5

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ cloud.google.com/go/longrunning v0.6.7 h1:IGtfDWHhQCgCjwQjV9iiLnUta9LBCo8R9QmAFs
 cloud.google.com/go/longrunning v0.6.7/go.mod h1:EAFV3IZAKmM56TyiE6VAP3VoTzhZzySwI/YI1s/nRsY=
 cloud.google.com/go/monitoring v1.24.2 h1:5OTsoJ1dXYIiMiuL+sYscLc9BumrL3CarVLL7dd7lHM=
 cloud.google.com/go/monitoring v1.24.2/go.mod h1:x7yzPWcgDRnPEv3sI+jJGBkwl5qINf+6qY4eq0I9B4U=
+cloud.google.com/go/pubsub v1.49.0 h1:5054IkbslnrMCgA2MAEPcsN3Ky+AyMpEZcii/DoySPo=
+cloud.google.com/go/pubsub v1.49.0/go.mod h1:K1FswTWP+C1tI/nfi3HQecoVeFvL4HUOB1tdaNXKhUY=
 cloud.google.com/go/storage v1.50.0 h1:3TbVkzTooBvnZsk7WaAQfOsNrdoM8QHusXA1cpk6QJs=
 cloud.google.com/go/storage v1.50.0/go.mod h1:l7XeiD//vx5lfqE3RavfmU9yvk5Pp0Zhcv482poyafY=
 cloud.google.com/go/trace v1.11.6 h1:2O2zjPzqPYAHrn3OKl029qlqG6W8ZdYaOWRyr8NgMT4=


### PR DESCRIPTION
## Description

Fixes #1060.

Add GCP Pub/Sub topic (`gcp-pubsub-topic`) as a new supported cloud-nuke resource. Also wires the `--exclude-first-seen` flag to GCP commands, matching the existing AWS behaviour.

### How it works

**List:** Since the Pub/Sub API does not expose a creation timestamp for topics, a first-seen label approach is used. On first discovery, a `cloud-nuke-first-seen` label is stamped on the topic with the current Unix epoch seconds. On subsequent runs, this stored value is used for `--older-than` / `--newer-than` filtering, matching the AWS pattern. Topics are never deleted on the first run when time-based filters are active.

**Delete:** Sends a delete request for each topic. Already-deleted topics (404) are handled gracefully.

**Identifier format:** Full resource name — `projects/{project}/topics/{topic}`

**`--exclude-first-seen` flag:** The `--exclude-first-seen` flag is now wired to GCP (`gcp` and `inspect-gcp` commands), allowing users to skip first-seen label stamping entirely. This matches the existing AWS behaviour.

### Test output

```text
=== RUN   TestPubSubTopics_ResourceName
--- PASS: TestPubSubTopics_ResourceName (0.00s)
=== RUN   TestPubSubTopics_MaxBatchSize
--- PASS: TestPubSubTopics_MaxBatchSize (0.00s)
PASS
ok      github.com/gruntwork-io/cloud-nuke/gcp/resources        0.020s
```

Manually verified against a real GCP project:
- First-seen label stamped on first run
- `--older-than 24h` returns 0 topics as expected
- `--exclude-first-seen` returns the topic without stamping or time filtering

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts. *(Note: `nuke_sandbox` and `nuke_phxdevops` only run `aws`, so no exclusions are needed for this new GCP resource.)*

## Release Notes (draft)

Added GCP Pub/Sub topic (`gcp-pubsub-topic`) as a new supported resource type with first-seen label-based time filtering. Wired the `--exclude-first-seen` flag to GCP commands, matching the existing AWS behaviour.

### Migration Guide

This PR introduces `gcp-pubsub-topic` as a new GCP resource type. Since `cloud-nuke` automatically includes all registered resource types, Pub/Sub topics will be nuked by default if no config file is provided.
To opt out, add the following to your `cloud-nuke.yml` config file:

```yaml
GcpPubSubTopic:
  exclude:
    names_regex:
      - ".*"
```