### PR TITLE
add BackupPlan support

### DIFF
--- a/aws/resource_registry.go
+++ b/aws/resource_registry.go
@@ -67,6 +67,7 @@ func getRegisteredRegionalResources() []resources.AwsResource {
 		resources.NewApiGatewayV2(),
 		resources.NewASGroups(),
 		resources.NewAppRunnerService(),
+		resources.NewBackupPlan(),
 		resources.NewBackupVault(),
 		resources.NewManagedPrometheus(),
 		resources.NewGrafana(),

--- a/aws/resources/backup_plan.go
+++ b/aws/resources/backup_plan.go
@@ -52,7 +52,7 @@ func listBackupPlans(ctx context.Context, client BackupPlanAPI, scope resource.S
 			tags, err := getBackupPlanTags(ctx, client, cfg, plan)
 			if err != nil {
 				logging.Errorf("Unable to fetch tags for %s: %s", aws.ToString(plan.BackupPlanArn), err)
-				continue
+				return nil, err
 			}
 
 			if cfg.ShouldInclude(config.ResourceValue{

--- a/aws/resources/backup_plan.go
+++ b/aws/resources/backup_plan.go
@@ -1,0 +1,137 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/backup"
+	"github.com/aws/aws-sdk-go-v2/service/backup/types"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/logging"
+	"github.com/gruntwork-io/cloud-nuke/resource"
+	"github.com/gruntwork-io/go-commons/errors"
+)
+
+// BackupPlanAPI defines the interface for Backup Plan operations.
+type BackupPlanAPI interface {
+	DeleteBackupPlan(ctx context.Context, params *backup.DeleteBackupPlanInput, optFns ...func(*backup.Options)) (*backup.DeleteBackupPlanOutput, error)
+	DeleteBackupSelection(ctx context.Context, params *backup.DeleteBackupSelectionInput, optFns ...func(*backup.Options)) (*backup.DeleteBackupSelectionOutput, error)
+	ListBackupPlans(ctx context.Context, params *backup.ListBackupPlansInput, optFns ...func(*backup.Options)) (*backup.ListBackupPlansOutput, error)
+	ListBackupSelections(ctx context.Context, params *backup.ListBackupSelectionsInput, optFns ...func(*backup.Options)) (*backup.ListBackupSelectionsOutput, error)
+	ListTags(ctx context.Context, params *backup.ListTagsInput, optFns ...func(*backup.Options)) (*backup.ListTagsOutput, error)
+}
+
+// NewBackupPlan creates a new BackupPlan resource using the generic resource pattern.
+func NewBackupPlan() AwsResource {
+	return NewAwsResource(&resource.Resource[BackupPlanAPI]{
+		ResourceTypeName: "backup-plan",
+		BatchSize:        DefaultBatchSize,
+		InitClient: WrapAwsInitClient(func(r *resource.Resource[BackupPlanAPI], cfg aws.Config) {
+			r.Scope.Region = cfg.Region
+			r.Client = backup.NewFromConfig(cfg)
+		}),
+		ConfigGetter: func(c config.Config) config.ResourceType {
+			return c.BackupPlan
+		},
+		Lister: listBackupPlans,
+		Nuker:  resource.MultiStepDeleter(nukeBackupSelections, nukeBackupPlan),
+	})
+}
+
+// listBackupPlans retrieves all Backup Plans that match the config filters.
+func listBackupPlans(ctx context.Context, client BackupPlanAPI, scope resource.Scope, cfg config.ResourceType) ([]*string, error) {
+	var ids []*string
+	paginator := backup.NewListBackupPlansPaginator(client, &backup.ListBackupPlansInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, plan := range page.BackupPlansList {
+			tags, err := getBackupPlanTags(ctx, client, cfg, plan)
+			if err != nil {
+				logging.Errorf("Unable to fetch tags for %s: %s", aws.ToString(plan.BackupPlanArn), err)
+				continue
+			}
+
+			if cfg.ShouldInclude(config.ResourceValue{
+				Name: plan.BackupPlanName,
+				Time: plan.CreationDate,
+				Tags: tags,
+			}) {
+				ids = append(ids, plan.BackupPlanId)
+			}
+		}
+	}
+
+	return ids, nil
+}
+
+// getBackupPlanTags retrieves the tags for a given backup plan if tag-based filters are specified in the config.
+func getBackupPlanTags(ctx context.Context, client BackupPlanAPI, cfg config.ResourceType, plan types.BackupPlansListMember) (map[string]string, error) {
+	tags := map[string]string{}
+	if len(cfg.IncludeRule.Tags) > 0 || len(cfg.ExcludeRule.Tags) > 0 {
+		tagsPaginator := backup.NewListTagsPaginator(client, &backup.ListTagsInput{
+			ResourceArn: plan.BackupPlanArn,
+		})
+		for tagsPaginator.HasMorePages() {
+			tagsPage, err := tagsPaginator.NextPage(ctx)
+			if err != nil {
+				return nil, errors.WithStackTrace(err)
+			}
+
+			for tagKey, tagValue := range tagsPage.Tags {
+				tags[tagKey] = tagValue
+			}
+		}
+	}
+	return tags, nil
+}
+
+// nukeBackupSelections deletes all backup selections for a backup plan.
+func nukeBackupSelections(ctx context.Context, client BackupPlanAPI, id *string) error {
+	planId := aws.ToString(id)
+	logging.Debugf("Nuking backup selections of backup plan %s", planId)
+
+	paginator := backup.NewListBackupSelectionsPaginator(client, &backup.ListBackupSelectionsInput{
+		BackupPlanId: id,
+	})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			logging.Debugf("[Failed] listing backup selections of backup plan %s: %v", planId, err)
+			return err
+		}
+
+		for _, selection := range page.BackupSelectionsList {
+			selectionId := aws.ToString(selection.SelectionId)
+			logging.Debugf("Deleting backup selection %s from backup plan %s", selectionId, planId)
+
+			_, err = client.DeleteBackupSelection(ctx, &backup.DeleteBackupSelectionInput{
+				BackupPlanId: id,
+				SelectionId:  selection.SelectionId,
+			})
+			if err != nil {
+				logging.Debugf("[Failed] deleting backup selection %s: %v", selectionId, err)
+				return err
+			}
+		}
+	}
+
+	logging.Debugf("[OK] Successfully nuked backup selections of backup plan %s", planId)
+	return nil
+}
+
+// nukeBackupPlan deletes a single backup plan.
+func nukeBackupPlan(ctx context.Context, client BackupPlanAPI, id *string) error {
+	_, err := client.DeleteBackupPlan(ctx, &backup.DeleteBackupPlanInput{
+		BackupPlanId: id,
+	})
+	if err != nil {
+		logging.Debugf("[Failed] nuking the backup plan %s: %v", aws.ToString(id), err)
+		return err
+	}
+	return nil
+}

--- a/aws/resources/backup_plan_test.go
+++ b/aws/resources/backup_plan_test.go
@@ -1,0 +1,296 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/backup"
+	"github.com/aws/aws-sdk-go-v2/service/backup/types"
+	"github.com/gruntwork-io/cloud-nuke/config"
+	"github.com/gruntwork-io/cloud-nuke/resource"
+	"github.com/stretchr/testify/require"
+)
+
+type mockBackupPlanListTagsPageOutput struct {
+	ListTagsPages []backup.ListTagsOutput
+	listTagsIndex int
+}
+
+type mockBackupPlanClient struct {
+	// ListBackupPlans pagination support
+	ListBackupPlansPages []backup.ListBackupPlansOutput
+	listPlansPageIndex   int
+
+	// ListBackupSelections pagination support
+	ListBackupSelectionsPages  []backup.ListBackupSelectionsOutput
+	listSelectionsPageIndex    int
+	DeleteBackupSelectionCount atomic.Int32
+
+	// ListTags pagination support
+	ListTagsPages map[string]*mockBackupPlanListTagsPageOutput
+	ListTagsErr   error
+}
+
+func (m *mockBackupPlanClient) DeleteBackupPlan(ctx context.Context, params *backup.DeleteBackupPlanInput, optFns ...func(*backup.Options)) (*backup.DeleteBackupPlanOutput, error) {
+	return &backup.DeleteBackupPlanOutput{}, nil
+}
+
+func (m *mockBackupPlanClient) DeleteBackupSelection(ctx context.Context, params *backup.DeleteBackupSelectionInput, optFns ...func(*backup.Options)) (*backup.DeleteBackupSelectionOutput, error) {
+	m.DeleteBackupSelectionCount.Add(1)
+	return &backup.DeleteBackupSelectionOutput{}, nil
+}
+
+func (m *mockBackupPlanClient) ListBackupPlans(ctx context.Context, params *backup.ListBackupPlansInput, optFns ...func(*backup.Options)) (*backup.ListBackupPlansOutput, error) {
+	if m.listPlansPageIndex >= len(m.ListBackupPlansPages) {
+		return &backup.ListBackupPlansOutput{}, nil
+	}
+	output := m.ListBackupPlansPages[m.listPlansPageIndex]
+	m.listPlansPageIndex++
+	return &output, nil
+}
+
+func (m *mockBackupPlanClient) ListBackupSelections(ctx context.Context, params *backup.ListBackupSelectionsInput, optFns ...func(*backup.Options)) (*backup.ListBackupSelectionsOutput, error) {
+	if m.listSelectionsPageIndex >= len(m.ListBackupSelectionsPages) {
+		return &backup.ListBackupSelectionsOutput{}, nil
+	}
+	output := m.ListBackupSelectionsPages[m.listSelectionsPageIndex]
+	m.listSelectionsPageIndex++
+	return &output, nil
+}
+
+func (m *mockBackupPlanClient) ListTags(ctx context.Context, params *backup.ListTagsInput, optFns ...func(*backup.Options)) (*backup.ListTagsOutput, error) {
+	if m.ListTagsErr != nil {
+		return nil, m.ListTagsErr
+	}
+	pages := m.ListTagsPages[*params.ResourceArn]
+	if pages == nil || pages.listTagsIndex >= len(pages.ListTagsPages) {
+		return &backup.ListTagsOutput{}, nil
+	}
+
+	output := pages.ListTagsPages[pages.listTagsIndex]
+	pages.listTagsIndex++
+
+	if pages.listTagsIndex < len(pages.ListTagsPages) {
+		output.NextToken = aws.String("token")
+	}
+
+	return &output, nil
+}
+
+func TestListBackupPlans(t *testing.T) {
+	t.Parallel()
+
+	testId1 := "plan-id-1"
+	testId2 := "plan-id-2"
+	now := time.Now()
+
+	tests := map[string]struct {
+		configObj config.ResourceType
+		expected  []string
+	}{
+		"emptyFilter": {
+			configObj: config.ResourceType{},
+			expected:  []string{testId1, testId2},
+		},
+		"nameExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					NamesRegExp: []config.Expression{{
+						RE: *regexp.MustCompile("test-plan-1"),
+					}}},
+			},
+			expected: []string{testId2},
+		},
+		"timeAfterExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					TimeAfter: aws.Time(now.Add(-1)),
+				}},
+			expected: []string{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mock := &mockBackupPlanClient{
+				ListBackupPlansPages: []backup.ListBackupPlansOutput{
+					{
+						BackupPlansList: []types.BackupPlansListMember{
+							{BackupPlanId: aws.String(testId1), BackupPlanName: aws.String("test-plan-1"), CreationDate: aws.Time(now)},
+							{BackupPlanId: aws.String(testId2), BackupPlanName: aws.String("test-plan-2"), CreationDate: aws.Time(now.Add(1))},
+						},
+					},
+				},
+			}
+
+			ids, err := listBackupPlans(context.Background(), mock, resource.Scope{}, tc.configObj)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, aws.ToStringSlice(ids))
+		})
+	}
+}
+
+func TestListBackupPlans_FilterTags(t *testing.T) {
+	t.Parallel()
+
+	planWithoutTags := "plan-no-tags"
+	planFooFaz := "plan-foo-faz"
+	planFoo := "plan-foo"
+
+	tests := map[string]struct {
+		configObj config.ResourceType
+		expected  []string
+	}{
+		"emptyFilter": {
+			configObj: config.ResourceType{},
+			expected:  []string{planWithoutTags, planFooFaz, planFoo},
+		},
+		"tagInclusionFilter": {
+			configObj: config.ResourceType{
+				IncludeRule: config.FilterRule{
+					Tags: map[string]config.Expression{"foo": {RE: *regexp.MustCompile("bar")}},
+				}},
+			expected: []string{planFooFaz, planFoo},
+		},
+		"tagExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					Tags: map[string]config.Expression{"faz": {RE: *regexp.MustCompile("baz")}},
+				}},
+			expected: []string{planWithoutTags, planFoo},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mock := &mockBackupPlanClient{
+				ListBackupPlansPages: []backup.ListBackupPlansOutput{
+					{
+						BackupPlansList: []types.BackupPlansListMember{
+							{BackupPlanId: aws.String(planWithoutTags), BackupPlanName: aws.String("no-tags"), BackupPlanArn: aws.String("arn:aws:" + planWithoutTags)},
+							{BackupPlanId: aws.String(planFooFaz), BackupPlanName: aws.String("foo-faz"), BackupPlanArn: aws.String("arn:aws:" + planFooFaz)},
+							{BackupPlanId: aws.String(planFoo), BackupPlanName: aws.String("foo"), BackupPlanArn: aws.String("arn:aws:" + planFoo)},
+						},
+					},
+				},
+				ListTagsPages: map[string]*mockBackupPlanListTagsPageOutput{
+					"arn:aws:" + planFoo: {
+						ListTagsPages: []backup.ListTagsOutput{
+							{Tags: map[string]string{"foo": "bar"}},
+						},
+					},
+					"arn:aws:" + planFooFaz: {
+						ListTagsPages: []backup.ListTagsOutput{
+							{Tags: map[string]string{"foo": "bar"}},
+							{Tags: map[string]string{"faz": "baz"}},
+						},
+					},
+				},
+			}
+
+			ids, err := listBackupPlans(context.Background(), mock, resource.Scope{}, tc.configObj)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, aws.ToStringSlice(ids))
+		})
+	}
+}
+
+func TestListBackupPlans_TagsError(t *testing.T) {
+	t.Parallel()
+
+	testArn := "arn:aws:backup:us-east-1:123456789012:backup-plan:plan-1"
+	mock := &mockBackupPlanClient{
+		ListBackupPlansPages: []backup.ListBackupPlansOutput{
+			{
+				BackupPlansList: []types.BackupPlansListMember{
+					{BackupPlanId: aws.String("plan-1"), BackupPlanName: aws.String("test-plan"), BackupPlanArn: aws.String(testArn)},
+				},
+			},
+		},
+		ListTagsErr: errors.New("BackupPlanException"),
+	}
+
+	cfg := config.ResourceType{
+		IncludeRule: config.FilterRule{
+			Tags: map[string]config.Expression{"foo": {RE: *regexp.MustCompile("bar")}},
+		},
+	}
+
+	ids, err := listBackupPlans(context.Background(), mock, resource.Scope{}, cfg)
+	require.NoError(t, err)
+	require.Equal(t, []string{}, aws.ToStringSlice(ids))
+}
+
+func TestNukeBackupPlan(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockBackupPlanClient{}
+
+	err := nukeBackupPlan(context.Background(), mock, aws.String("plan-1"))
+	require.NoError(t, err)
+}
+
+func TestNukeBackupSelections(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no selections", func(t *testing.T) {
+		mock := &mockBackupPlanClient{
+			ListBackupSelectionsPages: []backup.ListBackupSelectionsOutput{
+				{BackupSelectionsList: []types.BackupSelectionsListMember{}},
+			},
+		}
+
+		err := nukeBackupSelections(context.Background(), mock, aws.String("plan-1"))
+		require.NoError(t, err)
+		require.Equal(t, int32(0), mock.DeleteBackupSelectionCount.Load())
+	})
+
+	t.Run("with selections", func(t *testing.T) {
+		mock := &mockBackupPlanClient{
+			ListBackupSelectionsPages: []backup.ListBackupSelectionsOutput{
+				{
+					BackupSelectionsList: []types.BackupSelectionsListMember{
+						{SelectionId: aws.String("sel-1"), BackupPlanId: aws.String("plan-1")},
+						{SelectionId: aws.String("sel-2"), BackupPlanId: aws.String("plan-1")},
+					},
+				},
+			},
+		}
+
+		err := nukeBackupSelections(context.Background(), mock, aws.String("plan-1"))
+		require.NoError(t, err)
+		require.Equal(t, int32(2), mock.DeleteBackupSelectionCount.Load())
+	})
+}
+
+func TestListBackupPlansPagination(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	mock := &mockBackupPlanClient{
+		ListBackupPlansPages: []backup.ListBackupPlansOutput{
+			{
+				BackupPlansList: []types.BackupPlansListMember{
+					{BackupPlanId: aws.String("plan-1"), BackupPlanName: aws.String("plan-1"), CreationDate: aws.Time(now)},
+				},
+				NextToken: aws.String("token1"),
+			},
+			{
+				BackupPlansList: []types.BackupPlansListMember{
+					{BackupPlanId: aws.String("plan-2"), BackupPlanName: aws.String("plan-2"), CreationDate: aws.Time(now)},
+				},
+			},
+		},
+	}
+
+	ids, err := listBackupPlans(context.Background(), mock, resource.Scope{}, config.ResourceType{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"plan-1", "plan-2"}, aws.ToStringSlice(ids))
+}

