### PR TITLE
feat: add tag filtering for EventBridge Archive and Macie, update docs

### DIFF
--- a/aws/resources/eventbridge_archive.go
+++ b/aws/resources/eventbridge_archive.go
@@ -8,11 +8,14 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/resource"
+	"github.com/gruntwork-io/cloud-nuke/util"
 )
 
 // EventBridgeArchiveAPI defines the interface for EventBridge Archive operations.
 type EventBridgeArchiveAPI interface {
 	ListArchives(ctx context.Context, params *eventbridge.ListArchivesInput, optFns ...func(*eventbridge.Options)) (*eventbridge.ListArchivesOutput, error)
+	DescribeArchive(ctx context.Context, params *eventbridge.DescribeArchiveInput, optFns ...func(*eventbridge.Options)) (*eventbridge.DescribeArchiveOutput, error)
+	ListTagsForResource(ctx context.Context, params *eventbridge.ListTagsForResourceInput, optFns ...func(*eventbridge.Options)) (*eventbridge.ListTagsForResourceOutput, error)
 	DeleteArchive(ctx context.Context, params *eventbridge.DeleteArchiveInput, optFns ...func(*eventbridge.Options)) (*eventbridge.DeleteArchiveOutput, error)
 }
 
@@ -48,9 +51,32 @@ func listEventBridgeArchives(ctx context.Context, client EventBridgeArchiveAPI, 
 		}
 
 		for _, archive := range archives.Archives {
+			describeOutput, err := client.DescribeArchive(ctx, &eventbridge.DescribeArchiveInput{
+				ArchiveName: archive.ArchiveName,
+			})
+			if err != nil {
+				logging.Debugf("[Event Bridge Archives] Failed to describe archive %s: %s", aws.ToString(archive.ArchiveName), err)
+				continue
+			}
+
+			if describeOutput.ArchiveArn == nil {
+				continue
+			}
+
+			tagsOutput, err := client.ListTagsForResource(ctx, &eventbridge.ListTagsForResourceInput{
+				ResourceARN: describeOutput.ArchiveArn,
+			})
+			if err != nil {
+				logging.Debugf("[Event Bridge Archives] Failed to list tags for archive %s: %s", aws.ToString(archive.ArchiveName), err)
+				continue
+			}
+
+			tags := util.ConvertEventBridgeTagsToMap(tagsOutput.Tags)
+
 			if cfg.ShouldInclude(config.ResourceValue{
 				Name: archive.ArchiveName,
 				Time: archive.CreationTime,
+				Tags: tags,
 			}) {
 				identifiers = append(identifiers, archive.ArchiveName)
 			}

--- a/aws/resources/eventbridge_archive_test.go
+++ b/aws/resources/eventbridge_archive_test.go
@@ -17,8 +17,10 @@ import (
 
 type mockedEventBridgeArchiveService struct {
 	EventBridgeArchiveAPI
-	DeleteArchiveOutput eventbridge.DeleteArchiveOutput
-	ListArchivesOutput  eventbridge.ListArchivesOutput
+	DeleteArchiveOutput   eventbridge.DeleteArchiveOutput
+	ListArchivesOutput    eventbridge.ListArchivesOutput
+	DescribeArchiveByName map[string]eventbridge.DescribeArchiveOutput
+	TagsByArn             map[string][]types.Tag
 }
 
 func (m mockedEventBridgeArchiveService) DeleteArchive(ctx context.Context, params *eventbridge.DeleteArchiveInput, optFns ...func(*eventbridge.Options)) (*eventbridge.DeleteArchiveOutput, error) {
@@ -29,12 +31,32 @@ func (m mockedEventBridgeArchiveService) ListArchives(ctx context.Context, param
 	return &m.ListArchivesOutput, nil
 }
 
+func (m mockedEventBridgeArchiveService) DescribeArchive(ctx context.Context, params *eventbridge.DescribeArchiveInput, optFns ...func(*eventbridge.Options)) (*eventbridge.DescribeArchiveOutput, error) {
+	if m.DescribeArchiveByName != nil {
+		if out, ok := m.DescribeArchiveByName[aws.ToString(params.ArchiveName)]; ok {
+			return &out, nil
+		}
+	}
+	return &eventbridge.DescribeArchiveOutput{}, nil
+}
+
+func (m mockedEventBridgeArchiveService) ListTagsForResource(ctx context.Context, params *eventbridge.ListTagsForResourceInput, optFns ...func(*eventbridge.Options)) (*eventbridge.ListTagsForResourceOutput, error) {
+	if m.TagsByArn != nil {
+		if tags, ok := m.TagsByArn[aws.ToString(params.ResourceARN)]; ok {
+			return &eventbridge.ListTagsForResourceOutput{Tags: tags}, nil
+		}
+	}
+	return &eventbridge.ListTagsForResourceOutput{}, nil
+}
+
 func Test_EventBridgeArchive_GetAll(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
 	archive1 := "test-archive-1"
 	archive2 := "test-archive-2"
+	archive1Arn := "arn:aws:events:us-east-1:123456789012:archive/test-archive-1"
+	archive2Arn := "arn:aws:events:us-east-1:123456789012:archive/test-archive-2"
 
 	client := mockedEventBridgeArchiveService{
 		ListArchivesOutput: eventbridge.ListArchivesOutput{
@@ -48,6 +70,14 @@ func Test_EventBridgeArchive_GetAll(t *testing.T) {
 					CreationTime: aws.Time(now.Add(time.Hour)),
 				},
 			},
+		},
+		DescribeArchiveByName: map[string]eventbridge.DescribeArchiveOutput{
+			archive1: {ArchiveArn: aws.String(archive1Arn)},
+			archive2: {ArchiveArn: aws.String(archive2Arn)},
+		},
+		TagsByArn: map[string][]types.Tag{
+			archive1Arn: {{Key: aws.String("env"), Value: aws.String("production")}},
+			archive2Arn: {{Key: aws.String("env"), Value: aws.String("development")}},
 		},
 	}
 
@@ -74,6 +104,15 @@ func Test_EventBridgeArchive_GetAll(t *testing.T) {
 					TimeAfter: aws.Time(now.Add(-1 * time.Hour)),
 				}},
 			expected: []string{},
+		},
+		"tagInclusionFilter": {
+			configObj: config.ResourceType{
+				IncludeRule: config.FilterRule{
+					Tags: map[string]config.Expression{
+						"env": {RE: *regexp.MustCompile("^development$")},
+					},
+				}},
+			expected: []string{archive2},
 		},
 	}
 

