### PR TITLE
fix: delete SageMaker inference components before endpoint

### DIFF
--- a/aws/resources/sagemaker_endpoint.go
+++ b/aws/resources/sagemaker_endpoint.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
@@ -18,6 +19,8 @@ type SageMakerEndpointAPI interface {
 	ListEndpoints(ctx context.Context, params *sagemaker.ListEndpointsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListEndpointsOutput, error)
 	DeleteEndpoint(ctx context.Context, params *sagemaker.DeleteEndpointInput, optFns ...func(*sagemaker.Options)) (*sagemaker.DeleteEndpointOutput, error)
 	ListTags(ctx context.Context, params *sagemaker.ListTagsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListTagsOutput, error)
+	ListInferenceComponents(ctx context.Context, params *sagemaker.ListInferenceComponentsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListInferenceComponentsOutput, error)
+	DeleteInferenceComponent(ctx context.Context, params *sagemaker.DeleteInferenceComponentInput, optFns ...func(*sagemaker.Options)) (*sagemaker.DeleteInferenceComponentOutput, error)
 }
 
 // NewSageMakerEndpoint creates a new SageMakerEndpoint resource using the generic resource pattern.
@@ -114,6 +117,12 @@ func shouldExcludeByTags(endpointName *string, tagMap map[string]string, cfg con
 func deleteSageMakerEndpoint(ctx context.Context, client SageMakerEndpointAPI, endpointName *string) error {
 	logging.Debugf("Deleting SageMaker Endpoint: %s", aws.ToString(endpointName))
 
+	// SageMaker rejects DeleteEndpoint while any inference component is still
+	// associated with the endpoint, so clear those first.
+	if err := deleteEndpointInferenceComponents(ctx, client, endpointName); err != nil {
+		return err
+	}
+
 	_, err := client.DeleteEndpoint(ctx, &sagemaker.DeleteEndpointInput{
 		EndpointName: endpointName,
 	})
@@ -122,4 +131,66 @@ func deleteSageMakerEndpoint(ctx context.Context, client SageMakerEndpointAPI, e
 	}
 
 	return nil
+}
+
+// deleteEndpointInferenceComponents deletes the endpoint's inference components
+// and waits for them to be fully removed, since deletion is asynchronous.
+func deleteEndpointInferenceComponents(ctx context.Context, client SageMakerEndpointAPI, endpointName *string) error {
+	componentNames, err := listEndpointInferenceComponents(ctx, client, endpointName)
+	if err != nil {
+		return err
+	}
+	if len(componentNames) == 0 {
+		return nil
+	}
+
+	for _, name := range componentNames {
+		logging.Debugf("Deleting SageMaker Inference Component %s on endpoint %s",
+			aws.ToString(name), aws.ToString(endpointName))
+		if _, err := client.DeleteInferenceComponent(ctx, &sagemaker.DeleteInferenceComponentInput{
+			InferenceComponentName: name,
+		}); err != nil {
+			return errors.WithStackTrace(err)
+		}
+	}
+
+	startTime := time.Now()
+	for {
+		remaining, err := listEndpointInferenceComponents(ctx, client, endpointName)
+		if err != nil {
+			return err
+		}
+		if len(remaining) == 0 {
+			logging.Debugf("[OK] all inference components on endpoint %s deleted", aws.ToString(endpointName))
+			return nil
+		}
+		if time.Since(startTime) > sageMakerMaxWaitTime {
+			return fmt.Errorf("timeout waiting for inference components on endpoint %s to delete after %v",
+				aws.ToString(endpointName), sageMakerMaxWaitTime)
+		}
+		time.Sleep(sageMakerRetryDelay)
+	}
+}
+
+// listEndpointInferenceComponents returns the names of all inference components
+// associated with the given endpoint.
+func listEndpointInferenceComponents(ctx context.Context, client SageMakerEndpointAPI, endpointName *string) ([]*string, error) {
+	var names []*string
+	paginator := sagemaker.NewListInferenceComponentsPaginator(client, &sagemaker.ListInferenceComponentsInput{
+		EndpointNameEquals: endpointName,
+	})
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, errors.WithStackTrace(err)
+		}
+		for _, component := range output.InferenceComponents {
+			if component.InferenceComponentName != nil {
+				names = append(names, component.InferenceComponentName)
+			}
+		}
+	}
+
+	return names, nil
 }

