### PR TITLE
fix: classify transient nuke failures as warnings

### DIFF
--- a/.github/workflows/nuke-account.yml
+++ b/.github/workflows/nuke-account.yml
@@ -127,16 +127,19 @@ jobs:
           # Aggregate counts from all JSON files into a temp file for sorting
           TOTAL_DELETED=0
           TOTAL_FAILED=0
+          TOTAL_WARNED=0
           REGION_DATA=$(mktemp)
           while IFS= read -r json_file; do
             if [ -f "$json_file" ]; then
               REGION=$(basename "$json_file" .json | sed 's/^nuke-//')
               DELETED=$(jq -r '.summary.deleted // 0' "$json_file")
               FAILED=$(jq -r '.summary.failed // 0' "$json_file")
+              WARNED=$(jq -r '.summary.warned // 0' "$json_file")
               TOTAL_DELETED=$((TOTAL_DELETED + DELETED))
               TOTAL_FAILED=$((TOTAL_FAILED + FAILED))
-              if [ "$DELETED" -gt 0 ] || [ "$FAILED" -gt 0 ]; then
-                echo "${DELETED} ${FAILED} ${REGION}" >> "$REGION_DATA"
+              TOTAL_WARNED=$((TOTAL_WARNED + WARNED))
+              if [ "$DELETED" -gt 0 ] || [ "$FAILED" -gt 0 ] || [ "$WARNED" -gt 0 ]; then
+                echo "${DELETED} ${FAILED} ${WARNED} ${REGION}" >> "$REGION_DATA"
               fi
             fi
           done < <(find /tmp/logs -name "*.json" 2>/dev/null | sort)
@@ -148,14 +151,20 @@ jobs:
           REMAINING_COUNT=0
           REMAINING_DELETED=0
           REMAINING_FAILED=0
-          while IFS=' ' read -r DEL FAIL REG; do
+          REMAINING_WARNED=0
+          while IFS=' ' read -r DEL FAIL WARN REG; do
             if [ "$SHOWN" -lt 5 ]; then
-              TOP_REGIONS="${TOP_REGIONS}${NL}• ${REG}: deleted ${DEL}, failed ${FAIL}"
+              REGION_LINE="• ${REG}: deleted ${DEL}, failed ${FAIL}"
+              if [ "$WARN" -gt 0 ]; then
+                REGION_LINE="${REGION_LINE}, warned ${WARN}"
+              fi
+              TOP_REGIONS="${TOP_REGIONS}${NL}${REGION_LINE}"
               SHOWN=$((SHOWN + 1))
             else
               REMAINING_COUNT=$((REMAINING_COUNT + 1))
               REMAINING_DELETED=$((REMAINING_DELETED + DEL))
               REMAINING_FAILED=$((REMAINING_FAILED + FAIL))
+              REMAINING_WARNED=$((REMAINING_WARNED + WARN))
             fi
           done < <(sort -k2,2nr "$REGION_DATA")
           rm -f "$REGION_DATA"
@@ -169,12 +178,20 @@ jobs:
           fi
 
           MSG="*${{ inputs.account_name }} Nuke*: ${STATUS}"
-          MSG="${MSG}${NL}Deleted: ${TOTAL_DELETED:-0} | Failed: ${TOTAL_FAILED:-0}"
+          SUMMARY_LINE="Deleted: ${TOTAL_DELETED:-0} | Failed: ${TOTAL_FAILED:-0}"
+          if [ "${TOTAL_WARNED:-0}" -gt 0 ]; then
+            SUMMARY_LINE="${SUMMARY_LINE} | Warned: ${TOTAL_WARNED}"
+          fi
+          MSG="${MSG}${NL}${SUMMARY_LINE}"
           if [ -n "$TOP_REGIONS" ]; then
             MSG="${MSG}${TOP_REGIONS}"
           fi
           if [ "$REMAINING_COUNT" -gt 0 ]; then
-            MSG="${MSG}${NL}_+ ${REMAINING_COUNT} other regions: deleted ${REMAINING_DELETED}, failed ${REMAINING_FAILED}_"
+            REMAINING_LINE="_+ ${REMAINING_COUNT} other regions: deleted ${REMAINING_DELETED}, failed ${REMAINING_FAILED}"
+            if [ "$REMAINING_WARNED" -gt 0 ]; then
+              REMAINING_LINE="${REMAINING_LINE}, warned ${REMAINING_WARNED}"
+            fi
+            MSG="${MSG}${NL}${REMAINING_LINE}_"
           fi
           MSG="${MSG}${NL}<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
 

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -183,6 +183,7 @@ func nukeAllResourcesInRegion(ctx context.Context, account *AwsAccountResources,
 					Region:       region,
 					Identifier:   result.Identifier,
 					Success:      result.Error == nil,
+					Warning:      result.Error != nil && util.IsWarningError(result.Error),
 					Error:        errStr,
 				})
 			}

