### PR TITLE
chore: exempt cost-anomaly-alerts logging IAM policy from nuke

### DIFF
--- a/.github/nuke_config.yml
+++ b/.github/nuke_config.yml
@@ -108,6 +108,8 @@ IAMPolicies:
       - "^ecs-prod-.*"
       - "^ecs-stage-.*"
       - "^edr-.*"
+      # Cost alerting (auto-generated logging policy from terraform-aws-lambda)
+      - "^cost-anomaly-alerts-to-slack-logging.*"
       # Service policies
       - "^AWSConfigSNSPublishPolicy$"
       - "^AmazonEKSFullAccess$"


### PR DESCRIPTION
## Summary

Adds the auto-generated logging IAM policy from the phxdevops `cost-anomaly-alerts` Lambda to the cloud-nuke exemption list. The Lambda function, role, and log group were already exempt; the IAM policy was the missing piece.

The policy name pattern is `cost-anomaly-alerts-to-slack-logging<random>`, generated by `terraform-aws-lambda` via `name_prefix`. Without an exemption, cloud-nuke deletes it on each run and the next Terraform apply recreates it.

## Impact of the gap (before this fix)

Lambda execution still succeeded (alerts kept reaching Slack), but CloudWatch logging silently failed during the window between cloud-nuke deletion and the next apply. Confirmed in phxdevops: latest plan output showed the policy had been deleted outside Terraform with timestamp suffix from Mar 6, 2026, recreated today (Apr 26).

## Changes

- `.github/nuke_config.yml` -- add `^cost-anomaly-alerts-to-slack-logging.*` under `IAMPolicies.exclude.names_regex`