--- a/aws/resources/sagemaker_endpoint_test.go
+++ b/aws/resources/sagemaker_endpoint_test.go
@@ -19,6 +19,12 @@ type mockSageMakerEndpointClient struct {
 	ListEndpointsOutput  sagemaker.ListEndpointsOutput
 	DeleteEndpointOutput sagemaker.DeleteEndpointOutput
 	ListTagsOutput       sagemaker.ListTagsOutput
+
+	// ListInferenceComponentsOutputs is returned one per call, then empty once
+	// exhausted, to simulate components disappearing after deletion.
+	ListInferenceComponentsOutputs []sagemaker.ListInferenceComponentsOutput
+	listInferenceComponentsCalls   int
+	deletedInferenceComponents     []string
 }
 
 func (m *mockSageMakerEndpointClient) ListEndpoints(ctx context.Context, params *sagemaker.ListEndpointsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListEndpointsOutput, error) {
@@ -31,6 +37,20 @@ func (m *mockSageMakerEndpointClient) DeleteEndpoint(ctx context.Context, params
 
 func (m *mockSageMakerEndpointClient) ListTags(ctx context.Context, params *sagemaker.ListTagsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListTagsOutput, error) {
 	return &m.ListTagsOutput, nil
+}
+
+func (m *mockSageMakerEndpointClient) ListInferenceComponents(ctx context.Context, params *sagemaker.ListInferenceComponentsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListInferenceComponentsOutput, error) {
+	defer func() { m.listInferenceComponentsCalls++ }()
+	if m.listInferenceComponentsCalls < len(m.ListInferenceComponentsOutputs) {
+		out := m.ListInferenceComponentsOutputs[m.listInferenceComponentsCalls]
+		return &out, nil
+	}
+	return &sagemaker.ListInferenceComponentsOutput{}, nil
+}
+
+func (m *mockSageMakerEndpointClient) DeleteInferenceComponent(ctx context.Context, params *sagemaker.DeleteInferenceComponentInput, optFns ...func(*sagemaker.Options)) (*sagemaker.DeleteInferenceComponentOutput, error) {
+	m.deletedInferenceComponents = append(m.deletedInferenceComponents, aws.ToString(params.InferenceComponentName))
+	return &sagemaker.DeleteInferenceComponentOutput{}, nil
 }
 
 func TestListSageMakerEndpoints(t *testing.T) {
@@ -117,4 +137,28 @@ func TestDeleteSageMakerEndpoint(t *testing.T) {
 
 	err := deleteSageMakerEndpoint(context.Background(), mock, aws.String("test-endpoint"))
 	require.NoError(t, err)
+	require.Empty(t, mock.deletedInferenceComponents)
+}
+
+func TestDeleteSageMakerEndpointWithInferenceComponents(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockSageMakerEndpointClient{
+		DeleteEndpointOutput: sagemaker.DeleteEndpointOutput{},
+		// First list reports a component; the wait loop's next call returns empty.
+		ListInferenceComponentsOutputs: []sagemaker.ListInferenceComponentsOutput{
+			{
+				InferenceComponents: []types.InferenceComponentSummary{
+					{
+						InferenceComponentName: aws.String("test-component"),
+						EndpointName:           aws.String("test-endpoint"),
+					},
+				},
+			},
+		},
+	}
+
+	err := deleteSageMakerEndpoint(context.Background(), mock, aws.String("test-endpoint"))
+	require.NoError(t, err)
+	require.Equal(t, []string{"test-component"}, mock.deletedInferenceComponents)
 }


### PR DESCRIPTION
## What

The scheduled PhxDevOps nuke was failing because `DeleteEndpoint` returns a `ValidationException` when an inference component is still associated with the endpoint:

```
Cannot delete endpoint with inference component associated.
Please delete inference component and try it again.
```

`deleteSageMakerEndpoint` now deletes the endpoint's inference components and waits for them to be removed (deletion is async) before deleting the endpoint. Endpoints with no components are unaffected.

## Testing

Added `TestDeleteSageMakerEndpointWithInferenceComponents`. Build, vet, and existing sagemaker tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SageMaker endpoint deletion now properly handles associated inference components to prevent deletion failures.

* **Tests**
  * Added test coverage to verify inference component cleanup during endpoint deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->