### PR TITLE
fix: scope ipam-custom-allocation state per instance

### DIFF
--- a/aws/resources/ec2_ipam_custom_allocation.go
+++ b/aws/resources/ec2_ipam_custom_allocation.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -20,47 +19,43 @@ type EC2IPAMCustomAllocationAPI interface {
 	ReleaseIpamPoolAllocation(ctx context.Context, params *ec2.ReleaseIpamPoolAllocationInput, optFns ...func(*ec2.Options)) (*ec2.ReleaseIpamPoolAllocationOutput, error)
 }
 
-// ipamCustomAllocationState holds runtime state needed for custom allocation operations.
-// This is stored alongside the Resource to track pool-allocation mappings during listing and deletion.
-type ipamCustomAllocationState struct {
-	mu                   sync.RWMutex
-	poolAndAllocationMap map[string]allocationInfo
-}
-
 type allocationInfo struct {
 	PoolID string
 	Cidr   string
 }
 
-var customAllocationState = &ipamCustomAllocationState{
-	poolAndAllocationMap: make(map[string]allocationInfo),
-}
-
 // NewEC2IPAMCustomAllocation creates a new EC2 IPAM Custom Allocation resource using the generic resource pattern.
+// Pool+CIDR metadata discovered during listing is required again at deletion time (ReleaseIpamPoolAllocation needs
+// both), so it is stashed in a per-instance map captured by closure. Per-instance scoping matters because
+// GetAndInitRegisteredResources creates a fresh instance for each region — sharing one map across regions would
+// let later regions' Init calls overwrite earlier regions' metadata and break deletion.
 func NewEC2IPAMCustomAllocation() AwsResource {
+	poolAndAllocationMap := make(map[string]allocationInfo)
+
 	return NewAwsResource(&resource.Resource[EC2IPAMCustomAllocationAPI]{
 		ResourceTypeName: "ipam-custom-allocation",
 		BatchSize:        1000,
 		InitClient: WrapAwsInitClient(func(r *resource.Resource[EC2IPAMCustomAllocationAPI], cfg aws.Config) {
 			r.Scope.Region = cfg.Region
 			r.Client = ec2.NewFromConfig(cfg)
-			// Reset state on init
-			customAllocationState.mu.Lock()
-			customAllocationState.poolAndAllocationMap = make(map[string]allocationInfo)
-			customAllocationState.mu.Unlock()
 		}),
 		ConfigGetter: func(c config.Config) config.ResourceType {
 			return c.EC2IPAMCustomAllocation
 		},
-		Lister:             listEC2IPAMCustomAllocations,
-		Nuker:              resource.SimpleBatchDeleter(deleteEC2IPAMCustomAllocation),
-		PermissionVerifier: verifyEC2IPAMCustomAllocationPermission,
+		Lister: func(ctx context.Context, client EC2IPAMCustomAllocationAPI, scope resource.Scope, cfg config.ResourceType) ([]*string, error) {
+			return listEC2IPAMCustomAllocations(ctx, client, poolAndAllocationMap)
+		},
+		Nuker: resource.SimpleBatchDeleter(func(ctx context.Context, client EC2IPAMCustomAllocationAPI, id *string) error {
+			return deleteEC2IPAMCustomAllocation(ctx, client, id, poolAndAllocationMap)
+		}),
+		PermissionVerifier: func(ctx context.Context, client EC2IPAMCustomAllocationAPI, id *string) error {
+			return verifyEC2IPAMCustomAllocationPermission(ctx, client, id, poolAndAllocationMap)
+		},
 	})
 }
 
 // listEC2IPAMCustomAllocations retrieves all custom allocations across all IPAM pools.