--- a/renderers/cli.go
+++ b/renderers/cli.go
@@ -15,6 +15,7 @@ import (
 const (
 	SuccessEmoji = "✅"
 	FailureEmoji = "❌"
+	WarningEmoji = "⚠️"
 )
 
 // MaxResourcesForDetailedTable is the threshold above which the CLI renders
@@ -326,6 +327,8 @@ func (r *CLIRenderer) printDeletedTable() {
 		var status string
 		if e.Success {
 			status = SuccessEmoji
+		} else if e.Warning {
+			status = fmt.Sprintf("%s %s", WarningEmoji, util.Truncate(util.RemoveNewlines(e.Error), 40))
 		} else {
 			status = fmt.Sprintf("%s %s", FailureEmoji, util.Truncate(util.RemoveNewlines(e.Error), 40))
 		}
@@ -354,6 +357,7 @@ func (r *CLIRenderer) printDeletedSummaryTable() {
 	type counts struct {
 		success int
 		failure int
+		warned  int
 	}
 
 	summary := make(map[key]*counts)
@@ -369,13 +373,15 @@ func (r *CLIRenderer) printDeletedSummaryTable() {
 		}
 		if e.Success {
 			c.success++
+		} else if e.Warning {
+			c.warned++
 		} else {
 			c.failure++
 		}
 	}
 
 	tableData := pterm.TableData{
-		{"Resource Type", "Region", "Successful", "Failed"},
+		{"Resource Type", "Region", "Successful", "Failed", "Warned"},
 	}
 	for _, k := range order {
 		c := summary[k]
@@ -384,6 +390,7 @@ func (r *CLIRenderer) printDeletedSummaryTable() {
 			k.Region,
 			fmt.Sprintf("%d", c.success),
 			fmt.Sprintf("%d", c.failure),
+			fmt.Sprintf("%d", c.warned),
 		})
 	}
 

--- a/renderers/json.go
+++ b/renderers/json.go
@@ -153,12 +153,18 @@ func (r *JSONRenderer) renderNukeOutput() error {
 	resources := make([]NukeResourceInfo, 0, len(r.deleted))
 	deletedCount := 0
 	failedCount := 0
+	warnedCount := 0
 
 	for _, e := range r.deleted {
 		status := "deleted"
 		if !e.Success {
-			status = "failed"
-			failedCount++
+			if e.Warning {
+				status = "warned"
+				warnedCount++
+			} else {
+				status = "failed"
+				failedCount++
+			}
 		} else {
 			deletedCount++
 		}
@@ -192,6 +198,7 @@ func (r *JSONRenderer) renderNukeOutput() error {
 			Total:         len(r.deleted),
 			Deleted:       deletedCount,
 			Failed:        failedCount,
+			Warned:        warnedCount,
 			GeneralErrors: len(r.errors),
 		},
 	}

--- a/renderers/types.go
+++ b/renderers/types.go
@@ -60,7 +60,7 @@ type NukeResourceInfo struct {
 	ResourceType string `json:"resource_type"`
 	Region       string `json:"region"`
 	Identifier   string `json:"identifier"`
-	Status       string `json:"status"` // "deleted" or "failed"
+	Status       string `json:"status"` // "deleted", "failed", or "warned"
 	Error        string `json:"error,omitempty"`
 }
 
@@ -77,6 +77,7 @@ type NukeSummary struct {
 	Total         int `json:"total"`
 	Deleted       int `json:"deleted"`
 	Failed        int `json:"failed"`
+	Warned        int `json:"warned"`
 	GeneralErrors int `json:"general_errors"`
 }
 

--- a/reporting/events.go
+++ b/reporting/events.go
@@ -52,6 +52,7 @@ type ResourceDeleted struct {
 	Region       string
 	Identifier   string
 	Success      bool
+	Warning      bool   // True if failure is transient/expected (e.g., DependencyViolation)
 	Error        string // Empty if success
 }
 

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -194,8 +194,13 @@ func (r *Resource[C]) Nuke(ctx context.Context, identifiers []string) ([]NukeRes
 	var allErrs *multierror.Error
 	for _, result := range results {
 		if result.Error != nil {
-			logging.Errorf("[Failed] %s %s: %s", r.ResourceTypeName, result.Identifier, result.Error)
-			allErrs = multierror.Append(allErrs, fmt.Errorf("%s: %w", result.Identifier, result.Error))
+			if util.IsWarningError(result.Error) {
+				logging.Warnf("[Warning] %s %s: %s (non-fatal, will retry next run)",
+					r.ResourceTypeName, result.Identifier, result.Error)
+			} else {
+				logging.Errorf("[Failed] %s %s: %s", r.ResourceTypeName, result.Identifier, result.Error)
+				allErrs = multierror.Append(allErrs, fmt.Errorf("%s: %w", result.Identifier, result.Error))
+			}
 		} else {
 			logging.Debugf("[OK] Deleted %s: %s", r.ResourceTypeName, result.Identifier)
 		}

--- a/util/error.go
+++ b/util/error.go
@@ -75,3 +75,42 @@ func IsThrottlingError(err error) bool {
 	}
 	return false
 }
+
+// IsWarningError checks if the error is a transient/expected failure that
+// should be logged as a warning rather than causing a non-zero exit code.
+// These errors fall into two categories:
+//
+// Ordering/dependency errors — resources deleted in the wrong order. The
+// dependent resource will be cleaned up on the next nuke run once the
+// parent is gone:
+//   - DependencyViolation: EC2 subnet/ENI/SG still referenced by another resource
+//   - InvalidDBSubnetGroupStateFault: RDS subnet group in use by a DB instance
+//   - InvalidDBClusterStateFault: RDS cluster can't be deleted while its instances exist
+//   - InvalidClusterState: Redshift cluster has an operation in progress
+//
+// Already-deleted errors — resource was deleted between the scan and nuke
+// phases (e.g., by another concurrent nuke run or TTL expiry). Safe to ignore:
+//   - DBSubnetGroupNotFoundFault: RDS subnet group no longer exists
+//   - DBParameterGroupNotFound: RDS parameter group no longer exists
+//   - InvalidSubnetID.NotFound: EC2 subnet no longer exists
+//   - InvalidNetworkInterfaceID.NotFound: EC2 ENI no longer exists
+func IsWarningError(err error) bool {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		// Ordering/dependency errors
+		case "DependencyViolation",
+			"InvalidDBSubnetGroupStateFault",
+			"InvalidDBClusterStateFault",
+			"InvalidClusterState":
+			return true
+		// Already-deleted errors
+		case "DBSubnetGroupNotFoundFault",
+			"DBParameterGroupNotFound",
+			"InvalidSubnetID.NotFound",
+			"InvalidNetworkInterfaceID.NotFound":
+			return true
+		}
+	}
+	return false
+}

--- a/util/error_test.go
+++ b/util/error_test.go
@@ -111,3 +111,23 @@ func TestTransformAWSError(t *testing.T) {
 		})
 	}
 }
