### PR TITLE
fix: honor cloud-nuke-excluded tag on iam-instance-profile

### DIFF
--- a/aws/resources/iam_instance_profile.go
+++ b/aws/resources/iam_instance_profile.go
@@ -9,11 +9,13 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/resource"
+	"github.com/gruntwork-io/cloud-nuke/util"
 )
 
 // IAMInstanceProfilesAPI defines the interface for IAM instance profile operations.
 type IAMInstanceProfilesAPI interface {
 	ListInstanceProfiles(ctx context.Context, params *iam.ListInstanceProfilesInput, optFns ...func(*iam.Options)) (*iam.ListInstanceProfilesOutput, error)
+	ListInstanceProfileTags(ctx context.Context, params *iam.ListInstanceProfileTagsInput, optFns ...func(*iam.Options)) (*iam.ListInstanceProfileTagsOutput, error)
 	GetInstanceProfile(ctx context.Context, params *iam.GetInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.GetInstanceProfileOutput, error)
 	RemoveRoleFromInstanceProfile(ctx context.Context, params *iam.RemoveRoleFromInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.RemoveRoleFromInstanceProfileOutput, error)
 	DeleteInstanceProfile(ctx context.Context, params *iam.DeleteInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.DeleteInstanceProfileOutput, error)
@@ -49,16 +51,21 @@ func listIAMInstanceProfiles(ctx context.Context, client IAMInstanceProfilesAPI,
 		}
 
 		for _, profile := range output.InstanceProfiles {
+			// The ListInstanceProfiles API does not populate tags, so we must fetch them
+			// explicitly to support tag-based filtering, including the default
+			// cloud-nuke-excluded tag. Without this, instance profiles with the exclusion
+			// tag would still be nuked.
+			tagsOut, err := client.ListInstanceProfileTags(ctx, &iam.ListInstanceProfileTagsInput{
+				InstanceProfileName: profile.InstanceProfileName,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to list tags for instance profile %s: %w", aws.ToString(profile.InstanceProfileName), err)
+			}
+
 			rv := config.ResourceValue{
 				Name: profile.InstanceProfileName,
 				Time: profile.CreateDate,
-				Tags: map[string]string{},
-			}
-			for _, tag := range profile.Tags {
-				if tag.Key == nil || tag.Value == nil {
-					continue
-				}
-				rv.Tags[*tag.Key] = *tag.Value
+				Tags: util.ConvertIAMTagsToMap(tagsOut.Tags),
 			}
 			if !cfg.ShouldInclude(rv) {
 				continue

--- a/aws/resources/iam_instance_profile_test.go
+++ b/aws/resources/iam_instance_profile_test.go
@@ -90,6 +90,13 @@ func TestIAMInstanceProfiles_ListIAMInstanceProfiles(t *testing.T) {
 			configObj: config.ResourceType{},
 			expected:  []string{testName1, testName2},
 		},
+		// Regression test for #1140: a profile tagged cloud-nuke-excluded=true must be
+		// filtered out even with no explicit filters. This only works because tags are
+		// fetched via ListInstanceProfileTags; ListInstanceProfiles returns no tags.
+		"defaultExclusionTag": {
+			configObj: config.ResourceType{},
+			expected:  []string{testName1, testName2},
+		},
 		"nameExclusionFilter": {
 			configObj: config.ResourceType{
 				ExcludeRule: config.FilterRule{

--- a/aws/resources/iam_instance_profile_test.go
+++ b/aws/resources/iam_instance_profile_test.go
@@ -19,8 +19,14 @@ type mockedIAMInstanceProfiles struct {
 
 	GetInstanceProfileOutput            iam.GetInstanceProfileOutput
 	ListInstanceProfilesOutput          iam.ListInstanceProfilesOutput
+	ListInstanceProfileTagsOutput       map[string]iam.ListInstanceProfileTagsOutput
 	RemoveRoleFromInstanceProfileOutput iam.RemoveRoleFromInstanceProfileOutput
 	DeleteInstanceProfileOutput         iam.DeleteInstanceProfileOutput
+}
+
+func (m mockedIAMInstanceProfiles) ListInstanceProfileTags(ctx context.Context, params *iam.ListInstanceProfileTagsInput, optFns ...func(*iam.Options)) (*iam.ListInstanceProfileTagsOutput, error) {
+	out := m.ListInstanceProfileTagsOutput[aws.ToString(params.InstanceProfileName)]
+	return &out, nil
 }
 
 func (m mockedIAMInstanceProfiles) GetInstanceProfile(ctx context.Context, params *iam.GetInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.GetInstanceProfileOutput, error) {
@@ -44,6 +50,9 @@ func TestIAMInstanceProfiles_ListIAMInstanceProfiles(t *testing.T) {
 	testArn2 := "arn:aws:iam::123456789012:instance-profile/MyInstanceProfiles2"
 	now := time.Now()
 
+	testName3 := "MyInstanceProfiles3"
+	testArn3 := "arn:aws:iam::123456789012:instance-profile/MyInstanceProfiles3"
+
 	client := mockedIAMInstanceProfiles{
 		ListInstanceProfilesOutput: iam.ListInstanceProfilesOutput{
 			InstanceProfiles: []types.InstanceProfile{
@@ -51,25 +60,25 @@ func TestIAMInstanceProfiles_ListIAMInstanceProfiles(t *testing.T) {
 					Arn:                 aws.String(testArn1),
 					InstanceProfileName: aws.String(testName1),
 					CreateDate:          aws.Time(now),
-					Tags: []types.Tag{
-						{
-							Key:   aws.String("somearn"),
-							Value: aws.String("some" + testArn1),
-						},
-					},
 				},
 				{
 					Arn:                 aws.String(testArn2),
 					InstanceProfileName: aws.String(testName2),
 					CreateDate:          aws.Time(now.Add(1)),
-					Tags: []types.Tag{
-						{
-							Key:   aws.String("somearn"),
-							Value: aws.String("some" + testArn2),
-						},
-					},
+				},
+				{
+					Arn:                 aws.String(testArn3),
+					InstanceProfileName: aws.String(testName3),
+					CreateDate:          aws.Time(now.Add(2)),
 				},
 			},
+		},
+		// The ListInstanceProfiles API does not return tags; they are fetched separately
+		// via ListInstanceProfileTags. testName3 carries the cloud-nuke-excluded tag.
+		ListInstanceProfileTagsOutput: map[string]iam.ListInstanceProfileTagsOutput{
+			testName1: {Tags: []types.Tag{{Key: aws.String("somearn"), Value: aws.String("some" + testArn1)}}},
+			testName2: {Tags: []types.Tag{{Key: aws.String("somearn"), Value: aws.String("some" + testArn2)}}},
+			testName3: {Tags: []types.Tag{{Key: aws.String("cloud-nuke-excluded"), Value: aws.String("true")}}},
 		},
 	}
 


### PR DESCRIPTION
## Problem

IAM instance profiles tagged with `cloud-nuke-excluded = true` were still nuked, both in dry-run and on delete (#1140, LIB-5139).

## Root cause

The AWS IAM `ListInstanceProfiles` API does not populate the `Tags` field on returned profiles. The lister read `profile.Tags` directly, so it always saw an empty tag set and the exclusion tag (and any tag filter) was silently ignored.

## Fix

Fetch tags explicitly via `ListInstanceProfileTags` for each profile, mirroring the existing approach in `iam_role.go` (which already does this for the same reason).

## Testing

Added a third instance profile carrying the `cloud-nuke-excluded` tag to the lister test; it is now correctly filtered out. The empty-filter case serves as the regression guard. `go build ./...` and the `iam-instance-profile` tests pass.

Fixes #1140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed instance profile tag retrieval to ensure tags are properly fetched and applied during filtering operations.
  * Improved error handling when fetching instance profile tags with clearer error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->