--- a/aws/resources/backup_plan_test.go
+++ b/aws/resources/backup_plan_test.go
@@ -51,6 +51,9 @@ func (m *mockBackupPlanClient) ListBackupPlans(ctx context.Context, params *back
 	}
 	output := m.ListBackupPlansPages[m.listPlansPageIndex]
 	m.listPlansPageIndex++
+	if m.listPlansPageIndex < len(m.ListBackupPlansPages) {
+		output.NextToken = aws.String("next-plans-token")
+	}
 	return &output, nil
 }
 
@@ -60,6 +63,9 @@ func (m *mockBackupPlanClient) ListBackupSelections(ctx context.Context, params 
 	}
 	output := m.ListBackupSelectionsPages[m.listSelectionsPageIndex]
 	m.listSelectionsPageIndex++
+	if m.listSelectionsPageIndex < len(m.ListBackupSelectionsPages) {
+		output.NextToken = aws.String("next-selections-token")
+	}
 	return &output, nil
 }
 
@@ -224,8 +230,8 @@ func TestListBackupPlans_TagsError(t *testing.T) {
 	}
 
 	ids, err := listBackupPlans(context.Background(), mock, resource.Scope{}, cfg)
-	require.NoError(t, err)
-	require.Equal(t, []string{}, aws.ToStringSlice(ids))
+	require.Error(t, err)
+	require.Nil(t, ids)
 }
 
 func TestNukeBackupPlan(t *testing.T) {
@@ -280,7 +286,6 @@ func TestListBackupPlansPagination(t *testing.T) {
 				BackupPlansList: []types.BackupPlansListMember{
 					{BackupPlanId: aws.String("plan-1"), BackupPlanName: aws.String("plan-1"), CreationDate: aws.Time(now)},
 				},
-				NextToken: aws.String("token1"),
 			},
 			{
 				BackupPlansList: []types.BackupPlansListMember{

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	AccessAnalyzer                  ResourceType               `yaml:"AccessAnalyzer"`
 	AutoScalingGroup                ResourceType               `yaml:"AutoScalingGroup"`
 	AppRunnerService                ResourceType               `yaml:"AppRunnerService"`
+	BackupPlan                      ResourceType               `yaml:"BackupPlan"`
 	BackupVault                     ResourceType               `yaml:"BackupVault"`
 	ManagedPrometheus               ResourceType               `yaml:"ManagedPrometheus"`
 	CloudWatchAlarm                 ResourceType               `yaml:"CloudWatchAlarm"`
@@ -175,6 +176,7 @@ func (c *Config) allResourceTypes() []*ResourceType {
 		&c.AccessAnalyzer,
 		&c.AutoScalingGroup,
 		&c.AppRunnerService,
+		&c.BackupPlan,
 		&c.BackupVault,
 		&c.ManagedPrometheus,
 		&c.CloudWatchAlarm,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,6 +23,7 @@ func emptyConfig() *Config {
 		AccessAnalyzer:                  ResourceType{},
 		AutoScalingGroup:                ResourceType{},
 		AppRunnerService:                ResourceType{},
+		BackupPlan:                      ResourceType{},
 		BackupVault:                     ResourceType{},
 		ManagedPrometheus:               ResourceType{},
 		CloudWatchAlarm:                 ResourceType{},

--- a/config/examples/complete.yaml
+++ b/config/examples/complete.yaml
@@ -143,6 +143,24 @@ AppRunnerService:
       test: "true"
   timeout: 1h
   protect_until_expire: true
+BackupPlan:
+  include:
+    names_regex:
+    - that.*
+    - thats.*
+    time_after: 2024-02-02T00:00:00Z
+    time_before: 2024-01-01T00:00:00Z
+    tags:
+      test: "true"
+  exclude:
+    names_regex:
+    - this.*
+    time_after: 2024-02-02T00:00:00Z
+    time_before: 2024-01-01T00:00:00Z
+    tags:
+      test: "true"
+  timeout: 1h
+  protect_until_expire: true
 BackupVault:
   include:
     names_regex:

--- a/docs/supported-resources.md
+++ b/docs/supported-resources.md
@@ -12,6 +12,7 @@ cloud-nuke supports inspecting and deleting the following AWS resources. The **C
 | `api-gateway-v2` | API Gateway (v2) |
 | `app-runner-service` | App Runner Service |
 | `asg` | Auto Scaling Group |
+| `backup-plan` | Backup Plan |
 | `backup-vault` | Backup Vault |
 | `cloudformation-stack` | CloudFormation Stack |
 | `cloudfront-distribution` | CloudFront Distribution |
@@ -155,6 +156,7 @@ This table shows which filtering features are supported for each resource type i
 | api-gateway-v2 | APIGatewayV2 | ✓ | ✓ | ✓ | ✓ |
 | app-runner-service | AppRunnerService | ✓ | ✓ | ✓ | ✓ |
 | asg | AutoScalingGroup | ✓ | ✓ | ✓ | ✓ |
+| backup-plan | BackupPlan | ✓ | ✓ | ✓ | ✓ |
 | backup-vault | BackupVault | ✓ | ✓ | ✓ | ✓ |
 | cloudformation-stack | CloudFormationStack | ✓ | ✓ | ✓ | ✓ |
 | cloudfront-distribution | CloudFrontDistribution | ✓ | | ✓ | ✓ |


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #1137 .

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)


Added support for BackupPlan

<sup>Thomas Gunsch thomas.gunsch@mercedes-benz.com, Mercedes-Benz AG on behalf of Mercedes-Benz Tech Innovation GmbH, [Provider Information](https://github.com/mercedes-benz/foss/blob/main/PROVIDER_INFORMATION.md)</sup>

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
