### PR TITLE
ci: exclude AWS-managed EFS backup plan from PhxDevOps nuke

### DIFF
--- a/.github/nuke_config.yml
+++ b/.github/nuke_config.yml
@@ -179,6 +179,12 @@ BackupVault:
       # AWS-managed EFS automatic backup vault (resource policy explicitly denies deletion)
       - "^aws/efs/automatic-backup-vault$"
 
+BackupPlan:
+  exclude:
+    names_regex:
+      # AWS-managed EFS automatic backup plan (service-managed; DeleteBackupSelection returns 403)
+      - "^aws/efs/.*"
+
 CloudTrailTrail:
   exclude:
     names_regex:


### PR DESCRIPTION
## Summary
- Adds a `BackupPlan` exclude for `^aws/efs/.*` in `.github/nuke_config.yml`, mirroring the existing `BackupVault` exclude for the same AWS-managed EFS resource.
- After #1138 landed, the scheduled `Nuke: PhxDevOps` workflow has been failing every 3 hours in `us-east-1` on `DeleteBackupSelection` against `aws/efs/<uuid>` (403 AccessDenied; plan is service-managed by AWS Backup).

Example failing run: https://github.com/gruntwork-io/cloud-nuke/actions/runs/26191340381

## Test plan
- [ ] Manually trigger `Nuke: PhxDevOps` after merge and confirm `us-east-1` job is green.