--- a/aws/resources/macie.go
+++ b/aws/resources/macie.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -16,6 +17,7 @@ import (
 type MacieMemberAPI interface {
 	GetMacieSession(ctx context.Context, params *macie2.GetMacieSessionInput, optFns ...func(*macie2.Options)) (*macie2.GetMacieSessionOutput, error)
 	ListMembers(ctx context.Context, params *macie2.ListMembersInput, optFns ...func(*macie2.Options)) (*macie2.ListMembersOutput, error)
+	ListTagsForResource(ctx context.Context, params *macie2.ListTagsForResourceInput, optFns ...func(*macie2.Options)) (*macie2.ListTagsForResourceOutput, error)
 	DisassociateMember(ctx context.Context, params *macie2.DisassociateMemberInput, optFns ...func(*macie2.Options)) (*macie2.DisassociateMemberOutput, error)
 	DeleteMember(ctx context.Context, params *macie2.DeleteMemberInput, optFns ...func(*macie2.Options)) (*macie2.DeleteMemberOutput, error)
 	GetAdministratorAccount(ctx context.Context, params *macie2.GetAdministratorAccountInput, optFns ...func(*macie2.Options)) (*macie2.GetAdministratorAccountOutput, error)
@@ -55,8 +57,29 @@ func listMacieSessions(ctx context.Context, client MacieMemberAPI, scope resourc
 		return nil, errors.WithStackTrace(err)
 	}
 
+	// Fetch tags using the ServiceRole ARN to derive the Macie session ARN
+	var tags map[string]string
+	if output.ServiceRole != nil {
+		// ServiceRole ARN format: arn:aws:iam::<account>:role/aws-service-role/macie.amazonaws.com/...
+		// Macie session ARN format: arn:aws:macie2:<region>:<account>:
+		// Extract account ID from the service role ARN
+		parts := strings.Split(aws.ToString(output.ServiceRole), ":")
+		if len(parts) >= 5 {
+			accountID := parts[4]
+			macieArn := fmt.Sprintf("arn:aws:macie2:%s:%s:", scope.Region, accountID)
+			tagsOutput, err := client.ListTagsForResource(ctx, &macie2.ListTagsForResourceInput{
+				ResourceArn: aws.String(macieArn),
+			})
+			if err != nil {
+				logging.Debugf("[Macie] Failed to list tags: %s", err)
+			} else if tagsOutput != nil {
+				tags = tagsOutput.Tags
+			}
+		}
+	}
+
 	// Use status as identifier since Macie doesn't have a unique resource ID
-	if cfg.ShouldInclude(config.ResourceValue{Time: output.CreatedAt}) {
+	if cfg.ShouldInclude(config.ResourceValue{Time: output.CreatedAt, Tags: tags}) {
 		return []*string{aws.String(string(output.Status))}, nil
 	}
 

--- a/aws/resources/macie_test.go
+++ b/aws/resources/macie_test.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"regexp"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ type mockMacieClient struct {
 	GetMacieSessionOutput                      macie2.GetMacieSessionOutput
 	GetMacieSessionError                       error
 	ListMembersOutput                          macie2.ListMembersOutput
+	ListTagsForResourceOutput                  macie2.ListTagsForResourceOutput
 	DisassociateMemberOutput                   macie2.DisassociateMemberOutput
 	DeleteMemberOutput                         macie2.DeleteMemberOutput
 	GetAdministratorAccountOutput              macie2.GetAdministratorAccountOutput
@@ -33,6 +35,10 @@ func (m *mockMacieClient) GetMacieSession(ctx context.Context, params *macie2.Ge
 
 func (m *mockMacieClient) ListMembers(ctx context.Context, params *macie2.ListMembersInput, optFns ...func(*macie2.Options)) (*macie2.ListMembersOutput, error) {
 	return &m.ListMembersOutput, nil
+}
+
+func (m *mockMacieClient) ListTagsForResource(ctx context.Context, params *macie2.ListTagsForResourceInput, optFns ...func(*macie2.Options)) (*macie2.ListTagsForResourceOutput, error) {
+	return &m.ListTagsForResourceOutput, nil
 }
 
 func (m *mockMacieClient) DisassociateMember(ctx context.Context, params *macie2.DisassociateMemberInput, optFns ...func(*macie2.Options)) (*macie2.DisassociateMemberOutput, error) {
@@ -69,8 +75,9 @@ func TestListMacieSessions(t *testing.T) {
 		"enabled session - no filter": {
 			mock: &mockMacieClient{
 				GetMacieSessionOutput: macie2.GetMacieSessionOutput{
-					Status:    types.MacieStatusEnabled,
-					CreatedAt: aws.Time(now),
+					Status:      types.MacieStatusEnabled,
+					CreatedAt:   aws.Time(now),
+					ServiceRole: aws.String("arn:aws:iam::123456789012:role/aws-service-role/macie.amazonaws.com/AWSServiceRoleForAmazonMacie"),
 				},
 			},
 			configObj: config.ResourceType{},
@@ -174,15 +181,56 @@ func TestListMacieSessions_TimeInclusionFilter(t *testing.T) {
 
 	mock := &mockMacieClient{
 		GetMacieSessionOutput: macie2.GetMacieSessionOutput{
-			Status:    types.MacieStatusEnabled,
-			CreatedAt: aws.Time(now),
+			Status:      types.MacieStatusEnabled,
+			CreatedAt:   aws.Time(now),
+			ServiceRole: aws.String("arn:aws:iam::123456789012:role/aws-service-role/macie.amazonaws.com/AWSServiceRoleForAmazonMacie"),
 		},
 	}
 
 	// Test that time inclusion works - include sessions created before now+1h
-	results, err := listMacieSessions(context.Background(), mock, resource.Scope{}, config.ResourceType{
+	results, err := listMacieSessions(context.Background(), mock, resource.Scope{Region: "us-east-1"}, config.ResourceType{
 		IncludeRule: config.FilterRule{
 			TimeBefore: aws.Time(now.Add(1 * time.Hour)),
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, "ENABLED", aws.ToString(results[0]))
+}
+
+func TestListMacieSessions_TagInclusionFilter(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	mock := &mockMacieClient{
+		GetMacieSessionOutput: macie2.GetMacieSessionOutput{
+			Status:      types.MacieStatusEnabled,
+			CreatedAt:   aws.Time(now),
+			ServiceRole: aws.String("arn:aws:iam::123456789012:role/aws-service-role/macie.amazonaws.com/AWSServiceRoleForAmazonMacie"),
+		},
+		ListTagsForResourceOutput: macie2.ListTagsForResourceOutput{
+			Tags: map[string]string{"env": "production"},
+		},
+	}
+
+	// Should be excluded when include filter requires "development"
+	results, err := listMacieSessions(context.Background(), mock, resource.Scope{Region: "us-east-1"}, config.ResourceType{
+		IncludeRule: config.FilterRule{
+			Tags: map[string]config.Expression{
+				"env": {RE: *regexp.MustCompile("^development$")},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, results)
+
+	// Should be included when include filter matches
+	results, err = listMacieSessions(context.Background(), mock, resource.Scope{Region: "us-east-1"}, config.ResourceType{
+		IncludeRule: config.FilterRule{
+			Tags: map[string]config.Expression{
+				"env": {RE: *regexp.MustCompile("^production$")},
+			},
 		},
 	})
 	require.NoError(t, err)

--- a/docs/supported-resources.md
+++ b/docs/supported-resources.md
@@ -147,60 +147,60 @@ This table shows which filtering features are supported for each resource type i
 
 | Resource Type | Config Key | names_regex | time | tags | timeout |
 |---|---|---|---|---|---|
-| access-analyzer | AccessAnalyzer | ✓ | ✓ | | ✓ |
-| acm | ACM | ✓ | ✓ | | ✓ |
-| acmpca | ACMPCA | | ✓ | | ✓ |
+| access-analyzer | AccessAnalyzer | ✓ | ✓ | ✓ | ✓ |
+| acm | ACM | ✓ | ✓ | ✓ | ✓ |
+| acmpca | ACMPCA | | ✓ | ✓ | ✓ |
 | ami | AMI | ✓ | ✓ | ✓ | ✓ |
 | api-gateway | APIGateway | ✓ | ✓ | ✓ | ✓ |
 | api-gateway-v2 | APIGatewayV2 | ✓ | ✓ | ✓ | ✓ |
-| app-runner-service | AppRunnerService | ✓ | ✓ | | ✓ |
+| app-runner-service | AppRunnerService | ✓ | ✓ | ✓ | ✓ |
 | asg | AutoScalingGroup | ✓ | ✓ | ✓ | ✓ |
 | backup-vault | BackupVault | ✓ | ✓ | ✓ | ✓ |
 | cloudformation-stack | CloudFormationStack | ✓ | ✓ | ✓ | ✓ |
-| cloudfront-distribution | CloudFrontDistribution | ✓ | | | ✓ |
+| cloudfront-distribution | CloudFrontDistribution | ✓ | | ✓ | ✓ |
 | cloudmap-namespace | CloudMapNamespace | ✓ | ✓ | ✓ | ✓ |
 | cloudmap-service | CloudMapService | ✓ | ✓ | ✓ | ✓ |
 | cloudtrail | CloudTrailTrail | ✓ | | ✓ | ✓ |
-| cloudwatch-alarm | CloudWatchAlarm | ✓ | ✓ | | ✓ |
+| cloudwatch-alarm | CloudWatchAlarm | ✓ | ✓ | ✓ | ✓ |
 | cloudwatch-dashboard | CloudWatchDashboard | ✓ | ✓ | | ✓ |
-| cloudwatch-loggroup | CloudWatchLogGroup | ✓ | ✓ | | ✓ |
-| codedeploy-application | CodeDeployApplications | ✓ | ✓ | | ✓ |
+| cloudwatch-loggroup | CloudWatchLogGroup | ✓ | ✓ | ✓ | ✓ |
+| codedeploy-application | CodeDeployApplications | ✓ | ✓ | ✓ | ✓ |
 | config-recorders | ConfigServiceRecorder | ✓ | | | ✓ |
-| config-rules | ConfigServiceRule | ✓ | | | ✓ |
-| data-pipeline | DataPipeline | ✓ | ✓ | | ✓ |
-| data-sync-location | DataSyncLocation | ✓ | | | ✓ |
-| data-sync-task | DataSyncTask | ✓ | | | ✓ |
-| dynamodb | DynamoDB | ✓ | ✓ | | ✓ |
+| config-rules | ConfigServiceRule | ✓ | | ✓ | ✓ |
+| data-pipeline | DataPipeline | ✓ | ✓ | ✓ | ✓ |
+| data-sync-location | DataSyncLocation | ✓ | | ✓ | ✓ |
+| data-sync-task | DataSyncTask | ✓ | | ✓ | ✓ |
+| dynamodb | DynamoDB | ✓ | ✓ | ✓ | ✓ |
 | ebs | EBSVolume | ✓ | ✓ | ✓ | ✓ |
 | ebs-snapshot | Snapshots | | ✓ | ✓ | ✓ |
 | ec2 | EC2 | ✓ | ✓ | ✓ | ✓ |
-| ec2-dedicated-hosts | EC2DedicatedHosts | ✓ | ✓ | | ✓ |
-| ec2-dhcp-option | EC2DHCPOption | | | | ✓ |
+| ec2-dedicated-hosts | EC2DedicatedHosts | ✓ | ✓ | ✓ | ✓ |
+| ec2-dhcp-option | EC2DHCPOption | | | ✓ | ✓ |
 | ec2-endpoint | EC2Endpoint | ✓ | ✓ | ✓ | ✓ |
 | ec2-keypairs | EC2KeyPairs | ✓ | ✓ | ✓ | ✓ |
 | ec2-placement-groups | EC2PlacementGroups | ✓ | ✓ | ✓ | ✓ |
 | ec2-subnet | EC2Subnet | ✓ | ✓ | ✓ | |
-| ecr | ECRRepository | ✓ | ✓ | | ✓ |
+| ecr | ECRRepository | ✓ | ✓ | ✓ | ✓ |
 | ecs-cluster | ECSCluster | ✓ | ✓ | ✓ | ✓ |
 | ecs-service | ECSService | ✓ | ✓ | ✓ | ✓ |
-| efs | ElasticFileSystem | ✓ | ✓ | | ✓ |
+| efs | ElasticFileSystem | ✓ | ✓ | ✓ | ✓ |
 | egress-only-internet-gateway | EgressOnlyInternetGateway | ✓ | | ✓ | ✓ |
 | eip | ElasticIP | ✓ | ✓ | ✓ | ✓ |
 | eks-cluster | EKSCluster | ✓ | ✓ | ✓ | ✓ |
-| elastic-beanstalk | ElasticBeanstalk | ✓ | ✓ | | ✓ |
-| elasticache | ElastiCache | ✓ | ✓ | | ✓ |
-| elasticache-parameter-group | ElastiCacheParameterGroup | ✓ | | | ✓ |
-| elasticache-serverless | ElastiCacheServerless | ✓ | ✓ | | ✓ |
-| elasticache-subnet-group | ElastiCacheSubnetGroup | ✓ | | | ✓ |
-| elb | ELBv1 | ✓ | ✓ | | ✓ |
-| elbv2 | ELBv2 | ✓ | ✓ | | ✓ |
-| event-bridge | EventBridge | ✓ | ✓ | | ✓ |
-| event-bridge-archive | EventBridgeArchive | ✓ | ✓ | | ✓ |
-| event-bridge-rule | EventBridgeRule | ✓ | | | ✓ |
-| event-bridge-schedule | EventBridgeSchedule | ✓ | ✓ | | ✓ |
-| event-bridge-schedule-group | EventBridgeScheduleGroup | ✓ | ✓ | | ✓ |
+| elastic-beanstalk | ElasticBeanstalk | ✓ | ✓ | ✓ | ✓ |
+| elasticache | ElastiCache | ✓ | ✓ | ✓ | ✓ |
+| elasticache-parameter-group | ElastiCacheParameterGroup | ✓ | | ✓ | ✓ |
+| elasticache-serverless | ElastiCacheServerless | ✓ | ✓ | ✓ | ✓ |
+| elasticache-subnet-group | ElastiCacheSubnetGroup | ✓ | | ✓ | ✓ |
+| elb | ELBv1 | ✓ | ✓ | ✓ | ✓ |
+| elbv2 | ELBv2 | ✓ | ✓ | ✓ | ✓ |
+| event-bridge | EventBridge | ✓ | ✓ | ✓ | ✓ |
+| event-bridge-archive | EventBridgeArchive | ✓ | ✓ | ✓ | ✓ |
+| event-bridge-rule | EventBridgeRule | ✓ | | ✓ | ✓ |
+| event-bridge-schedule | EventBridgeSchedule | ✓ | ✓ | ✓ | ✓ |
+| event-bridge-schedule-group | EventBridgeScheduleGroup | ✓ | ✓ | ✓ | ✓ |
 | grafana | Grafana | ✓ | ✓ | ✓ | ✓ |
-| guard-duty | GuardDuty | | ✓ | | ✓ |
+| guard-duty | GuardDuty | | ✓ | ✓ | ✓ |
 | iam-group | IAMGroups | ✓ | ✓ | | ✓ |
 | iam-instance-profile | IAMInstanceProfiles | ✓ | ✓ | ✓ | ✓ |
 | iam-policy | IAMPolicies | ✓ | ✓ | ✓ | ✓ |
@@ -214,17 +214,17 @@ This table shows which filtering features are supported for each resource type i
 | ipam-pool | EC2IPAMPool | ✓ | ✓ | ✓ | ✓ |
 | ipam-resource-discovery | EC2IPAMResourceDiscovery | ✓ | ✓ | ✓ | ✓ |
 | ipam-scope | EC2IPAMScope | ✓ | ✓ | ✓ | ✓ |
-| kinesis-firehose | KinesisFirehose | ✓ | | | ✓ |
-| kinesis-stream | KinesisStream | ✓ | | | ✓ |
-| kms-customer-key | KMSCustomerKeys | ✓ | ✓ | | |
+| kinesis-firehose | KinesisFirehose | ✓ | | ✓ | ✓ |
+| kinesis-stream | KinesisStream | ✓ | | ✓ | ✓ |
+| kms-customer-key | KMSCustomerKeys | ✓ | ✓ | ✓ | |
 | lambda | LambdaFunction | ✓ | ✓ | ✓ | ✓ |
-| lambda-layer | LambdaLayer | ✓ | ✓ | | ✓ |
+| lambda-layer | LambdaLayer | ✓ | ✓ | ✓ | ✓ |
 | launch-configuration | LaunchConfiguration | ✓ | ✓ | | ✓ |
 | launch-template | LaunchTemplate | ✓ | ✓ | ✓ | ✓ |
-| macie-member | MacieMember | | ✓ | | ✓ |
+| macie-member | MacieMember | | ✓ | ✓ | ✓ |
 | managed-prometheus | ManagedPrometheus | ✓ | ✓ | ✓ | ✓ |
 | mq-broker | MQBroker | ✓ | ✓ | ✓ | ✓ |
-| msk-cluster | MSKCluster | ✓ | ✓ | | ✓ |
+| msk-cluster | MSKCluster | ✓ | ✓ | ✓ | ✓ |
 | nat-gateway | NATGateway | ✓ | ✓ | ✓ | ✓ |
 | network-acl | NetworkACL | ✓ | ✓ | ✓ | ✓ |
 | network-firewall | NetworkFirewall | ✓ | ✓ | ✓ | |
@@ -234,18 +234,18 @@ This table shows which filtering features are supported for each resource type i
 | network-firewall-tls-config | NetworkFirewallTLSConfig | ✓ | ✓ | ✓ | |
 | network-interface | NetworkInterface | ✓ | ✓ | ✓ | ✓ |
 | oidc-provider | OIDCProvider | ✓ | ✓ | ✓ | ✓ |
-| opensearch-domain | OpenSearchDomain | ✓ | ✓ | | ✓ |
+| opensearch-domain | OpenSearchDomain | ✓ | ✓ | ✓ | ✓ |
 | rds-cluster | DBClusters | ✓ | ✓ | ✓ | ✓ |
-| rds-global-cluster | DBGlobalClusters | ✓ | | | ✓ |
-| rds-global-cluster-membership | DBGlobalClusterMemberships | ✓ | | | ✓ |
+| rds-global-cluster | DBGlobalClusters | ✓ | | ✓ | ✓ |
+| rds-global-cluster-membership | DBGlobalClusterMemberships | ✓ | | ✓ | ✓ |
 | rds-instance | DBInstances | ✓ | ✓ | ✓ | ✓ |
-| rds-parameter-group | RDSParameterGroup | ✓ | | | ✓ |
-| rds-proxy | RDSProxy | ✓ | ✓ | | ✓ |
+| rds-parameter-group | RDSParameterGroup | ✓ | | ✓ | ✓ |
+| rds-proxy | RDSProxy | ✓ | ✓ | ✓ | ✓ |
 | rds-cluster-snapshot | RDSClusterSnapshot | ✓ | ✓ | ✓ | ✓ |
 | rds-snapshot | RDSSnapshot | ✓ | ✓ | ✓ | ✓ |
 | rds-subnet-group | DBSubnetGroups | ✓ | | ✓ | ✓ |
-| redshift | Redshift | ✓ | ✓ | | ✓ |
-| redshift-snapshot-copy-grant | RedshiftSnapshotCopyGrant | ✓ | | | ✓ |
+| redshift | Redshift | ✓ | ✓ | ✓ | ✓ |
+| redshift-snapshot-copy-grant | RedshiftSnapshotCopyGrant | ✓ | | ✓ | ✓ |
 | resource-share | ResourceShare | ✓ | ✓ | ✓ | ✓ |
 | route-table | RouteTable | ✓ | ✓ | ✓ | ✓ |
 | route53-cidr-collection | Route53CIDRCollection | ✓ | | | |
@@ -257,27 +257,27 @@ This table shows which filtering features are supported for each resource type i
 | s3-object-lambda-access-point | S3ObjectLambdaAccessPoint | ✓ | | | ✓ |
 | sagemaker-endpoint | SageMakerEndpoint | ✓ | ✓ | ✓ | ✓ |
 | sagemaker-endpoint-config | SageMakerEndpointConfig | ✓ | ✓ | ✓ | ✓ |
-| sagemaker-notebook-instance | SageMakerNotebook | ✓ | ✓ | | ✓ |
-| sagemaker-studio | SageMakerStudioDomain | ✓ | ✓ | | ✓ |
+| sagemaker-notebook-instance | SageMakerNotebook | ✓ | ✓ | ✓ | ✓ |
+| sagemaker-studio | SageMakerStudioDomain | ✓ | ✓ | ✓ | ✓ |
 | secrets-manager | SecretsManager | ✓ | ✓ | ✓ | ✓ |
 | security-group | SecurityGroup | ✓ | ✓ | ✓ | |
-| security-hub | SecurityHub | | ✓ | | ✓ |
+| security-hub | SecurityHub | | ✓ | ✓ | ✓ |
 | ses-configuration-set | SESConfigurationSet | ✓ | | | ✓ |
 | ses-email-template | SESEmailTemplates | ✓ | ✓ | | ✓ |
 | ses-identity | SESIdentity | ✓ | | | ✓ |
 | ses-receipt-filter | SESReceiptFilter | ✓ | | | ✓ |
 | ses-receipt-rule-set | SESReceiptRuleSet | ✓ | ✓ | | ✓ |
-| sns-topic | SNS | ✓ | ✓ | | ✓ |
-| sqs | SQS | ✓ | ✓ | | ✓ |
+| sns-topic | SNS | ✓ | ✓ | ✓ | ✓ |
+| sqs | SQS | ✓ | ✓ | ✓ | ✓ |
 | ssm-parameter | SSMParameter | ✓ | ✓ | ✓ | ✓ |
-| transit-gateway | TransitGateway | ✓ | ✓ | | ✓ |
-| transit-gateway-attachment | TransitGatewayVPCAttachment | | ✓ | | ✓ |
-| transit-gateway-peering-attachment | TransitGatewayPeeringAttachment | | ✓ | | ✓ |
-| transit-gateway-route-table | TransitGatewayRouteTable | | ✓ | | ✓ |
+| transit-gateway | TransitGateway | ✓ | ✓ | ✓ | ✓ |
+| transit-gateway-attachment | TransitGatewayVPCAttachment | | ✓ | ✓ | ✓ |
+| transit-gateway-peering-attachment | TransitGatewayPeeringAttachment | | ✓ | ✓ | ✓ |
+| transit-gateway-route-table | TransitGatewayRouteTable | | ✓ | ✓ | ✓ |
 | vpc | VPC | ✓ | ✓ | ✓ | |
-| vpc-lattice-service | VPCLatticeService | ✓ | ✓ | | ✓ |
-| vpc-lattice-service-network | VPCLatticeServiceNetwork | ✓ | ✓ | | ✓ |
-| vpc-lattice-target-group | VPCLatticeTargetGroup | ✓ | ✓ | | ✓ |
+| vpc-lattice-service | VPCLatticeService | ✓ | ✓ | ✓ | ✓ |
+| vpc-lattice-service-network | VPCLatticeServiceNetwork | ✓ | ✓ | ✓ | ✓ |
+| vpc-lattice-target-group | VPCLatticeTargetGroup | ✓ | ✓ | ✓ | ✓ |
 | vpc-peering-connection | VPCPeeringConnection | ✓ | ✓ | ✓ | ✓ |
 
 ## GCP Supported Resources

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 go = "1.25.0"
-golangci-lint = "2.1.6"
+golangci-lint = "2.11.4"

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-go = "1.24.0"
+go = "1.25.0"
 golangci-lint = "2.1.6"


### PR DESCRIPTION
## Summary
- Add tag filtering support for `event-bridge-archive` (via DescribeArchive + ListTagsForResource) and `macie-member` (via ListTagsForResource)
- Update `docs/supported-resources.md` to mark 55 resources with tag support that were missing the ✓ in the tags column

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Unit tests pass for both resources: `go test ./aws/resources/ -run "TestListMacieSessions|Test_EventBridgeArchive" -v`