### PR TITLE
feat: Adding parallelism

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
+	"github.com/gruntwork-io/cloud-nuke/aws/resources"
 	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/hashicorp/go-multierror"
 
@@ -38,83 +42,129 @@ func GetAllResources(c context.Context, query *Query, configObj config.Config, c
 	}
 
 	c = context.WithValue(c, util.ExcludeFirstSeenTagKey, query.ExcludeFirstSeen)
+
+	parallelism := util.GetParallelism(c)
+
+	var accountMu sync.Mutex
+	g := new(errgroup.Group)
+	g.SetLimit(parallelism)
+
 	for _, region := range query.Regions {
-		cloudNukeSession, errSession := NewSession(region)
-		if errSession != nil {
-			return nil, errSession
-		}
-
-		accountId, err := util.GetCurrentAccountId(cloudNukeSession)
-		if err == nil {
-			telemetry.SetAccountId(accountId)
-			c = context.WithValue(c, util.AccountIdKey, accountId)
-		}
-
-		awsResource := AwsResources{}
-		registeredResources := GetAndInitRegisteredResources(cloudNukeSession, region)
-		for _, resource := range registeredResources {
-			if IsNukeable((*resource).ResourceName(), query.ResourceTypes) {
-
-				(*resource).GetAndSetResourceConfig(configObj)
-
-				// Emit scan progress event
-				collector.Emit(reporting.ScanProgress{
-					ResourceType: (*resource).ResourceName(),
-					Region:       region,
-				})
-
-				start := time.Now()
-				identifiers, err := (*resource).GetAndSetIdentifiers(c, configObj)
-				if err != nil {
-					logging.Errorf("Unable to retrieve %v, %v", (*resource).ResourceName(), err)
-
-					// Reporting resource-level failures encountered during the GetIdentifiers phase
-					telemetry.TrackEvent(commonTelemetry.EventContext{
-						EventName: fmt.Sprintf("error:GetIdentifiers:%s", (*resource).ResourceName()),
-					}, map[string]interface{}{
-						"region": region,
-					})
-
-					collector.Emit(reporting.GeneralError{
-						ResourceType: (*resource).ResourceName(),
-						Description:  fmt.Sprintf("Unable to retrieve %s", (*resource).ResourceName()),
-						Error:        err.Error(),
-					})
-				}
-
-				telemetry.TrackEvent(commonTelemetry.EventContext{
-					EventName: fmt.Sprintf("Done getting %s identifiers", (*resource).ResourceName()),
-				}, map[string]interface{}{
-					"recordCount": len(identifiers),
-					"actionTime":  time.Since(start).Seconds(),
-				})
-
-				// Only append if we have non-empty identifiers
-				if len(identifiers) > 0 {
-					logging.Infof("Found %d %s resources in %s", len(identifiers), (*resource).ResourceName(), region)
-					awsResource.Resources = append(awsResource.Resources, resource)
-
-					// Emit ResourceFound events for each identifier
-					for _, id := range identifiers {
-						nukable, reason := true, ""
-						if _, err := (*resource).IsNukable(id); err != nil {
-							nukable, reason = false, err.Error()
-						}
-						collector.Emit(reporting.ResourceFound{
-							ResourceType: (*resource).ResourceName(),
-							Region:       region,
-							Identifier:   id,
-							Nukable:      nukable,
-							Reason:       reason,
-						})
-					}
-				}
+		g.Go(func() error {
+			cloudNukeSession, errSession := NewSession(region)
+			if errSession != nil {
+				return errSession
 			}
-		}
 
-		if len(awsResource.Resources) > 0 {
-			account.Resources[region] = awsResource
-		}
+			regionCtx := c
+			accountId, err := util.GetCurrentAccountId(cloudNukeSession)
+			if err == nil {
+				telemetry.SetAccountId(accountId)
+				regionCtx = context.WithValue(c, util.AccountIdKey, accountId)
+			}
+
+			registeredResources := GetAndInitRegisteredResources(cloudNukeSession, region)
+
+			// Collect resources for this region; preserve registry order for nuking later.
+			// We list all types concurrently then reassemble in original order.
+			type indexedResource struct {
+				idx      int
+				resource *resources.AwsResource
+			}
+			found := make([]indexedResource, 0, len(registeredResources))
+			var regionMu sync.Mutex
+
+			inner := new(errgroup.Group)
+			inner.SetLimit(parallelism)
+
+			for i, resource := range registeredResources {
+				if !IsNukeable((*resource).ResourceName(), query.ResourceTypes) {
+					continue
+				}
+				inner.Go(func() error {
+					(*resource).GetAndSetResourceConfig(configObj)
+
+					collector.Emit(reporting.ScanProgress{
+						ResourceType: (*resource).ResourceName(),
+						Region:       region,
+					})
+
+					start := time.Now()
+					identifiers, err := (*resource).GetAndSetIdentifiers(regionCtx, configObj)
+					if err != nil {
+						logging.Errorf("Unable to retrieve %v, %v", (*resource).ResourceName(), err)
+
+						telemetry.TrackEvent(commonTelemetry.EventContext{
+							EventName: fmt.Sprintf("error:GetIdentifiers:%s", (*resource).ResourceName()),
+						}, map[string]interface{}{
+							"region": region,
+						})
+
+						collector.Emit(reporting.GeneralError{
+							ResourceType: (*resource).ResourceName(),
+							Description:  fmt.Sprintf("Unable to retrieve %s", (*resource).ResourceName()),
+							Error:        err.Error(),
+						})
+						return nil
+					}
+
+					telemetry.TrackEvent(commonTelemetry.EventContext{
+						EventName: fmt.Sprintf("Done getting %s identifiers", (*resource).ResourceName()),
+					}, map[string]interface{}{
+						"recordCount": len(identifiers),
+						"actionTime":  time.Since(start).Seconds(),
+					})
+
+					if len(identifiers) > 0 {
+						logging.Infof("Found %d %s resources in %s", len(identifiers), (*resource).ResourceName(), region)
+
+						regionMu.Lock()
+						found = append(found, indexedResource{idx: i, resource: resource})
+						regionMu.Unlock()
+
+						for _, id := range identifiers {
+							nukable, reason := true, ""
+							if _, err := (*resource).IsNukable(id); err != nil {
+								nukable, reason = false, err.Error()
+							}
+							collector.Emit(reporting.ResourceFound{
+								ResourceType: (*resource).ResourceName(),
+								Region:       region,
+								Identifier:   id,
+								Nukable:      nukable,
+								Reason:       reason,
+							})
+						}
+					}
+					return nil
+				})
+			}
+
+			if err := inner.Wait(); err != nil {
+				return err
+			}
+
+			if len(found) == 0 {
+				return nil
+			}
+
+			// Re-sort by original registry index so nuking respects dependency order.
+			sort.Slice(found, func(a, b int) bool { return found[a].idx < found[b].idx })
+			awsResources := AwsResources{Resources: make([]*resources.AwsResource, len(found))}
+			for i, r := range found {
+				awsResources.Resources[i] = r.resource
+			}
+
+			accountMu.Lock()
+			account.Resources[region] = awsResources
+			accountMu.Unlock()
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	logging.Info("Done searching for resources")
@@ -221,28 +271,44 @@ func NukeAllResources(ctx context.Context, account *AwsAccountResources, regions
 	// Emit NukeStarted event (CLIRenderer will initialize progress bar)
 	collector.Emit(reporting.NukeStarted{Total: account.TotalResourceCount()})
 
-	var allErrors *multierror.Error
-
 	telemetry.TrackEvent(commonTelemetry.EventContext{
 		EventName: "Begin nuking resources",
 	}, map[string]interface{}{})
 
-	for _, region := range regions {
-		telemetry.TrackEvent(commonTelemetry.EventContext{
-			EventName: "Creating session for region",
-		}, map[string]interface{}{
-			"region": region,
-		})
+	parallelism := util.GetParallelism(ctx)
 
-		if err := nukeAllResourcesInRegion(ctx, account, region, collector); err != nil {
-			allErrors = multierror.Append(allErrors, err)
-		}
-		telemetry.TrackEvent(commonTelemetry.EventContext{
-			EventName: "Done Nuking Region",
-		}, map[string]interface{}{
-			"region":        region,
-			"resourceCount": len(account.Resources[region].Resources),
+	var mu sync.Mutex
+	var allErrors *multierror.Error
+
+	g := new(errgroup.Group)
+	g.SetLimit(parallelism)
+
+	for _, region := range regions {
+		g.Go(func() error {
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Creating session for region",
+			}, map[string]interface{}{
+				"region": region,
+			})
+
+			if err := nukeAllResourcesInRegion(ctx, account, region, collector); err != nil {
+				mu.Lock()
+				allErrors = multierror.Append(allErrors, err)
+				mu.Unlock()
+			}
+
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: "Done Nuking Region",
+			}, map[string]interface{}{
+				"region":        region,
+				"resourceCount": len(account.Resources[region].Resources),
+			})
+			return nil
 		})
+	}
+
+	if err := g.Wait(); err != nil {
+		allErrors = multierror.Append(allErrors, err)
 	}
 
 	// Emit NukeComplete event (triggers final output in renderers)

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1,9 +1,10 @@
 package aws
 
 import (
+	"cmp"
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -42,129 +43,162 @@ func GetAllResources(c context.Context, query *Query, configObj config.Config, c
 	}
 
 	c = context.WithValue(c, util.ExcludeFirstSeenTagKey, query.ExcludeFirstSeen)
-
+	// Inject parallelism from the query so downstream callers (e.g. batch_deleter) can read it
+	// via util.GetParallelism without needing the caller to set it on the context.
+	c = context.WithValue(c, util.ParallelismKey, query.Parallelism)
 	parallelism := util.GetParallelism(c)
 
-	var accountMu sync.Mutex
-	g := new(errgroup.Group)
-	g.SetLimit(parallelism)
+	type indexedResource struct {
+		idx      int
+		resource *resources.AwsResource
+	}
+	type regionSetup struct {
+		regionCtx context.Context
+		nukeable  []indexedResource
+	}
 
+	// Phase 1: set up sessions and init resources for each region concurrently.
+	// GetAndInitRegisteredResources only allocates SDK clients (no API calls), so
+	// no concurrency limit is needed here.
+	setups := make(map[string]*regionSetup, len(query.Regions))
+	var setupMu sync.Mutex
+	var setAccountOnce sync.Once
+
+	setupGroup := new(errgroup.Group)
 	for _, region := range query.Regions {
-		g.Go(func() error {
-			cloudNukeSession, errSession := NewSession(region)
-			if errSession != nil {
-				return errSession
+		setupGroup.Go(func() error {
+			cloudNukeSession, err := NewSession(region)
+			if err != nil {
+				return err
 			}
-
 			regionCtx := c
 			accountId, err := util.GetCurrentAccountId(cloudNukeSession)
 			if err == nil {
-				telemetry.SetAccountId(accountId)
+				// All regions share the same account ID; set it once to avoid a data race.
+				setAccountOnce.Do(func() { telemetry.SetAccountId(accountId) })
 				regionCtx = context.WithValue(c, util.AccountIdKey, accountId)
 			}
-
 			registeredResources := GetAndInitRegisteredResources(cloudNukeSession, region)
-
-			// Collect resources for this region; preserve registry order for nuking later.
-			// We list all types concurrently then reassemble in original order.
-			type indexedResource struct {
-				idx      int
-				resource *resources.AwsResource
-			}
-			found := make([]indexedResource, 0, len(registeredResources))
-			var regionMu sync.Mutex
-
-			inner := new(errgroup.Group)
-			inner.SetLimit(parallelism)
-
-			for i, resource := range registeredResources {
-				if !IsNukeable((*resource).ResourceName(), query.ResourceTypes) {
-					continue
+			setup := &regionSetup{regionCtx: regionCtx}
+			for i, res := range registeredResources {
+				if IsNukeable((*res).ResourceName(), query.ResourceTypes) {
+					setup.nukeable = append(setup.nukeable, indexedResource{idx: i, resource: res})
 				}
-				inner.Go(func() error {
-					(*resource).GetAndSetResourceConfig(configObj)
-
-					collector.Emit(reporting.ScanProgress{
-						ResourceType: (*resource).ResourceName(),
-						Region:       region,
-					})
-
-					start := time.Now()
-					identifiers, err := (*resource).GetAndSetIdentifiers(regionCtx, configObj)
-					if err != nil {
-						logging.Errorf("Unable to retrieve %v, %v", (*resource).ResourceName(), err)
-
-						telemetry.TrackEvent(commonTelemetry.EventContext{
-							EventName: fmt.Sprintf("error:GetIdentifiers:%s", (*resource).ResourceName()),
-						}, map[string]interface{}{
-							"region": region,
-						})
-
-						collector.Emit(reporting.GeneralError{
-							ResourceType: (*resource).ResourceName(),
-							Description:  fmt.Sprintf("Unable to retrieve %s", (*resource).ResourceName()),
-							Error:        err.Error(),
-						})
-						return nil
-					}
-
-					telemetry.TrackEvent(commonTelemetry.EventContext{
-						EventName: fmt.Sprintf("Done getting %s identifiers", (*resource).ResourceName()),
-					}, map[string]interface{}{
-						"recordCount": len(identifiers),
-						"actionTime":  time.Since(start).Seconds(),
-					})
-
-					if len(identifiers) > 0 {
-						logging.Infof("Found %d %s resources in %s", len(identifiers), (*resource).ResourceName(), region)
-
-						regionMu.Lock()
-						found = append(found, indexedResource{idx: i, resource: resource})
-						regionMu.Unlock()
-
-						for _, id := range identifiers {
-							nukable, reason := true, ""
-							if _, err := (*resource).IsNukable(id); err != nil {
-								nukable, reason = false, err.Error()
-							}
-							collector.Emit(reporting.ResourceFound{
-								ResourceType: (*resource).ResourceName(),
-								Region:       region,
-								Identifier:   id,
-								Nukable:      nukable,
-								Reason:       reason,
-							})
-						}
-					}
-					return nil
-				})
 			}
-
-			if err := inner.Wait(); err != nil {
-				return err
-			}
-
-			if len(found) == 0 {
-				return nil
-			}
-
-			// Re-sort by original registry index so nuking respects dependency order.
-			sort.Slice(found, func(a, b int) bool { return found[a].idx < found[b].idx })
-			awsResources := AwsResources{Resources: make([]*resources.AwsResource, len(found))}
-			for i, r := range found {
-				awsResources.Resources[i] = r.resource
-			}
-
-			accountMu.Lock()
-			account.Resources[region] = awsResources
-			accountMu.Unlock()
-
+			setupMu.Lock()
+			setups[region] = setup
+			setupMu.Unlock()
 			return nil
 		})
 	}
-
-	if err := g.Wait(); err != nil {
+	if err := setupGroup.Wait(); err != nil {
 		return nil, err
+	}
+
+	// Phase 2: scan all nukeable resources across all regions with a single shared
+	// concurrency limit. Using one errgroup (instead of nested per-region groups)
+	// ensures --parallelism N means at most N simultaneous API calls total.
+	type resourceTask struct {
+		region    string
+		regionCtx context.Context
+		idx       int
+		resource  *resources.AwsResource
+	}
+	var allTasks []resourceTask
+	for _, region := range query.Regions {
+		setup, ok := setups[region]
+		if !ok {
+			continue
+		}
+		for _, r := range setup.nukeable {
+			allTasks = append(allTasks, resourceTask{
+				region:    region,
+				regionCtx: setup.regionCtx,
+				idx:       r.idx,
+				resource:  r.resource,
+			})
+		}
+	}
+
+	foundByRegion := make(map[string][]indexedResource)
+	var foundMu sync.Mutex
+
+	scanGroup := new(errgroup.Group)
+	scanGroup.SetLimit(parallelism)
+	for _, task := range allTasks {
+		scanGroup.Go(func() error {
+			(*task.resource).GetAndSetResourceConfig(configObj)
+
+			collector.Emit(reporting.ScanProgress{
+				ResourceType: (*task.resource).ResourceName(),
+				Region:       task.region,
+			})
+
+			start := time.Now()
+			identifiers, err := (*task.resource).GetAndSetIdentifiers(task.regionCtx, configObj)
+			if err != nil {
+				logging.Errorf("Unable to retrieve %v, %v", (*task.resource).ResourceName(), err)
+
+				telemetry.TrackEvent(commonTelemetry.EventContext{
+					EventName: fmt.Sprintf("error:GetIdentifiers:%s", (*task.resource).ResourceName()),
+				}, map[string]interface{}{
+					"region": task.region,
+				})
+
+				collector.Emit(reporting.GeneralError{
+					ResourceType: (*task.resource).ResourceName(),
+					Description:  fmt.Sprintf("Unable to retrieve %s", (*task.resource).ResourceName()),
+					Error:        err.Error(),
+				})
+				return nil
+			}
+
+			telemetry.TrackEvent(commonTelemetry.EventContext{
+				EventName: fmt.Sprintf("Done getting %s identifiers", (*task.resource).ResourceName()),
+			}, map[string]interface{}{
+				"recordCount": len(identifiers),
+				"actionTime":  time.Since(start).Seconds(),
+			})
+
+			if len(identifiers) > 0 {
+				logging.Infof("Found %d %s resources in %s", len(identifiers), (*task.resource).ResourceName(), task.region)
+
+				foundMu.Lock()
+				foundByRegion[task.region] = append(foundByRegion[task.region], indexedResource{task.idx, task.resource})
+				foundMu.Unlock()
+
+				for _, id := range identifiers {
+					nukable, reason := true, ""
+					if _, err := (*task.resource).IsNukable(id); err != nil {
+						nukable, reason = false, err.Error()
+					}
+					collector.Emit(reporting.ResourceFound{
+						ResourceType: (*task.resource).ResourceName(),
+						Region:       task.region,
+						Identifier:   id,
+						Nukable:      nukable,
+						Reason:       reason,
+					})
+				}
+			}
+			return nil
+		})
+	}
+	if err := scanGroup.Wait(); err != nil {
+		return nil, err
+	}
+
+	// Sort resources within each region by original registry index to preserve
+	// the dependency ordering required for safe nuking (e.g. EC2 before VPCs).
+	for region, found := range foundByRegion {
+		slices.SortFunc(found, func(a, b indexedResource) int {
+			return cmp.Compare(a.idx, b.idx)
+		})
+		awsResources := AwsResources{Resources: make([]*resources.AwsResource, len(found))}
+		for i, r := range found {
+			awsResources.Resources[i] = r.resource
+		}
+		account.Resources[region] = awsResources
 	}
 
 	logging.Info("Done searching for resources")
@@ -180,7 +214,7 @@ func ListResourceTypes() []string {
 		resourceTypes = append(resourceTypes, (*resource).ResourceName())
 	}
 
-	sort.Strings(resourceTypes)
+	slices.Sort(resourceTypes)
 	return resourceTypes
 }
 
@@ -267,48 +301,64 @@ func nukeAllResourcesInRegion(ctx context.Context, account *AwsAccountResources,
 }
 
 // NukeAllResources - Nukes all aws resources
-func NukeAllResources(ctx context.Context, account *AwsAccountResources, regions []string, collector *reporting.Collector) error {
-	// Emit NukeStarted event (CLIRenderer will initialize progress bar)
-	collector.Emit(reporting.NukeStarted{Total: account.TotalResourceCount()})
+func NukeAllResources(ctx context.Context, account *AwsAccountResources, regions []string, parallelism int, collector *reporting.Collector) error {
+	// Inject parallelism into context so batch_deleter (called via Nuke) can read it.
+	ctx = context.WithValue(ctx, util.ParallelismKey, parallelism)
+	p := util.GetParallelism(ctx)
 
+	collector.Emit(reporting.NukeStarted{Total: account.TotalResourceCount()})
 	telemetry.TrackEvent(commonTelemetry.EventContext{
 		EventName: "Begin nuking resources",
 	}, map[string]interface{}{})
 
-	parallelism := util.GetParallelism(ctx)
-
 	var mu sync.Mutex
 	var allErrors *multierror.Error
 
-	g := new(errgroup.Group)
-	g.SetLimit(parallelism)
+	nukeRegion := func(region string) {
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Creating session for region",
+		}, map[string]interface{}{
+			"region": region,
+		})
 
-	for _, region := range regions {
-		g.Go(func() error {
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Creating session for region",
-			}, map[string]interface{}{
-				"region": region,
-			})
+		if err := nukeAllResourcesInRegion(ctx, account, region, collector); err != nil {
+			mu.Lock()
+			allErrors = multierror.Append(allErrors, err)
+			mu.Unlock()
+		}
 
-			if err := nukeAllResourcesInRegion(ctx, account, region, collector); err != nil {
-				mu.Lock()
-				allErrors = multierror.Append(allErrors, err)
-				mu.Unlock()
-			}
-
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Done Nuking Region",
-			}, map[string]interface{}{
-				"region":        region,
-				"resourceCount": len(account.Resources[region].Resources),
-			})
-			return nil
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Done Nuking Region",
+		}, map[string]interface{}{
+			"region":        region,
+			"resourceCount": len(account.Resources[region].Resources),
 		})
 	}
 
-	if err := g.Wait(); err != nil {
+	// Phase 1: nuke all regional resources in parallel. GlobalRegion is
+	// intentionally excluded here because global resources (IAM, S3, CloudFront,
+	// Route53) must be torn down after regional ones to avoid breaking in-flight
+	// regional deletions that still depend on them.
+	eg := new(errgroup.Group)
+	eg.SetLimit(p)
+	for _, region := range regions {
+		if region == GlobalRegion {
+			continue
+		}
+		eg.Go(func() error {
+			nukeRegion(region)
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
 		allErrors = multierror.Append(allErrors, err)
+	}
+
+	// Phase 2: nuke global resources after all regional nukes have completed.
+	for _, region := range regions {
+		if region == GlobalRegion {
+			nukeRegion(region)
+		}
 	}
 
 	// Emit NukeComplete event (triggers final output in renderers)

--- a/aws/query.go
+++ b/aws/query.go
@@ -19,6 +19,7 @@ type Query struct {
 	ExcludeFirstSeen     bool
 	DefaultOnly          bool
 	IncludeTags          map[string]config.Expression
+	Parallelism          int
 }
 
 // Validate ensures the configured values for a Query are valid, returning an error if there are

--- a/aws/query.go
+++ b/aws/query.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/gruntwork-io/cloud-nuke/config"
@@ -46,6 +47,10 @@ func (q *Query) Validate() error {
 	}
 
 	q.Regions = targetRegions
+
+	if q.Parallelism < 0 {
+		return fmt.Errorf("--parallelism must be >= 0 (0 uses the GOMAXPROCS default)")
+	}
 
 	return nil
 }

--- a/commands/aws_commands.go
+++ b/commands/aws_commands.go
@@ -1,14 +1,11 @@
 package commands
 
 import (
-	"context"
-
 	"github.com/gruntwork-io/cloud-nuke/aws"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/renderers"
 	"github.com/gruntwork-io/cloud-nuke/reporting"
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
 	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"github.com/urfave/cli/v2"
@@ -149,10 +146,8 @@ func awsNukeHelper(c *cli.Context, configObj config.Config, query *aws.Query, ou
 	// Emit scan started event with query parameters
 	collector.Emit(buildAwsScanStarted(query))
 
-	ctx := context.WithValue(c.Context, util.ParallelismKey, query.Parallelism)
-
 	// Retrieve all matching resources (emits ResourceFound events via collector)
-	account, err := aws.GetAllResources(ctx, query, configObj, collector)
+	account, err := aws.GetAllResources(c.Context, query, configObj, collector)
 	if err != nil {
 		telemetry.TrackEvent(commonTelemetry.EventContext{
 			EventName: "Error getting resources",
@@ -171,7 +166,7 @@ func awsNukeHelper(c *cli.Context, configObj config.Config, query *aws.Query, ou
 
 	// Execute the nuke operation if confirmed
 	if shouldProceed {
-		return aws.NukeAllResources(ctx, account, query.Regions, collector)
+		return aws.NukeAllResources(c.Context, account, query.Regions, query.Parallelism, collector)
 	}
 
 	return nil
@@ -244,10 +239,8 @@ func handleGetResourcesWithFormat(c *cli.Context, configObj config.Config, query
 	// Emit scan started event with query parameters
 	collector.Emit(buildAwsScanStarted(query))
 
-	ctx := context.WithValue(c.Context, util.ParallelismKey, query.Parallelism)
-
 	// Retrieve all resources matching the query (emits ResourceFound events via collector)
-	accountResources, err := aws.GetAllResources(ctx, query, configObj, collector)
+	accountResources, err := aws.GetAllResources(c.Context, query, configObj, collector)
 	if err != nil {
 		telemetry.TrackEvent(commonTelemetry.EventContext{
 			EventName: "Error inspecting resources",

--- a/commands/aws_commands.go
+++ b/commands/aws_commands.go
@@ -1,11 +1,14 @@
 package commands
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/cloud-nuke/aws"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/renderers"
 	"github.com/gruntwork-io/cloud-nuke/reporting"
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
 	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"github.com/urfave/cli/v2"
@@ -146,8 +149,10 @@ func awsNukeHelper(c *cli.Context, configObj config.Config, query *aws.Query, ou
 	// Emit scan started event with query parameters
 	collector.Emit(buildAwsScanStarted(query))
 
+	ctx := context.WithValue(c.Context, util.ParallelismKey, query.Parallelism)
+
 	// Retrieve all matching resources (emits ResourceFound events via collector)
-	account, err := aws.GetAllResources(c.Context, query, configObj, collector)
+	account, err := aws.GetAllResources(ctx, query, configObj, collector)
 	if err != nil {
 		telemetry.TrackEvent(commonTelemetry.EventContext{
 			EventName: "Error getting resources",
@@ -166,7 +171,7 @@ func awsNukeHelper(c *cli.Context, configObj config.Config, query *aws.Query, ou
 
 	// Execute the nuke operation if confirmed
 	if shouldProceed {
-		return aws.NukeAllResources(c.Context, account, query.Regions, collector)
+		return aws.NukeAllResources(ctx, account, query.Regions, collector)
 	}
 
 	return nil
@@ -217,6 +222,7 @@ func generateQuery(c *cli.Context, includeUnaliasedKmsKeys bool, overridingResou
 		DefaultOnly:          onlyDefault,
 		ExcludeFirstSeen:     c.Bool(FlagExcludeFirstSeen),
 		IncludeTags:          includeTags,
+		Parallelism:          c.Int(FlagParallelism),
 	}
 	if err := q.Validate(); err != nil {
 		return nil, err
@@ -238,8 +244,10 @@ func handleGetResourcesWithFormat(c *cli.Context, configObj config.Config, query
 	// Emit scan started event with query parameters
 	collector.Emit(buildAwsScanStarted(query))
 
+	ctx := context.WithValue(c.Context, util.ParallelismKey, query.Parallelism)
+
 	// Retrieve all resources matching the query (emits ResourceFound events via collector)
-	accountResources, err := aws.GetAllResources(c.Context, query, configObj, collector)
+	accountResources, err := aws.GetAllResources(ctx, query, configObj, collector)
 	if err != nil {
 		telemetry.TrackEvent(commonTelemetry.EventContext{
 			EventName: "Error inspecting resources",

--- a/commands/flags.go
+++ b/commands/flags.go
@@ -1,6 +1,10 @@
 package commands
 
-import "github.com/urfave/cli/v2"
+import (
+	"runtime"
+
+	"github.com/urfave/cli/v2"
+)
 
 // Default values
 const (
@@ -35,6 +39,7 @@ const (
 	FlagRegion                 = "region"
 	FlagExcludeRegion          = "exclude-region"
 	FlagIncludeTag             = "include-tag"
+	FlagParallelism            = "parallelism"
 )
 
 // Common flag sets for reuse across commands
@@ -105,6 +110,11 @@ func CommonExecutionFlags() []cli.Flag {
 		&cli.StringFlag{
 			Name:  FlagTimeout,
 			Usage: "Resource execution timeout.",
+		},
+		&cli.IntFlag{
+			Name:  FlagParallelism,
+			Value: runtime.GOMAXPROCS(0),
+			Usage: "Number of resources to delete concurrently. Defaults to the value of GOMAXPROCS.",
 		},
 	}
 }

--- a/commands/gcp_commands.go
+++ b/commands/gcp_commands.go
@@ -1,11 +1,14 @@
 package commands
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/gcp"
 	"github.com/gruntwork-io/cloud-nuke/renderers"
 	"github.com/gruntwork-io/cloud-nuke/reporting"
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
+	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
 	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"github.com/urfave/cli/v2"
@@ -43,6 +46,7 @@ func gcpNuke(c *cli.Context) error {
 		ResourceTypes:        c.StringSlice(FlagResourceType),
 		ExcludeResourceTypes: c.StringSlice(FlagExcludeResourceType),
 		ExcludeFirstSeen:     c.Bool(FlagExcludeFirstSeen),
+		Parallelism:          c.Int(FlagParallelism),
 	}
 
 	// Apply timeout to config
@@ -88,6 +92,7 @@ func gcpInspect(c *cli.Context) error {
 		ResourceTypes:        c.StringSlice(FlagResourceType),
 		ExcludeResourceTypes: c.StringSlice(FlagExcludeResourceType),
 		ExcludeFirstSeen:     c.Bool(FlagExcludeFirstSeen),
+		Parallelism:          c.Int(FlagParallelism),
 	}
 
 	// Load config file if provided
@@ -132,8 +137,10 @@ func gcpNukeHelper(c *cli.Context, configObj config.Config, query *gcp.Query, ou
 	}
 	defer cleanup()
 
+	ctx := context.WithValue(c.Context, util.ParallelismKey, query.Parallelism)
+
 	// Retrieve all matching resources (emits ResourceFound events via collector)
-	account, err := gcp.GetAllResources(c.Context, query, configObj, collector)
+	account, err := gcp.GetAllResources(ctx, query, configObj, collector)
 	if err != nil {
 		telemetry.TrackEvent(commonTelemetry.EventContext{
 			EventName: "Error getting resources",
@@ -152,7 +159,7 @@ func gcpNukeHelper(c *cli.Context, configObj config.Config, query *gcp.Query, ou
 
 	// Execute the nuke operation if confirmed
 	if shouldProceed {
-		if err := gcp.NukeAllResources(c.Context, account, query.Regions, collector); err != nil {
+		if err := gcp.NukeAllResources(ctx, account, query.Regions, collector); err != nil {
 			return err
 		}
 	}
@@ -171,8 +178,10 @@ func handleGetGcpResourcesWithFormat(c *cli.Context, configObj config.Config, qu
 	}
 	defer cleanup()
 
+	ctx := context.WithValue(c.Context, util.ParallelismKey, query.Parallelism)
+
 	// Retrieve all resources matching the filters (emits ResourceFound events via collector)
-	accountResources, err := gcp.GetAllResources(c.Context, query, configObj, collector)
+	accountResources, err := gcp.GetAllResources(ctx, query, configObj, collector)
 	if err != nil {
 		telemetry.TrackEvent(commonTelemetry.EventContext{
 			EventName: "Error inspecting resources",

--- a/commands/gcp_commands.go
+++ b/commands/gcp_commands.go
@@ -1,14 +1,11 @@
 package commands
 
 import (
-	"context"
-
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/gcp"
 	"github.com/gruntwork-io/cloud-nuke/renderers"
 	"github.com/gruntwork-io/cloud-nuke/reporting"
 	"github.com/gruntwork-io/cloud-nuke/telemetry"
-	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
 	commonTelemetry "github.com/gruntwork-io/go-commons/telemetry"
 	"github.com/urfave/cli/v2"
@@ -137,10 +134,8 @@ func gcpNukeHelper(c *cli.Context, configObj config.Config, query *gcp.Query, ou
 	}
 	defer cleanup()
 
-	ctx := context.WithValue(c.Context, util.ParallelismKey, query.Parallelism)
-
 	// Retrieve all matching resources (emits ResourceFound events via collector)
-	account, err := gcp.GetAllResources(ctx, query, configObj, collector)
+	account, err := gcp.GetAllResources(c.Context, query, configObj, collector)
 	if err != nil {
 		telemetry.TrackEvent(commonTelemetry.EventContext{
 			EventName: "Error getting resources",
@@ -159,7 +154,7 @@ func gcpNukeHelper(c *cli.Context, configObj config.Config, query *gcp.Query, ou
 
 	// Execute the nuke operation if confirmed
 	if shouldProceed {
-		if err := gcp.NukeAllResources(ctx, account, query.Regions, collector); err != nil {
+		if err := gcp.NukeAllResources(c.Context, account, query.Regions, query.Parallelism, collector); err != nil {
 			return err
 		}
 	}
@@ -178,10 +173,8 @@ func handleGetGcpResourcesWithFormat(c *cli.Context, configObj config.Config, qu
 	}
 	defer cleanup()
 
-	ctx := context.WithValue(c.Context, util.ParallelismKey, query.Parallelism)
-
 	// Retrieve all resources matching the filters (emits ResourceFound events via collector)
-	accountResources, err := gcp.GetAllResources(ctx, query, configObj, collector)
+	accountResources, err := gcp.GetAllResources(c.Context, query, configObj, collector)
 	if err != nil {
 		telemetry.TrackEvent(commonTelemetry.EventContext{
 			EventName: "Error inspecting resources",

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/gcp/resources"
@@ -41,62 +44,103 @@ func GetAllResources(ctx context.Context, query *Query, configObj config.Config,
 
 	ctx = context.WithValue(ctx, util.ExcludeFirstSeenTagKey, query.ExcludeFirstSeen)
 
+	parallelism := util.GetParallelism(ctx)
+
+	var allMu sync.Mutex
+	g := new(errgroup.Group)
+	g.SetLimit(parallelism)
+
 	for _, region := range query.Regions {
-		cfg := resources.GcpConfig{ProjectID: query.ProjectID, Region: region}
-		regionResources := GetAndInitRegisteredResources(cfg, region)
+		g.Go(func() error {
+			cfg := resources.GcpConfig{ProjectID: query.ProjectID, Region: region}
+			regionResources := GetAndInitRegisteredResources(cfg, region)
 
-		for _, res := range regionResources {
-			resourceName := (*res).ResourceName()
-
-			if !IsNukeable(resourceName, query.ResourceTypes, query.ExcludeResourceTypes) {
-				continue
+			type indexedResource struct {
+				idx int
+				res *GcpResource
 			}
+			found := make([]indexedResource, 0, len(regionResources))
+			var regionMu sync.Mutex
 
-			// Emit scan progress event
-			collector.Emit(reporting.ScanProgress{
-				ResourceType: resourceName,
-				Region:       region,
-			})
+			inner := new(errgroup.Group)
+			inner.SetLimit(parallelism)
 
-			// Get all resource identifiers
-			identifiers, err := (*res).GetAndSetIdentifiers(ctx, configObj)
-			if err != nil {
-				if isServiceDisabledError(err) && !collections.ListContainsElement(query.ResourceTypes, resourceName) {
-					logging.Debugf("Skipping %s: API is disabled in this project", resourceName)
+			for i, res := range regionResources {
+				resourceName := (*res).ResourceName()
+				if !IsNukeable(resourceName, query.ResourceTypes, query.ExcludeResourceTypes) {
 					continue
 				}
-				logging.Debugf("Error getting identifiers for %s: %v", resourceName, err)
-				collector.Emit(reporting.GeneralError{
-					ResourceType: resourceName,
-					Description:  fmt.Sprintf("Unable to retrieve %s", resourceName),
-					Error:        err.Error(),
-				})
-				continue
-			}
-
-			// Only append if we have non-empty identifiers
-			if len(identifiers) > 0 {
-				logging.Infof("Found %d %s resources", len(identifiers), resourceName)
-				allResources.Resources[region] = GcpResources{
-					Resources: append(allResources.Resources[region].Resources, res),
-				}
-
-				// Emit ResourceFound events for each identifier
-				for _, id := range identifiers {
-					nukable, reason := true, ""
-					if _, err := (*res).IsNukable(id); err != nil {
-						nukable, reason = false, err.Error()
-					}
-					collector.Emit(reporting.ResourceFound{
+				inner.Go(func() error {
+					collector.Emit(reporting.ScanProgress{
 						ResourceType: resourceName,
 						Region:       region,
-						Identifier:   id,
-						Nukable:      nukable,
-						Reason:       reason,
 					})
-				}
+
+					identifiers, err := (*res).GetAndSetIdentifiers(ctx, configObj)
+					if err != nil {
+						if isServiceDisabledError(err) && !collections.ListContainsElement(query.ResourceTypes, resourceName) {
+							logging.Debugf("Skipping %s: API is disabled in this project", resourceName)
+							return nil
+						}
+						logging.Debugf("Error getting identifiers for %s: %v", resourceName, err)
+						collector.Emit(reporting.GeneralError{
+							ResourceType: resourceName,
+							Description:  fmt.Sprintf("Unable to retrieve %s", resourceName),
+							Error:        err.Error(),
+						})
+						return nil
+					}
+
+					if len(identifiers) > 0 {
+						logging.Infof("Found %d %s resources", len(identifiers), resourceName)
+
+						regionMu.Lock()
+						found = append(found, indexedResource{idx: i, res: res})
+						regionMu.Unlock()
+
+						for _, id := range identifiers {
+							nukable, reason := true, ""
+							if _, err := (*res).IsNukable(id); err != nil {
+								nukable, reason = false, err.Error()
+							}
+							collector.Emit(reporting.ResourceFound{
+								ResourceType: resourceName,
+								Region:       region,
+								Identifier:   id,
+								Nukable:      nukable,
+								Reason:       reason,
+							})
+						}
+					}
+					return nil
+				})
 			}
-		}
+
+			if err := inner.Wait(); err != nil {
+				return err
+			}
+
+			if len(found) == 0 {
+				return nil
+			}
+
+			// Re-sort to preserve registry order for nuking.
+			sort.Slice(found, func(a, b int) bool { return found[a].idx < found[b].idx })
+			regionList := make([]*GcpResource, len(found))
+			for i, r := range found {
+				regionList[i] = r.res
+			}
+
+			allMu.Lock()
+			allResources.Resources[region] = GcpResources{Resources: regionList}
+			allMu.Unlock()
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	logging.Info("Done searching for GCP resources")
@@ -110,12 +154,27 @@ func NukeAllResources(ctx context.Context, account *GcpProjectResources, regions
 	// Emit NukeStarted event (CLIRenderer will initialize progress bar)
 	collector.Emit(reporting.NukeStarted{Total: account.TotalResourceCount()})
 
+	parallelism := util.GetParallelism(ctx)
+
+	var mu sync.Mutex
 	var allErrors *multierror.Error
 
+	g := new(errgroup.Group)
+	g.SetLimit(parallelism)
+
 	for _, region := range regions {
-		if err := nukeAllResourcesInRegion(ctx, account, region, collector); err != nil {
-			allErrors = multierror.Append(allErrors, err)
-		}
+		g.Go(func() error {
+			if err := nukeAllResourcesInRegion(ctx, account, region, collector); err != nil {
+				mu.Lock()
+				allErrors = multierror.Append(allErrors, err)
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		allErrors = multierror.Append(allErrors, err)
 	}
 
 	// Emit NukeComplete event (triggers final output in renderers)

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -1,9 +1,10 @@
 package gcp
 
 import (
+	"cmp"
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -43,104 +44,133 @@ func GetAllResources(ctx context.Context, query *Query, configObj config.Config,
 	}
 
 	ctx = context.WithValue(ctx, util.ExcludeFirstSeenTagKey, query.ExcludeFirstSeen)
-
+	// Inject parallelism from the query so downstream callers can read it via
+	// util.GetParallelism without needing the caller to set it on the context.
+	ctx = context.WithValue(ctx, util.ParallelismKey, query.Parallelism)
 	parallelism := util.GetParallelism(ctx)
 
-	var allMu sync.Mutex
-	g := new(errgroup.Group)
-	g.SetLimit(parallelism)
+	type indexedResource struct {
+		idx int
+		res *GcpResource
+	}
+	type regionSetup struct {
+		nukeable []indexedResource
+	}
 
+	// Phase 1: init resources for each region concurrently.
+	// GetAndInitRegisteredResources only allocates GCP clients (no API calls), so
+	// no concurrency limit is needed here.
+	setups := make(map[string]*regionSetup, len(query.Regions))
+	var setupMu sync.Mutex
+
+	setupGroup := new(errgroup.Group)
 	for _, region := range query.Regions {
-		g.Go(func() error {
+		setupGroup.Go(func() error {
 			cfg := resources.GcpConfig{ProjectID: query.ProjectID, Region: region}
 			regionResources := GetAndInitRegisteredResources(cfg, region)
-
-			type indexedResource struct {
-				idx int
-				res *GcpResource
-			}
-			found := make([]indexedResource, 0, len(regionResources))
-			var regionMu sync.Mutex
-
-			inner := new(errgroup.Group)
-			inner.SetLimit(parallelism)
-
+			setup := &regionSetup{}
 			for i, res := range regionResources {
 				resourceName := (*res).ResourceName()
-				if !IsNukeable(resourceName, query.ResourceTypes, query.ExcludeResourceTypes) {
-					continue
+				if IsNukeable(resourceName, query.ResourceTypes, query.ExcludeResourceTypes) {
+					setup.nukeable = append(setup.nukeable, indexedResource{idx: i, res: res})
 				}
-				inner.Go(func() error {
-					collector.Emit(reporting.ScanProgress{
-						ResourceType: resourceName,
-						Region:       region,
-					})
-
-					identifiers, err := (*res).GetAndSetIdentifiers(ctx, configObj)
-					if err != nil {
-						if isServiceDisabledError(err) && !collections.ListContainsElement(query.ResourceTypes, resourceName) {
-							logging.Debugf("Skipping %s: API is disabled in this project", resourceName)
-							return nil
-						}
-						logging.Debugf("Error getting identifiers for %s: %v", resourceName, err)
-						collector.Emit(reporting.GeneralError{
-							ResourceType: resourceName,
-							Description:  fmt.Sprintf("Unable to retrieve %s", resourceName),
-							Error:        err.Error(),
-						})
-						return nil
-					}
-
-					if len(identifiers) > 0 {
-						logging.Infof("Found %d %s resources", len(identifiers), resourceName)
-
-						regionMu.Lock()
-						found = append(found, indexedResource{idx: i, res: res})
-						regionMu.Unlock()
-
-						for _, id := range identifiers {
-							nukable, reason := true, ""
-							if _, err := (*res).IsNukable(id); err != nil {
-								nukable, reason = false, err.Error()
-							}
-							collector.Emit(reporting.ResourceFound{
-								ResourceType: resourceName,
-								Region:       region,
-								Identifier:   id,
-								Nukable:      nukable,
-								Reason:       reason,
-							})
-						}
-					}
-					return nil
-				})
 			}
-
-			if err := inner.Wait(); err != nil {
-				return err
-			}
-
-			if len(found) == 0 {
-				return nil
-			}
-
-			// Re-sort to preserve registry order for nuking.
-			sort.Slice(found, func(a, b int) bool { return found[a].idx < found[b].idx })
-			regionList := make([]*GcpResource, len(found))
-			for i, r := range found {
-				regionList[i] = r.res
-			}
-
-			allMu.Lock()
-			allResources.Resources[region] = GcpResources{Resources: regionList}
-			allMu.Unlock()
-
+			setupMu.Lock()
+			setups[region] = setup
+			setupMu.Unlock()
 			return nil
 		})
 	}
-
-	if err := g.Wait(); err != nil {
+	if err := setupGroup.Wait(); err != nil {
 		return nil, err
+	}
+
+	// Phase 2: scan all nukeable resources across all regions with a single shared
+	// concurrency limit. Using one errgroup (instead of nested per-region groups)
+	// ensures --parallelism N means at most N simultaneous API calls total.
+	type resourceTask struct {
+		region string
+		idx    int
+		res    *GcpResource
+	}
+	var allTasks []resourceTask
+	for _, region := range query.Regions {
+		setup, ok := setups[region]
+		if !ok {
+			continue
+		}
+		for _, r := range setup.nukeable {
+			allTasks = append(allTasks, resourceTask{region: region, idx: r.idx, res: r.res})
+		}
+	}
+
+	foundByRegion := make(map[string][]indexedResource)
+	var foundMu sync.Mutex
+
+	scanGroup := new(errgroup.Group)
+	scanGroup.SetLimit(parallelism)
+	for _, task := range allTasks {
+		scanGroup.Go(func() error {
+			resourceName := (*task.res).ResourceName()
+			collector.Emit(reporting.ScanProgress{
+				ResourceType: resourceName,
+				Region:       task.region,
+			})
+
+			identifiers, err := (*task.res).GetAndSetIdentifiers(ctx, configObj)
+			if err != nil {
+				if isServiceDisabledError(err) && !collections.ListContainsElement(query.ResourceTypes, resourceName) {
+					logging.Debugf("Skipping %s: API is disabled in this project", resourceName)
+					return nil
+				}
+				logging.Debugf("Error getting identifiers for %s: %v", resourceName, err)
+				collector.Emit(reporting.GeneralError{
+					ResourceType: resourceName,
+					Description:  fmt.Sprintf("Unable to retrieve %s", resourceName),
+					Error:        err.Error(),
+				})
+				return nil
+			}
+
+			if len(identifiers) > 0 {
+				logging.Infof("Found %d %s resources", len(identifiers), resourceName)
+
+				foundMu.Lock()
+				foundByRegion[task.region] = append(foundByRegion[task.region], indexedResource{task.idx, task.res})
+				foundMu.Unlock()
+
+				for _, id := range identifiers {
+					nukable, reason := true, ""
+					if _, err := (*task.res).IsNukable(id); err != nil {
+						nukable, reason = false, err.Error()
+					}
+					collector.Emit(reporting.ResourceFound{
+						ResourceType: resourceName,
+						Region:       task.region,
+						Identifier:   id,
+						Nukable:      nukable,
+						Reason:       reason,
+					})
+				}
+			}
+			return nil
+		})
+	}
+	if err := scanGroup.Wait(); err != nil {
+		return nil, err
+	}
+
+	// Sort resources within each region by original registry index to preserve
+	// the dependency ordering required for safe nuking.
+	for region, found := range foundByRegion {
+		slices.SortFunc(found, func(a, b indexedResource) int {
+			return cmp.Compare(a.idx, b.idx)
+		})
+		regionList := make([]*GcpResource, len(found))
+		for i, r := range found {
+			regionList[i] = r.res
+		}
+		allResources.Resources[region] = GcpResources{Resources: regionList}
 	}
 
 	logging.Info("Done searching for GCP resources")
@@ -150,20 +180,20 @@ func GetAllResources(ctx context.Context, query *Query, configObj config.Config,
 }
 
 // NukeAllResources nukes all GCP resources across the given regions.
-func NukeAllResources(ctx context.Context, account *GcpProjectResources, regions []string, collector *reporting.Collector) error {
-	// Emit NukeStarted event (CLIRenderer will initialize progress bar)
+func NukeAllResources(ctx context.Context, account *GcpProjectResources, regions []string, parallelism int, collector *reporting.Collector) error {
+	// Inject parallelism into context so batch_deleter (called via Nuke) can read it.
+	ctx = context.WithValue(ctx, util.ParallelismKey, parallelism)
+	p := util.GetParallelism(ctx)
+
 	collector.Emit(reporting.NukeStarted{Total: account.TotalResourceCount()})
 
-	parallelism := util.GetParallelism(ctx)
-
+	eg := new(errgroup.Group)
+	eg.SetLimit(p)
 	var mu sync.Mutex
 	var allErrors *multierror.Error
 
-	g := new(errgroup.Group)
-	g.SetLimit(parallelism)
-
 	for _, region := range regions {
-		g.Go(func() error {
+		eg.Go(func() error {
 			if err := nukeAllResourcesInRegion(ctx, account, region, collector); err != nil {
 				mu.Lock()
 				allErrors = multierror.Append(allErrors, err)
@@ -172,8 +202,7 @@ func NukeAllResources(ctx context.Context, account *GcpProjectResources, regions
 			return nil
 		})
 	}
-
-	if err := g.Wait(); err != nil {
+	if err := eg.Wait(); err != nil {
 		allErrors = multierror.Append(allErrors, err)
 	}
 
@@ -278,6 +307,6 @@ func ListResourceTypes() []string {
 	for _, r := range GetAllRegisteredResources() {
 		resourceTypes = append(resourceTypes, (*r).ResourceName())
 	}
-	sort.Strings(resourceTypes)
+	slices.Sort(resourceTypes)
 	return resourceTypes
 }

--- a/gcp/query.go
+++ b/gcp/query.go
@@ -44,5 +44,9 @@ func (q *Query) Validate() error {
 		return fmt.Errorf("no regions to process after applying exclusions")
 	}
 
+	if q.Parallelism < 0 {
+		return fmt.Errorf("--parallelism must be >= 0 (0 uses the GOMAXPROCS default)")
+	}
+
 	return nil
 }

--- a/gcp/query.go
+++ b/gcp/query.go
@@ -19,6 +19,7 @@ type Query struct {
 	IncludeAfter         *time.Time
 	Timeout              *time.Duration
 	ExcludeFirstSeen     bool
+	Parallelism          int
 }
 
 // Validate ensures the query has valid defaults.

--- a/resource/batch_deleter.go
+++ b/resource/batch_deleter.go
@@ -9,11 +9,6 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/util"
 )
 
-const (
-	// DefaultMaxConcurrent is the default number of concurrent deletions
-	DefaultMaxConcurrent = 10
-)
-
 // NukeResult represents the result of nuking a single resource.
 type NukeResult struct {
 	Identifier string

--- a/resource/batch_deleter.go
+++ b/resource/batch_deleter.go
@@ -39,7 +39,7 @@ func logStart(identifiers []*string, resourceType string, scope Scope) bool {
 }
 
 // SimpleBatchDeleter creates a nuker that deletes resources concurrently.
-// Uses DefaultMaxConcurrent for parallelism control.
+// Concurrency is controlled by the parallelism value in ctx (see util.GetParallelism).
 func SimpleBatchDeleter[C any](deleteFn DeleteFunc[C]) NukerFunc[C] {
 	return func(ctx context.Context, client C, scope Scope, resourceType string, identifiers []*string) []NukeResult {
 		if logStart(identifiers, resourceType, scope) {
@@ -47,7 +47,7 @@ func SimpleBatchDeleter[C any](deleteFn DeleteFunc[C]) NukerFunc[C] {
 		}
 
 		results := make([]NukeResult, len(identifiers))
-		sem := make(chan struct{}, DefaultMaxConcurrent)
+		sem := make(chan struct{}, util.GetParallelism(ctx))
 		var wg sync.WaitGroup
 		var mu sync.Mutex
 
@@ -252,7 +252,7 @@ func ConcurrentDeleteThenWaitAll[C any](deleteFn DeleteFunc[C], waitAllFn WaitAl
 			err   error
 		}
 		deleteResults := make([]deleteResult, len(identifiers))
-		sem := make(chan struct{}, DefaultMaxConcurrent)
+		sem := make(chan struct{}, util.GetParallelism(ctx))
 		var wg sync.WaitGroup
 
 		for i, id := range identifiers {

--- a/resource/batch_deleter_test.go
+++ b/resource/batch_deleter_test.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 
@@ -206,7 +207,7 @@ func TestSimpleBatchDeleter_Concurrency(t *testing.T) {
 		count.Add(1)
 		return nil
 	})
-	// 25 items exceeds DefaultMaxConcurrent to exercise semaphore
+	// 25 items exercises the semaphore under the default GOMAXPROCS-based concurrency limit
 	items := make([]*string, 25)
 	for i := range items {
 		s := "id-" + string(rune('a'+i))
@@ -215,6 +216,60 @@ func TestSimpleBatchDeleter_Concurrency(t *testing.T) {
 	results := deleter(ctx, client, scope, "test", items)
 	assert.Len(t, results, 25)
 	assert.Equal(t, int32(25), count.Load())
+}
+
+func TestSimpleBatchDeleter_RespectsParallelismLimit(t *testing.T) {
+	const limit = 3
+
+	var current, peak atomic.Int32
+	// ready signals that a worker has entered the delete function; buffered so
+	// workers never block on send.
+	ready := make(chan struct{}, limit+5)
+	// close release to unblock all in-flight workers at once.
+	release := make(chan struct{})
+
+	deleter := SimpleBatchDeleter(func(_ context.Context, _ *mockClient, _ *string) error {
+		n := current.Add(1)
+		for {
+			old := peak.Load()
+			if n <= old || peak.CompareAndSwap(old, n) {
+				break
+			}
+		}
+		ready <- struct{}{}
+		<-release
+		current.Add(-1)
+		return nil
+	})
+
+	items := make([]*string, limit+5)
+	for i := range items {
+		s := fmt.Sprintf("id-%d", i)
+		items[i] = &s
+	}
+
+	ctxWithP := context.WithValue(context.Background(), util.ParallelismKey, limit)
+	done := make(chan struct{})
+	go func() {
+		deleter(ctxWithP, client, scope, "test", items)
+		close(done)
+	}()
+
+	// Drain exactly `limit` ready signals. At this point the semaphore is full
+	// (main goroutine inside deleter is blocked on the next sem<-), so no
+	// additional goroutine can start.
+	for i := 0; i < limit; i++ {
+		<-ready
+	}
+	assert.Equal(t, int32(limit), peak.Load(), "peak concurrency must equal the limit")
+	select {
+	case <-ready:
+		t.Fatal("a goroutine started beyond the concurrency limit")
+	default:
+	}
+
+	close(release)
+	<-done
 }
 
 // Empty input tests — all NukerFunc types should return nil

--- a/util/context.go
+++ b/util/context.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"errors"
+	"runtime"
 )
 
 // ContextKey is a custom type to avoid collisions when using context.WithValue
@@ -10,6 +11,7 @@ type ContextKey string
 
 const (
 	ExcludeFirstSeenTagKey ContextKey = "exclude-first-seen-tag"
+	ParallelismKey         ContextKey = "parallelism"
 )
 
 func GetBoolFromContext(ctx context.Context, key ContextKey) (bool, error) {
@@ -19,4 +21,13 @@ func GetBoolFromContext(ctx context.Context, key ContextKey) (bool, error) {
 	}
 
 	return result, nil
+}
+
+// GetParallelism returns the parallelism value stored in ctx, falling back to
+// runtime.GOMAXPROCS(0) if none was set.
+func GetParallelism(ctx context.Context) int {
+	if v, ok := ctx.Value(ParallelismKey).(int); ok && v > 0 {
+		return v
+	}
+	return runtime.GOMAXPROCS(0)
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds `--parallelism` flag and parallelizes destroys where possible to get them sped up.

We were doing our destroys sequentially, which became unsustainably slow.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--parallelism` CLI flag to control concurrent resource deletions (defaults to system CPU count).
  * Enabled parallel resource scanning and deletion for both AWS and GCP providers.

* **Bug Fixes**
  * Improved resource discovery concurrency and ordering consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->