-func listEC2IPAMCustomAllocations(ctx context.Context, client EC2IPAMCustomAllocationAPI, scope resource.Scope, cfg config.ResourceType) ([]*string, error) {
-	// First, get all pools
+func listEC2IPAMCustomAllocations(ctx context.Context, client EC2IPAMCustomAllocationAPI, poolAndAllocationMap map[string]allocationInfo) ([]*string, error) {
 	pools, err := getPools(ctx, client)
 	if err != nil {
 		return nil, err
@@ -68,7 +63,6 @@ func listEC2IPAMCustomAllocations(ctx context.Context, client EC2IPAMCustomAlloc
 
 	var result []*string
 
-	// For each pool, get all custom allocations
 	for _, poolID := range pools {
 		paginator := ec2.NewGetIpamPoolAllocationsPaginator(client, &ec2.GetIpamPoolAllocationsInput{
 			MaxResults: aws.Int32(1000),
@@ -85,13 +79,10 @@ func listEC2IPAMCustomAllocations(ctx context.Context, client EC2IPAMCustomAlloc
 			for _, allocation := range page.IpamPoolAllocations {
 				if allocation.ResourceType == types.IpamPoolAllocationResourceTypeCustom {
 					result = append(result, allocation.IpamPoolAllocationId)
-					// Store pool and CIDR info for later use during deletion
-					customAllocationState.mu.Lock()
-					customAllocationState.poolAndAllocationMap[aws.ToString(allocation.IpamPoolAllocationId)] = allocationInfo{
+					poolAndAllocationMap[aws.ToString(allocation.IpamPoolAllocationId)] = allocationInfo{
 						PoolID: aws.ToString(poolID),
 						Cidr:   aws.ToString(allocation.Cidr),
 					}
-					customAllocationState.mu.Unlock()
 				}
 			}
 		}
@@ -123,11 +114,8 @@ func getPools(ctx context.Context, client EC2IPAMCustomAllocationAPI) ([]*string
 }
 
 // verifyEC2IPAMCustomAllocationPermission performs a dry-run release to check permissions.
-func verifyEC2IPAMCustomAllocationPermission(ctx context.Context, client EC2IPAMCustomAllocationAPI, id *string) error {
-	customAllocationState.mu.RLock()
-	info, ok := customAllocationState.poolAndAllocationMap[aws.ToString(id)]
-	customAllocationState.mu.RUnlock()
-
+func verifyEC2IPAMCustomAllocationPermission(ctx context.Context, client EC2IPAMCustomAllocationAPI, id *string, poolAndAllocationMap map[string]allocationInfo) error {
+	info, ok := poolAndAllocationMap[aws.ToString(id)]
 	if !ok {
 		return fmt.Errorf("unable to find pool allocation info for %s", aws.ToString(id))
 	}
@@ -142,11 +130,8 @@ func verifyEC2IPAMCustomAllocationPermission(ctx context.Context, client EC2IPAM
 }
 
 // deleteEC2IPAMCustomAllocation releases a single custom allocation.
-func deleteEC2IPAMCustomAllocation(ctx context.Context, client EC2IPAMCustomAllocationAPI, id *string) error {
-	customAllocationState.mu.RLock()
-	info, ok := customAllocationState.poolAndAllocationMap[aws.ToString(id)]
-	customAllocationState.mu.RUnlock()
-
+func deleteEC2IPAMCustomAllocation(ctx context.Context, client EC2IPAMCustomAllocationAPI, id *string, poolAndAllocationMap map[string]allocationInfo) error {
+	info, ok := poolAndAllocationMap[aws.ToString(id)]
 	if !ok {
 		return fmt.Errorf("unable to find pool allocation info for %s", aws.ToString(id))
 	}

--- a/aws/resources/ec2_ipam_custom_allocation_test.go
+++ b/aws/resources/ec2_ipam_custom_allocation_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/gruntwork-io/cloud-nuke/config"
-	"github.com/gruntwork-io/cloud-nuke/resource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,21 +57,13 @@ func TestListEC2IPAMCustomAllocations(t *testing.T) {
 		},
 	}
 
-	// Reset global state before test
-	customAllocationState.mu.Lock()
-	customAllocationState.poolAndAllocationMap = make(map[string]allocationInfo)
-	customAllocationState.mu.Unlock()
-
-	ids, err := listEC2IPAMCustomAllocations(context.Background(), mock, resource.Scope{}, config.ResourceType{})
+	poolAndAllocationMap := make(map[string]allocationInfo)
+	ids, err := listEC2IPAMCustomAllocations(context.Background(), mock, poolAndAllocationMap)
 	require.NoError(t, err)
 	require.Equal(t, []string{testId1, testId2}, aws.ToStringSlice(ids))
 
-	// Verify state was stored
-	customAllocationState.mu.RLock()
-	info1, ok1 := customAllocationState.poolAndAllocationMap[testId1]
-	info2, ok2 := customAllocationState.poolAndAllocationMap[testId2]
-	customAllocationState.mu.RUnlock()
-
+	info1, ok1 := poolAndAllocationMap[testId1]
+	info2, ok2 := poolAndAllocationMap[testId2]
 	require.True(t, ok1)
 	require.True(t, ok2)
 	require.Equal(t, testPool1, info1.PoolID)
@@ -89,15 +79,68 @@ func TestDeleteEC2IPAMCustomAllocation(t *testing.T) {
 	testPool := "ipam-pool-test"
 	testCidr := "10.0.0.0/24"
 
-	// Set up state before test
-	customAllocationState.mu.Lock()
-	customAllocationState.poolAndAllocationMap[testId] = allocationInfo{
-		PoolID: testPool,
-		Cidr:   testCidr,
+	poolAndAllocationMap := map[string]allocationInfo{
+		testId: {PoolID: testPool, Cidr: testCidr},
 	}
-	customAllocationState.mu.Unlock()
 
 	mock := &mockEC2IPAMCustomAllocationClient{}
-	err := deleteEC2IPAMCustomAllocation(context.Background(), mock, aws.String(testId))
+	err := deleteEC2IPAMCustomAllocation(context.Background(), mock, aws.String(testId), poolAndAllocationMap)
 	require.NoError(t, err)
+}
+
+// TestEC2IPAMCustomAllocationInstancesAreIsolated exercises the multi-region scenario that regressed
+// in v0.49.0: an allocation discovered in one instance must remain resolvable after a second instance
+// is constructed and initialized. A shared package-level map (the pre-fix design) fails this test;
+// per-instance closure state passes it.
+func TestEC2IPAMCustomAllocationInstancesAreIsolated(t *testing.T) {
+	t.Parallel()
+
+	regionAId := "ipam-pool-alloc-region-a"
+	regionAPool := "ipam-pool-region-a"
+	regionBId := "ipam-pool-alloc-region-b"
+	regionBPool := "ipam-pool-region-b"
+
+	mapA := make(map[string]allocationInfo)
+	mapB := make(map[string]allocationInfo)
+
+	_, err := listEC2IPAMCustomAllocations(context.Background(), &mockEC2IPAMCustomAllocationClient{
+		DescribeIpamPoolsOutput: ec2.DescribeIpamPoolsOutput{
+			IpamPools: []types.IpamPool{{IpamPoolId: aws.String(regionAPool)}},
+		},
+		GetIpamPoolAllocationsOutput: ec2.GetIpamPoolAllocationsOutput{
+			IpamPoolAllocations: []types.IpamPoolAllocation{{
+				Cidr:                 aws.String("10.1.0.0/24"),
+				IpamPoolAllocationId: aws.String(regionAId),
+				ResourceType:         types.IpamPoolAllocationResourceTypeCustom,
+			}},
+		},
+	}, mapA)
+	require.NoError(t, err)
+
+	_, err = listEC2IPAMCustomAllocations(context.Background(), &mockEC2IPAMCustomAllocationClient{
+		DescribeIpamPoolsOutput: ec2.DescribeIpamPoolsOutput{
+			IpamPools: []types.IpamPool{{IpamPoolId: aws.String(regionBPool)}},
+		},
+		GetIpamPoolAllocationsOutput: ec2.GetIpamPoolAllocationsOutput{
+			IpamPoolAllocations: []types.IpamPoolAllocation{{
+				Cidr:                 aws.String("10.2.0.0/24"),
+				IpamPoolAllocationId: aws.String(regionBId),
+				ResourceType:         types.IpamPoolAllocationResourceTypeCustom,
+			}},
+		},
+	}, mapB)
+	require.NoError(t, err)
+
+	infoA, okA := mapA[regionAId]
+	require.True(t, okA, "region A's allocation metadata should survive region B's listing")
+	require.Equal(t, regionAPool, infoA.PoolID)
+
+	infoB, okB := mapB[regionBId]
+	require.True(t, okB)
+	require.Equal(t, regionBPool, infoB.PoolID)
+
+	_, crossA := mapA[regionBId]
+	_, crossB := mapB[regionAId]
+	require.False(t, crossA, "region A's map should not see region B's allocation")
+	require.False(t, crossB, "region B's map should not see region A's allocation")
 }


### PR DESCRIPTION
## Summary

Fixes `unable to find pool allocation info for <id>` failures during `ipam-custom-allocation` deletion in multi-region runs. Regression from #992 (v0.49.0).

## Root cause

The pool+CIDR metadata captured by the lister (needed again by `ReleaseIpamPoolAllocation`) lived in a package-level global (`customAllocationState`) and was re-initialized to an empty map on every `InitClient` call. `GetAndInitRegisteredResources` constructs a fresh instance per region, so each region's init wiped the map — leaving earlier regions' allocations unresolvable at deletion time. Pre-#992, the map was a struct field on the per-region instance and naturally isolated.

## Fix

Move the map into `NewEC2IPAMCustomAllocation` as closure-captured per-instance state. Each region's instance now owns its own map. Drops the now-vestigial `sync.RWMutex`.

## Test plan

- [x] `go test ./aws/resources/ -run EC2IPAMCustomAllocation` — existing tests updated for new signatures
- [x] New `TestEC2IPAMCustomAllocationInstancesAreIsolated` exercises the two-region case and fails against the pre-fix design
- [x] `go build ./...` / `go vet ./...` clean
- [x] Verify against a real account with an existing custom allocation across regions