### PR TITLE
fix: classify ENI 'currently in use' as a warning

### DIFF
--- a/util/error.go
+++ b/util/error.go
@@ -146,6 +146,16 @@ func IsWarningError(err error) bool {
 			"OperationNotPermitted":
 			return true
 		}
+		// ENI still attached to a resource being deleted in the same run (NAT
+		// gateway, Lambda, VPC endpoint, etc.). AWS returns the generic
+		// InvalidParameterValue code here, so we have to discriminate on the
+		// message. Same ordering/dependency pattern as DependencyViolation —
+		// the next run succeeds once the attaching resource is gone.
+		if apiErr.ErrorCode() == "InvalidParameterValue" &&
+			strings.Contains(apiErr.ErrorMessage(), "Network interface") &&
+			strings.Contains(apiErr.ErrorMessage(), "currently in use") {
+			return true
+		}
 		// Already-deleted errors — any error code containing "NotFound"
 		if strings.Contains(strings.ToLower(apiErr.ErrorCode()), "notfound") {
 			return true

--- a/util/error_test.go
+++ b/util/error_test.go
@@ -140,6 +140,17 @@ func TestIsWarningError(t *testing.T) {
 		require.True(t, IsWarningError(&smithy.GenericAPIError{Code: code}), code)
 	}
 
+	// ENI still attached to a resource being deleted in the same run — warning
+	require.True(t, IsWarningError(&smithy.GenericAPIError{
+		Code:    "InvalidParameterValue",
+		Message: "Network interface 'eni-038687eab4e11c405' is currently in use.",
+	}))
+	// Generic InvalidParameterValue without the ENI signature — NOT a warning
+	require.False(t, IsWarningError(&smithy.GenericAPIError{
+		Code:    "InvalidParameterValue",
+		Message: "some other validation failure",
+	}))
+
 	// SCP-denied errors are warnings
 	require.True(t, IsWarningError(&smithy.GenericAPIError{
 		Code:    "AccessDeniedException",


### PR DESCRIPTION
## Summary

When an ENI is still attached to a resource being deleted in the same run (NAT gateway, Lambda, VPC endpoint, etc.), `DeleteNetworkInterface` returns:

```
InvalidParameterValue: Network interface 'eni-...' is currently in use.
```

The nuker's existing detach path only handles EC2-instance-attached ENIs; for every other attachment type, we rely on the attaching resource's own deletion to release the ENI, then clean up on the next scheduled run.

This is exactly the ordering/dependency pattern already classified as a warning for `DependencyViolation`, `CacheSubnetGroupInUse`, etc. — but because AWS returns the generic `InvalidParameterValue` code, it was being treated as a hard failure, exiting the whole nuke with code 1.

Observed in the `Nuke: PhxDevOps` nightly on 2026-04-22 (job 72439909704, ap-northeast-2).

## Fix

Classify the specific `InvalidParameterValue` + "Network interface … currently in use" signature as a warning in `util.IsWarningError`. Since the error code alone is too broad, match on the message substring.

## Test plan

- [x] `go test ./util/ -run TestIsWarningError` — new assertion covers positive case (ENI-in-use) and negative case (unrelated `InvalidParameterValue`)
- [x] `go test -race` clean