### PR TITLE
fix: deregister ECS container instances before cluster deletion

### DIFF
--- a/aws/resources/ecs_cluster.go
+++ b/aws/resources/ecs_cluster.go
@@ -18,7 +18,9 @@ import (
 type ECSClustersAPI interface {
 	DescribeClusters(ctx context.Context, params *ecs.DescribeClustersInput, optFns ...func(*ecs.Options)) (*ecs.DescribeClustersOutput, error)
 	DeleteCluster(ctx context.Context, params *ecs.DeleteClusterInput, optFns ...func(*ecs.Options)) (*ecs.DeleteClusterOutput, error)
+	DeregisterContainerInstance(ctx context.Context, params *ecs.DeregisterContainerInstanceInput, optFns ...func(*ecs.Options)) (*ecs.DeregisterContainerInstanceOutput, error)
 	ListClusters(ctx context.Context, params *ecs.ListClustersInput, optFns ...func(*ecs.Options)) (*ecs.ListClustersOutput, error)
+	ListContainerInstances(ctx context.Context, params *ecs.ListContainerInstancesInput, optFns ...func(*ecs.Options)) (*ecs.ListContainerInstancesOutput, error)
 	ListTagsForResource(ctx context.Context, params *ecs.ListTagsForResourceInput, optFns ...func(*ecs.Options)) (*ecs.ListTagsForResourceOutput, error)
 	ListTasks(ctx context.Context, params *ecs.ListTasksInput, optFns ...func(*ecs.Options)) (*ecs.ListTasksOutput, error)
 	StopTask(ctx context.Context, params *ecs.StopTaskInput, optFns ...func(*ecs.Options)) (*ecs.StopTaskOutput, error)
@@ -46,7 +48,7 @@ func NewECSClusters() AwsResource {
 			return c.ECSCluster
 		},
 		Lister: listECSClusters,
-		Nuker:  resource.MultiStepDeleter(stopClusterRunningTasks, deleteECSCluster),
+		Nuker:  resource.MultiStepDeleter(stopClusterRunningTasks, deregisterClusterContainerInstances, deleteECSCluster),
 	})
 }
 
@@ -238,6 +240,36 @@ func stopClusterRunningTasks(ctx context.Context, client ECSClustersAPI, cluster
 		}
 		logging.Debugf("[TASK] Success, stopped task %v", task)
 	}
