### PR TITLE
fix: exclude resources with nil creation time when a time filter is set

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -569,9 +569,7 @@ func (r ResourceType) ShouldIncludeBasedOnTime(time time.Time) bool {
 	return true
 }
 
-// hasTimeFilter reports whether any time-based include/exclude filter is configured
-// for this resource type. When a filter is set, callers must verify the resource has
-// a known creation time before deciding whether to include it.
+// hasTimeFilter reports whether any time-based filter is configured.
 func (r ResourceType) hasTimeFilter() bool {
 	return r.IncludeRule.TimeAfter != nil ||
 		r.IncludeRule.TimeBefore != nil ||
@@ -656,12 +654,8 @@ func (r ResourceType) ShouldInclude(value ResourceValue) bool {
 		return false
 	}
 
-	// SAFETY CHECK: AWS APIs return a nil creation time for resources in
-	// transitional states (e.g. an RDS instance in `creating`, where
-	// InstanceCreateTime is unset until the instance reaches `available`).
-	// If a time filter like --older-than is set, treat unknown-age resources
-	// as not-matching: silently passing them through races the filter against
-	// in-progress resources it was meant to protect.
+	// AWS returns nil creation time for resources in transitional states (e.g.
+	// RDS `creating`). Exclude when a time filter is set to avoid the race.
 	if value.Time == nil {
 		if r.hasTimeFilter() {
 			logging.Debugf("Resource has no creation time but a time filter is set - excluding for safety")

--- a/config/config.go
+++ b/config/config.go
@@ -569,6 +569,16 @@ func (r ResourceType) ShouldIncludeBasedOnTime(time time.Time) bool {
 	return true
 }
 
+// hasTimeFilter reports whether any time-based include/exclude filter is configured
+// for this resource type. When a filter is set, callers must verify the resource has
+// a known creation time before deciding whether to include it.
+func (r ResourceType) hasTimeFilter() bool {
+	return r.IncludeRule.TimeAfter != nil ||
+		r.IncludeRule.TimeBefore != nil ||
+		r.ExcludeRule.TimeAfter != nil ||
+		r.ExcludeRule.TimeBefore != nil
+}
+
 func (r ResourceType) getExclusionTag() string {
 	return DefaultAwsResourceExclusionTagKey
 }
@@ -644,9 +654,24 @@ func (r ResourceType) ShouldIncludeBasedOnTag(tags map[string]string) bool {
 func (r ResourceType) ShouldInclude(value ResourceValue) bool {
 	if !ShouldInclude(value.Name, r.IncludeRule.NamesRegExp, r.ExcludeRule.NamesRegExp) {
 		return false
-	} else if value.Time != nil && !r.ShouldIncludeBasedOnTime(*value.Time) {
+	}
+
+	// SAFETY CHECK: AWS APIs return a nil creation time for resources in
+	// transitional states (e.g. an RDS instance in `creating`, where
+	// InstanceCreateTime is unset until the instance reaches `available`).
+	// If a time filter like --older-than is set, treat unknown-age resources
+	// as not-matching: silently passing them through races the filter against
+	// in-progress resources it was meant to protect.
+	if value.Time == nil {
+		if r.hasTimeFilter() {
+			logging.Debugf("Resource has no creation time but a time filter is set - excluding for safety")
+			return false
+		}
+	} else if !r.ShouldIncludeBasedOnTime(*value.Time) {
 		return false
-	} else if !r.ShouldIncludeBasedOnTag(value.Tags) {
+	}
+
+	if !r.ShouldIncludeBasedOnTag(value.Tags) {
 		return false
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -318,6 +318,40 @@ func TestShouldInclude_NameAndTimeFilter(t *testing.T) {
 	}))
 }
 
+// TestShouldInclude_NilTimeWithFilter exercises the safety guard for AWS
+// resources whose creation time is nil during transitional states (e.g. an RDS
+// instance still in `creating`, where InstanceCreateTime is unset). When a
+// time filter such as --older-than is set, those resources must be excluded;
+// silently passing them through races the filter against in-progress resources.
+func TestShouldInclude_NilTimeWithFilter(t *testing.T) {
+	hourAgo := time.Now().Add(-1 * time.Hour)
+
+	t.Run("nil time + ExcludeRule.TimeAfter (--older-than) excludes", func(t *testing.T) {
+		r := ResourceType{ExcludeRule: FilterRule{TimeAfter: &hourAgo}}
+		assert.False(t, r.ShouldInclude(ResourceValue{Name: aws.String("rds-still-creating")}))
+	})
+
+	t.Run("nil time + IncludeRule.TimeAfter (--newer-than) excludes", func(t *testing.T) {
+		r := ResourceType{IncludeRule: FilterRule{TimeAfter: &hourAgo}}
+		assert.False(t, r.ShouldInclude(ResourceValue{Name: aws.String("rds-still-creating")}))
+	})
+
+	t.Run("nil time + no time filter still includes", func(t *testing.T) {
+		r := ResourceType{}
+		assert.True(t, r.ShouldInclude(ResourceValue{Name: aws.String("rds-still-creating")}))
+	})
+
+	t.Run("non-nil time still routes through ShouldIncludeBasedOnTime", func(t *testing.T) {
+		r := ResourceType{ExcludeRule: FilterRule{TimeAfter: &hourAgo}}
+		// Resource created 30 minutes ago: newer than the 1h cutoff, must be excluded.
+		recent := time.Now().Add(-30 * time.Minute)
+		assert.False(t, r.ShouldInclude(ResourceValue{Name: aws.String("recent"), Time: &recent}))
+		// Resource created 2 hours ago: older than the cutoff, must be included.
+		old := time.Now().Add(-2 * time.Hour)
+		assert.True(t, r.ShouldInclude(ResourceValue{Name: aws.String("old"), Time: &old}))
+	})
+}
+
 func TestAddIncludeAndExcludeAfterTime(t *testing.T) {
 	now := aws.Time(time.Now())
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -318,11 +318,8 @@ func TestShouldInclude_NameAndTimeFilter(t *testing.T) {
 	}))
 }
 
-// TestShouldInclude_NilTimeWithFilter exercises the safety guard for AWS
-// resources whose creation time is nil during transitional states (e.g. an RDS
-// instance still in `creating`, where InstanceCreateTime is unset). When a
-// time filter such as --older-than is set, those resources must be excluded;
-// silently passing them through races the filter against in-progress resources.
+// AWS returns nil creation time for resources in transitional states; with a
+// time filter set, ShouldInclude must exclude them to avoid the race.
 func TestShouldInclude_NilTimeWithFilter(t *testing.T) {
 	hourAgo := time.Now().Add(-1 * time.Hour)
 


### PR DESCRIPTION
## Summary
`ResourceType.ShouldInclude` silently let resources with a nil creation time through `--older-than` / `--newer-than`. AWS returns nil for resources in transitional states (e.g. RDS `creating`, where `InstanceCreateTime` is unset until `available`), so an hourly cloud-nuke can race a still-creating resource and call `Delete` on it. We hit this in `terraform-aws-data-storage` upgrade tests: every replica-touching test fails with `unexpected state 'deleting'` because the cloud-nuke job nukes a still-creating replica.

## Fix
At the central `ShouldInclude` choke point: if `value.Time == nil` and any time filter is set, exclude. Covers all 101 resources at once.

## Tradeoff
Resources whose AWS API exposes no creation time at all will no longer be deleted under a time filter. They should adopt the existing first-seen tag pattern (`opensearch.go`, `sns.go`, `ecs_cluster.go`); this fix makes that pattern work correctly across runs.

## Test plan
- [x] New `TestShouldInclude_NilTimeWithFilter` covers nil + `--older-than`, nil + `--newer-than`, nil + no filter, non-nil + filter
- [x] `go test ./config/...` and `go vet ./...` pass