+
+func TestIsWarningError(t *testing.T) {
+	warningCodes := []string{
+		"DependencyViolation",
+		"InvalidDBSubnetGroupStateFault",
+		"InvalidDBClusterStateFault",
+		"InvalidClusterState",
+		"DBSubnetGroupNotFoundFault",
+		"DBParameterGroupNotFound",
+		"InvalidSubnetID.NotFound",
+		"InvalidNetworkInterfaceID.NotFound",
+	}
+	for _, code := range warningCodes {
+		require.True(t, IsWarningError(&smithy.GenericAPIError{Code: code}), code)
+	}
+
+	require.False(t, IsWarningError(&smithy.GenericAPIError{Code: "AccessDenied"}))
+	require.False(t, IsWarningError(errors.New("some error")))
+	require.False(t, IsWarningError(nil))
+}


### PR DESCRIPTION
## Summary
- Transient AWS errors (dependency ordering, already-deleted resources) are now classified as warnings instead of hard failures
- Warning errors don't affect exit code — CI passes when only warnings occur
- JSON output includes `summary.warned` count; CLI tables show a Warned column
- Slack notifications display warned count separately from failures

## Warning error codes

**Ordering/dependency** (resolves on next run):
`DependencyViolation`, `InvalidDBSubnetGroupStateFault`, `InvalidDBClusterStateFault`, `InvalidClusterState`

**Already-deleted** (resource gone between scan and nuke):
`DBSubnetGroupNotFoundFault`, `DBParameterGroupNotFound`, `InvalidSubnetID.NotFound`, `InvalidNetworkInterfaceID.NotFound`

## Test plan
- [x] `go build ./...`
- [x] `go test ./util/... ./resource/... ./renderers/... ./reporting/... ./aws/...`
- [ ] Verify next scheduled nuke run shows `[Warning]` lines and reduced failures