+	return nil
+}
+
+// deregisterClusterContainerInstances force-deregisters every container instance registered to the
+// cluster. DeleteCluster fails with ClusterContainsContainerInstancesException when EC2-launch-type
+// clusters still have instances registered, so this must run before deleteECSCluster.
+func deregisterClusterContainerInstances(ctx context.Context, client ECSClustersAPI, clusterArn *string) error {
+	paginator := ecs.NewListContainerInstancesPaginator(client, &ecs.ListContainerInstancesInput{
+		Cluster: clusterArn,
+	})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return errors.WithStackTrace(err)
+		}
+
+		for _, instanceArn := range page.ContainerInstanceArns {
+			_, err := client.DeregisterContainerInstance(ctx, &ecs.DeregisterContainerInstanceInput{
+				Cluster:           clusterArn,
+				ContainerInstance: aws.String(instanceArn),
+				Force:             aws.Bool(true),
+			})
+			if err != nil {
+				logging.Debugf("[ECS] Unable to deregister container instance %s from cluster %s: %v", instanceArn, aws.ToString(clusterArn), err)
+				return errors.WithStackTrace(err)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/aws/resources/ecs_cluster_test.go
+++ b/aws/resources/ecs_cluster_test.go
@@ -17,13 +17,15 @@ import (
 
 type mockedEC2Cluster struct {
 	ECSClustersAPI
-	DescribeClustersOutput    ecs.DescribeClustersOutput
-	DeleteClusterOutput       ecs.DeleteClusterOutput
-	ListClustersOutput        ecs.ListClustersOutput
-	ListTagsForResourceOutput ecs.ListTagsForResourceOutput
-	ListTasksOutput           ecs.ListTasksOutput
-	StopTaskOutput            ecs.StopTaskOutput
-	TagResourceOutput         ecs.TagResourceOutput
+	DescribeClustersOutput             ecs.DescribeClustersOutput
+	DeleteClusterOutput                ecs.DeleteClusterOutput
+	DeregisterContainerInstanceOutput  ecs.DeregisterContainerInstanceOutput
+	ListClustersOutput                 ecs.ListClustersOutput
+	ListContainerInstancesOutput       ecs.ListContainerInstancesOutput
+	ListTagsForResourceOutput          ecs.ListTagsForResourceOutput
+	ListTasksOutput                    ecs.ListTasksOutput
+	StopTaskOutput                     ecs.StopTaskOutput
+	TagResourceOutput                  ecs.TagResourceOutput
 }
 
 func (m mockedEC2Cluster) DescribeClusters(ctx context.Context, params *ecs.DescribeClustersInput, optFns ...func(*ecs.Options)) (*ecs.DescribeClustersOutput, error) {
@@ -32,6 +34,14 @@ func (m mockedEC2Cluster) DescribeClusters(ctx context.Context, params *ecs.Desc
 
 func (m mockedEC2Cluster) DeleteCluster(ctx context.Context, params *ecs.DeleteClusterInput, optFns ...func(*ecs.Options)) (*ecs.DeleteClusterOutput, error) {
 	return &m.DeleteClusterOutput, nil
+}
+
+func (m mockedEC2Cluster) DeregisterContainerInstance(ctx context.Context, params *ecs.DeregisterContainerInstanceInput, optFns ...func(*ecs.Options)) (*ecs.DeregisterContainerInstanceOutput, error) {
+	return &m.DeregisterContainerInstanceOutput, nil
+}
+
+func (m mockedEC2Cluster) ListContainerInstances(ctx context.Context, params *ecs.ListContainerInstancesInput, optFns ...func(*ecs.Options)) (*ecs.ListContainerInstancesOutput, error) {
+	return &m.ListContainerInstancesOutput, nil
 }
 
 func (m mockedEC2Cluster) ListClusters(ctx context.Context, params *ecs.ListClustersInput, optFns ...func(*ecs.Options)) (*ecs.ListClustersOutput, error) {
@@ -437,6 +447,33 @@ func TestStopClusterRunningTasksWithTasks(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDeregisterClusterContainerInstances(t *testing.T) {
+	t.Parallel()
+
+	mock := mockedEC2Cluster{
+		ListContainerInstancesOutput: ecs.ListContainerInstancesOutput{
+			ContainerInstanceArns: []string{
+				"arn:aws:ecs:us-east-1:123456789012:container-instance/cluster1/instance-1",
+				"arn:aws:ecs:us-east-1:123456789012:container-instance/cluster1/instance-2",
+			},
+		},
+	}
+
+	err := deregisterClusterContainerInstances(context.Background(), mock, aws.String("arn:aws:ecs:us-east-1:123456789012:cluster/cluster1"))
+	require.NoError(t, err)
+}
+
+func TestDeregisterClusterContainerInstances_EmptyList(t *testing.T) {
+	t.Parallel()
+
+	mock := mockedEC2Cluster{
+		ListContainerInstancesOutput: ecs.ListContainerInstancesOutput{ContainerInstanceArns: []string{}},
+	}
+
+	err := deregisterClusterContainerInstances(context.Background(), mock, aws.String("arn:aws:ecs:us-east-1:123456789012:cluster/cluster1"))
+	require.NoError(t, err)
+}
+
 func TestECSClustersMultiStepDeleter(t *testing.T) {
 	t.Parallel()
 
@@ -448,10 +485,15 @@ func TestECSClustersMultiStepDeleter(t *testing.T) {
 				"task-arn-002",
 			},
 		},
+		ListContainerInstancesOutput: ecs.ListContainerInstancesOutput{
+			ContainerInstanceArns: []string{
+				"arn:aws:ecs:us-east-1:123456789012:container-instance/cluster1/instance-1",
+			},
+		},
 		StopTaskOutput: ecs.StopTaskOutput{},
 	}
 
-	nuker := resource.MultiStepDeleter(stopClusterRunningTasks, deleteECSCluster)
+	nuker := resource.MultiStepDeleter(stopClusterRunningTasks, deregisterClusterContainerInstances, deleteECSCluster)
 	results := nuker(context.Background(), mock, resource.Scope{Region: "us-east-1"}, "ecs-cluster", []*string{aws.String("arn:aws:ecs:us-east-1:123456789012:cluster/cluster1")})
 	require.Len(t, results, 1)
 	for _, result := range results {
@@ -464,7 +506,7 @@ func TestECSClustersMultiStepDeleter_EmptyList(t *testing.T) {
 
 	mock := mockedEC2Cluster{}
 
-	nuker := resource.MultiStepDeleter(stopClusterRunningTasks, deleteECSCluster)
+	nuker := resource.MultiStepDeleter(stopClusterRunningTasks, deregisterClusterContainerInstances, deleteECSCluster)
 	results := nuker(context.Background(), mock, resource.Scope{Region: "us-east-1"}, "ecs-cluster", []*string{})
 	require.Len(t, results, 0)
 }

--- a/aws/resources/ecs_cluster_test.go
+++ b/aws/resources/ecs_cluster_test.go
@@ -17,15 +17,15 @@ import (
 
 type mockedEC2Cluster struct {
 	ECSClustersAPI
-	DescribeClustersOutput             ecs.DescribeClustersOutput
-	DeleteClusterOutput                ecs.DeleteClusterOutput
-	DeregisterContainerInstanceOutput  ecs.DeregisterContainerInstanceOutput
-	ListClustersOutput                 ecs.ListClustersOutput
-	ListContainerInstancesOutput       ecs.ListContainerInstancesOutput
-	ListTagsForResourceOutput          ecs.ListTagsForResourceOutput
-	ListTasksOutput                    ecs.ListTasksOutput
-	StopTaskOutput                     ecs.StopTaskOutput
-	TagResourceOutput                  ecs.TagResourceOutput
+	DescribeClustersOutput            ecs.DescribeClustersOutput
+	DeleteClusterOutput               ecs.DeleteClusterOutput
+	DeregisterContainerInstanceOutput ecs.DeregisterContainerInstanceOutput
+	ListClustersOutput                ecs.ListClustersOutput
+	ListContainerInstancesOutput      ecs.ListContainerInstancesOutput
+	ListTagsForResourceOutput         ecs.ListTagsForResourceOutput
+	ListTasksOutput                   ecs.ListTasksOutput
+	StopTaskOutput                    ecs.StopTaskOutput
+	TagResourceOutput                 ecs.TagResourceOutput
 }
 
 func (m mockedEC2Cluster) DescribeClusters(ctx context.Context, params *ecs.DescribeClustersInput, optFns ...func(*ecs.Options)) (*ecs.DescribeClustersOutput, error) {


### PR DESCRIPTION
## Summary

ECS clusters using the EC2 launch type have registered container instances that must be deregistered before \`DeleteCluster\` succeeds. Without that step, the nuker fails with:

\`\`\`
ClusterContainsContainerInstancesException: The Cluster cannot be deleted while Container Instances are active or draining.
\`\`\`

Observed in scheduled \`cloud_nuke_cleanup\` runs against phxdevops (e.g. \`terraform-aws-ecs\` job 8017 on 2026-04-16) for both \`us-east-1\` and \`us-east-2\`.

## Fix

Adds \`deregisterClusterContainerInstances\` step between \`stopClusterRunningTasks\` and \`deleteECSCluster\` in the cluster's \`MultiStepDeleter\`. Uses \`ListContainerInstances\` paginator + \`DeregisterContainerInstance\` with \`Force=true\` so draining instances don't block the delete.

## Test plan

- [x] \`go test -race ./aws/resources/ -run ECSCluster\` — all pass, including new \`TestDeregisterClusterContainerInstances\` and \`TestDeregisterClusterContainerInstances_EmptyList\`
- [x] Updated \`TestECSClustersMultiStepDeleter\` to exercise the full three-step pipeline
- [ ] Verify against a real EC2-launch-type cluster in phxdevops