### PR TITLE
chore: reduce PhxDevOps nuke cadence to daily

### DIFF
--- a/.github/workflows/nuke-phxdevops.yml
+++ b/.github/workflows/nuke-phxdevops.yml
@@ -2,7 +2,7 @@ name: "Nuke: PhxDevOps"
 
 on:
   schedule:
-    - cron: '0 */3 * * *'  # Every 3 hours
+    - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:
 
 permissions:
@@ -15,5 +15,5 @@ jobs:
     with:
       account_name: PhxDevOps
       role_arn: arn:aws:iam::087285199408:role/cloud-nuke-gha
-      older_than: 2h
+      older_than: 24h
     secrets: inherit


### PR DESCRIPTION
## Summary
- Change PhxDevOps nuke schedule from every 3 hours to daily (midnight UTC)
- Update `older_than` from 2h to 24h to match the new cadence

Per-repo cleanup via CircleCI handles most residual resources hourly. The account-wide nuke from this repo serves as a final guardrail for untagged/missed resources and doesn't need to run 8x/day.