### PR TITLE
Review fixes for parallelism (#1144)

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -45,126 +45,132 @@ func GetAllResources(c context.Context, query *Query, configObj config.Config, c
 
 	parallelism := util.GetParallelism(c)
 
-	var accountMu sync.Mutex
+	// Build per-region sessions and registered resources up front (sequential and
+	// cheap). The account ID is identical across all regions, so it is fetched
+	// once here and stored on the context, avoiding a data race on the telemetry
+	// package global that concurrent per-region writes would otherwise cause.
+	type regionWork struct {
+		region    string
+		resources []*resources.AwsResource
+	}
+	var regionWorks []regionWork
+	accountIDFetched := false
+	for _, region := range query.Regions {
+		cloudNukeSession, errSession := NewSession(region)
+		if errSession != nil {
+			return nil, errSession
+		}
+
+		if !accountIDFetched {
+			if accountId, err := util.GetCurrentAccountId(cloudNukeSession); err == nil {
+				telemetry.SetAccountId(accountId)
+				c = context.WithValue(c, util.AccountIdKey, accountId)
+				accountIDFetched = true
+			}
+		}
+
+		regionWorks = append(regionWorks, regionWork{
+			region:    region,
+			resources: GetAndInitRegisteredResources(cloudNukeSession, region),
+		})
+	}
+
+	// Scan every (region, resource type) pair concurrently under a single global
+	// concurrency cap, so total in-flight API calls are bounded by `parallelism`
+	// (not parallelism^2 as nested per-region/per-type limits would produce).
+	type indexedResource struct {
+		idx      int
+		resource *resources.AwsResource
+	}
+	foundByRegion := make(map[string][]indexedResource)
+	var foundMu sync.Mutex
+
 	g := new(errgroup.Group)
 	g.SetLimit(parallelism)
 
-	for _, region := range query.Regions {
-		g.Go(func() error {
-			cloudNukeSession, errSession := NewSession(region)
-			if errSession != nil {
-				return errSession
+	for _, rw := range regionWorks {
+		region := rw.region
+		for i, resource := range rw.resources {
+			if !IsNukeable((*resource).ResourceName(), query.ResourceTypes) {
+				continue
 			}
+			idx, resource := i, resource
+			g.Go(func() error {
+				(*resource).GetAndSetResourceConfig(configObj)
 
-			regionCtx := c
-			accountId, err := util.GetCurrentAccountId(cloudNukeSession)
-			if err == nil {
-				telemetry.SetAccountId(accountId)
-				regionCtx = context.WithValue(c, util.AccountIdKey, accountId)
-			}
+				collector.Emit(reporting.ScanProgress{
+					ResourceType: (*resource).ResourceName(),
+					Region:       region,
+				})
 
-			registeredResources := GetAndInitRegisteredResources(cloudNukeSession, region)
-
-			// Collect resources for this region; preserve registry order for nuking later.
-			// We list all types concurrently then reassemble in original order.
-			type indexedResource struct {
-				idx      int
-				resource *resources.AwsResource
-			}
-			found := make([]indexedResource, 0, len(registeredResources))
-			var regionMu sync.Mutex
-
-			inner := new(errgroup.Group)
-			inner.SetLimit(parallelism)
-
-			for i, resource := range registeredResources {
-				if !IsNukeable((*resource).ResourceName(), query.ResourceTypes) {
-					continue
-				}
-				inner.Go(func() error {
-					(*resource).GetAndSetResourceConfig(configObj)
-
-					collector.Emit(reporting.ScanProgress{
-						ResourceType: (*resource).ResourceName(),
-						Region:       region,
-					})
-
-					start := time.Now()
-					identifiers, err := (*resource).GetAndSetIdentifiers(regionCtx, configObj)
-					if err != nil {
-						logging.Errorf("Unable to retrieve %v, %v", (*resource).ResourceName(), err)
-
-						telemetry.TrackEvent(commonTelemetry.EventContext{
-							EventName: fmt.Sprintf("error:GetIdentifiers:%s", (*resource).ResourceName()),
-						}, map[string]interface{}{
-							"region": region,
-						})
-
-						collector.Emit(reporting.GeneralError{
-							ResourceType: (*resource).ResourceName(),
-							Description:  fmt.Sprintf("Unable to retrieve %s", (*resource).ResourceName()),
-							Error:        err.Error(),
-						})
-						return nil
-					}
+				start := time.Now()
+				identifiers, err := (*resource).GetAndSetIdentifiers(c, configObj)
+				if err != nil {
+					logging.Errorf("Unable to retrieve %v, %v", (*resource).ResourceName(), err)
 
 					telemetry.TrackEvent(commonTelemetry.EventContext{
-						EventName: fmt.Sprintf("Done getting %s identifiers", (*resource).ResourceName()),
+						EventName: fmt.Sprintf("error:GetIdentifiers:%s", (*resource).ResourceName()),
 					}, map[string]interface{}{
-						"recordCount": len(identifiers),
-						"actionTime":  time.Since(start).Seconds(),
+						"region": region,
 					})
 
-					if len(identifiers) > 0 {
-						logging.Infof("Found %d %s resources in %s", len(identifiers), (*resource).ResourceName(), region)
-
-						regionMu.Lock()
-						found = append(found, indexedResource{idx: i, resource: resource})
-						regionMu.Unlock()
-
-						for _, id := range identifiers {
-							nukable, reason := true, ""
-							if _, err := (*resource).IsNukable(id); err != nil {
-								nukable, reason = false, err.Error()
-							}
-							collector.Emit(reporting.ResourceFound{
-								ResourceType: (*resource).ResourceName(),
-								Region:       region,
-								Identifier:   id,
-								Nukable:      nukable,
-								Reason:       reason,
-							})
-						}
-					}
+					collector.Emit(reporting.GeneralError{
+						ResourceType: (*resource).ResourceName(),
+						Description:  fmt.Sprintf("Unable to retrieve %s", (*resource).ResourceName()),
+						Error:        err.Error(),
+					})
 					return nil
+				}
+
+				telemetry.TrackEvent(commonTelemetry.EventContext{
+					EventName: fmt.Sprintf("Done getting %s identifiers", (*resource).ResourceName()),
+				}, map[string]interface{}{
+					"recordCount": len(identifiers),
+					"actionTime":  time.Since(start).Seconds(),
 				})
-			}
 
-			if err := inner.Wait(); err != nil {
-				return err
-			}
+				if len(identifiers) > 0 {
+					logging.Infof("Found %d %s resources in %s", len(identifiers), (*resource).ResourceName(), region)
 
-			if len(found) == 0 {
+					foundMu.Lock()
+					foundByRegion[region] = append(foundByRegion[region], indexedResource{idx: idx, resource: resource})
+					foundMu.Unlock()
+
+					for _, id := range identifiers {
+						nukable, reason := true, ""
+						if _, err := (*resource).IsNukable(id); err != nil {
+							nukable, reason = false, err.Error()
+						}
+						collector.Emit(reporting.ResourceFound{
+							ResourceType: (*resource).ResourceName(),
+							Region:       region,
+							Identifier:   id,
+							Nukable:      nukable,
+							Reason:       reason,
+						})
+					}
+				}
 				return nil
-			}
-
-			// Re-sort by original registry index so nuking respects dependency order.
-			sort.Slice(found, func(a, b int) bool { return found[a].idx < found[b].idx })
-			awsResources := AwsResources{Resources: make([]*resources.AwsResource, len(found))}
-			for i, r := range found {
-				awsResources.Resources[i] = r.resource
-			}
-
-			accountMu.Lock()
-			account.Resources[region] = awsResources
-			accountMu.Unlock()
-
-			return nil
-		})
+			})
+		}
 	}
 
 	if err := g.Wait(); err != nil {
 		return nil, err
+	}
+
+	// Reassemble each region's resources in registry order so that nuking respects
+	// dependency order (e.g. instances/ENIs/NAT before VPC).
+	for region, found := range foundByRegion {
+		if len(found) == 0 {
+			continue
+		}
+		sort.Slice(found, func(a, b int) bool { return found[a].idx < found[b].idx })
+		awsResources := AwsResources{Resources: make([]*resources.AwsResource, len(found))}
+		for i, r := range found {
+			awsResources.Resources[i] = r.resource
+		}
+		account.Resources[region] = awsResources
 	}
 
 	logging.Info("Done searching for resources")
@@ -280,35 +286,61 @@ func NukeAllResources(ctx context.Context, account *AwsAccountResources, regions
 	var mu sync.Mutex
 	var allErrors *multierror.Error
 
+	// Regional resources are independent across regions and safe to nuke
+	// concurrently. The `global` pseudo-region (IAM, Route53, CloudFront, etc.)
+	// must be nuked AFTER all regional resources, because regional resources can
+	// depend on global ones (e.g. an EC2 instance using a global IAM instance
+	// profile, or a regional RDS global-cluster membership belonging to a global
+	// cluster). Running it concurrently would risk dependency-violation errors.
+	regionalRegions := make([]string, 0, len(regions))
+	hasGlobal := false
+	for _, region := range regions {
+		if region == GlobalRegion {
+			hasGlobal = true
+			continue
+		}
+		regionalRegions = append(regionalRegions, region)
+	}
+
+	nukeRegion := func(region string) {
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Creating session for region",
+		}, map[string]interface{}{
+			"region": region,
+		})
+
+		if err := nukeAllResourcesInRegion(ctx, account, region, collector); err != nil {
+			mu.Lock()
+			allErrors = multierror.Append(allErrors, err)
+			mu.Unlock()
+		}
+
+		telemetry.TrackEvent(commonTelemetry.EventContext{
+			EventName: "Done Nuking Region",
+		}, map[string]interface{}{
+			"region":        region,
+			"resourceCount": len(account.Resources[region].Resources),
+		})
+	}
+
 	g := new(errgroup.Group)
 	g.SetLimit(parallelism)
 
-	for _, region := range regions {
+	for _, region := range regionalRegions {
+		region := region
 		g.Go(func() error {
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Creating session for region",
-			}, map[string]interface{}{
-				"region": region,
-			})
-
-			if err := nukeAllResourcesInRegion(ctx, account, region, collector); err != nil {
-				mu.Lock()
-				allErrors = multierror.Append(allErrors, err)
-				mu.Unlock()
-			}
-
-			telemetry.TrackEvent(commonTelemetry.EventContext{
-				EventName: "Done Nuking Region",
-			}, map[string]interface{}{
-				"region":        region,
-				"resourceCount": len(account.Resources[region].Resources),
-			})
+			nukeRegion(region)
 			return nil
 		})
 	}
 
 	if err := g.Wait(); err != nil {
 		allErrors = multierror.Append(allErrors, err)
+	}
+
+	// Nuke global resources last, after every regional resource is gone.
+	if hasGlobal {
+		nukeRegion(GlobalRegion)
 	}
 
 	// Emit NukeComplete event (triggers final output in renderers)

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -93,6 +93,7 @@ func CreateCli(version string) *cli.App {
 				CommonTimeFlags(),
 				CommonOutputFlags(),
 				[]cli.Flag{
+					ParallelismFlag(),
 					ConfigFlag(),
 					&cli.BoolFlag{
 						Name:  FlagExcludeFirstSeen,
@@ -138,6 +139,7 @@ func CreateCli(version string) *cli.App {
 				TagFlags(),
 				CommonOutputFlags(),
 				[]cli.Flag{
+					ParallelismFlag(),
 					ConfigFlag(),
 					&cli.BoolFlag{
 						Name:  FlagListUnaliasedKMSKeys,

--- a/commands/flags.go
+++ b/commands/flags.go
@@ -1,8 +1,7 @@
 package commands
 
 import (
-	"runtime"
-
+	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/urfave/cli/v2"
 )
 
@@ -111,11 +110,17 @@ func CommonExecutionFlags() []cli.Flag {
 			Name:  FlagTimeout,
 			Usage: "Resource execution timeout.",
 		},
-		&cli.IntFlag{
-			Name:  FlagParallelism,
-			Value: runtime.GOMAXPROCS(0),
-			Usage: "Number of resources to delete concurrently. Defaults to the value of GOMAXPROCS.",
-		},
+		ParallelismFlag(),
+	}
+}
+
+// ParallelismFlag controls how many regions/resources are scanned and deleted
+// concurrently. The work is IO-bound, so the default is independent of CPU count.
+func ParallelismFlag() cli.Flag {
+	return &cli.IntFlag{
+		Name:  FlagParallelism,
+		Value: util.DefaultParallelism,
+		Usage: "Number of regions/resources to scan and delete concurrently. The work is IO-bound, so this is independent of CPU count.",
 	}
 }
 

--- a/externalcreds/creds.go
+++ b/externalcreds/creds.go
@@ -26,8 +26,13 @@ func Get(region string) (aws.Config, error) {
 		return configProvider(region)
 	}
 
+	// Use adaptive retry so that the higher API-call concurrency from parallel
+	// scanning/nuking is absorbed by client-side rate limiting and backoff rather
+	// than surfacing as throttling errors (which would silently skip resources).
 	cfg, err := config.LoadDefaultConfig(context.TODO(),
 		config.WithRegion(region),
+		config.WithRetryMode(aws.RetryModeAdaptive),
+		config.WithRetryMaxAttempts(10),
 	)
 
 	if err != nil {

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -46,101 +46,92 @@ func GetAllResources(ctx context.Context, query *Query, configObj config.Config,
 
 	parallelism := util.GetParallelism(ctx)
 
-	var allMu sync.Mutex
+	// Scan every (region, resource type) pair concurrently under a single global
+	// concurrency cap, so total in-flight API calls are bounded by `parallelism`
+	// rather than parallelism^2 (which nested per-region/per-type limits produced).
+	type indexedResource struct {
+		idx int
+		res *GcpResource
+	}
+	foundByRegion := make(map[string][]indexedResource)
+	var foundMu sync.Mutex
+
 	g := new(errgroup.Group)
 	g.SetLimit(parallelism)
 
 	for _, region := range query.Regions {
-		g.Go(func() error {
-			cfg := resources.GcpConfig{ProjectID: query.ProjectID, Region: region}
-			regionResources := GetAndInitRegisteredResources(cfg, region)
-
-			type indexedResource struct {
-				idx int
-				res *GcpResource
+		region := region
+		cfg := resources.GcpConfig{ProjectID: query.ProjectID, Region: region}
+		regionResources := GetAndInitRegisteredResources(cfg, region)
+		for i, res := range regionResources {
+			resourceName := (*res).ResourceName()
+			if !IsNukeable(resourceName, query.ResourceTypes, query.ExcludeResourceTypes) {
+				continue
 			}
-			found := make([]indexedResource, 0, len(regionResources))
-			var regionMu sync.Mutex
+			idx, res := i, res
+			g.Go(func() error {
+				collector.Emit(reporting.ScanProgress{
+					ResourceType: resourceName,
+					Region:       region,
+				})
 
-			inner := new(errgroup.Group)
-			inner.SetLimit(parallelism)
-
-			for i, res := range regionResources {
-				resourceName := (*res).ResourceName()
-				if !IsNukeable(resourceName, query.ResourceTypes, query.ExcludeResourceTypes) {
-					continue
-				}
-				inner.Go(func() error {
-					collector.Emit(reporting.ScanProgress{
-						ResourceType: resourceName,
-						Region:       region,
-					})
-
-					identifiers, err := (*res).GetAndSetIdentifiers(ctx, configObj)
-					if err != nil {
-						if isServiceDisabledError(err) && !collections.ListContainsElement(query.ResourceTypes, resourceName) {
-							logging.Debugf("Skipping %s: API is disabled in this project", resourceName)
-							return nil
-						}
-						logging.Debugf("Error getting identifiers for %s: %v", resourceName, err)
-						collector.Emit(reporting.GeneralError{
-							ResourceType: resourceName,
-							Description:  fmt.Sprintf("Unable to retrieve %s", resourceName),
-							Error:        err.Error(),
-						})
+				identifiers, err := (*res).GetAndSetIdentifiers(ctx, configObj)
+				if err != nil {
+					if isServiceDisabledError(err) && !collections.ListContainsElement(query.ResourceTypes, resourceName) {
+						logging.Debugf("Skipping %s: API is disabled in this project", resourceName)
 						return nil
 					}
-
-					if len(identifiers) > 0 {
-						logging.Infof("Found %d %s resources", len(identifiers), resourceName)
-
-						regionMu.Lock()
-						found = append(found, indexedResource{idx: i, res: res})
-						regionMu.Unlock()
-
-						for _, id := range identifiers {
-							nukable, reason := true, ""
-							if _, err := (*res).IsNukable(id); err != nil {
-								nukable, reason = false, err.Error()
-							}
-							collector.Emit(reporting.ResourceFound{
-								ResourceType: resourceName,
-								Region:       region,
-								Identifier:   id,
-								Nukable:      nukable,
-								Reason:       reason,
-							})
-						}
-					}
+					logging.Debugf("Error getting identifiers for %s: %v", resourceName, err)
+					collector.Emit(reporting.GeneralError{
+						ResourceType: resourceName,
+						Description:  fmt.Sprintf("Unable to retrieve %s", resourceName),
+						Error:        err.Error(),
+					})
 					return nil
-				})
-			}
+				}
 
-			if err := inner.Wait(); err != nil {
-				return err
-			}
+				if len(identifiers) > 0 {
+					logging.Infof("Found %d %s resources", len(identifiers), resourceName)
 
-			if len(found) == 0 {
+					foundMu.Lock()
+					foundByRegion[region] = append(foundByRegion[region], indexedResource{idx: idx, res: res})
+					foundMu.Unlock()
+
+					for _, id := range identifiers {
+						nukable, reason := true, ""
+						if _, err := (*res).IsNukable(id); err != nil {
+							nukable, reason = false, err.Error()
+						}
+						collector.Emit(reporting.ResourceFound{
+							ResourceType: resourceName,
+							Region:       region,
+							Identifier:   id,
+							Nukable:      nukable,
+							Reason:       reason,
+						})
+					}
+				}
 				return nil
-			}
-
-			// Re-sort to preserve registry order for nuking.
-			sort.Slice(found, func(a, b int) bool { return found[a].idx < found[b].idx })
-			regionList := make([]*GcpResource, len(found))
-			for i, r := range found {
-				regionList[i] = r.res
-			}
-
-			allMu.Lock()
-			allResources.Resources[region] = GcpResources{Resources: regionList}
-			allMu.Unlock()
-
-			return nil
-		})
+			})
+		}
 	}
 
 	if err := g.Wait(); err != nil {
 		return nil, err
+	}
+
+	// Reassemble each region's resources in registry order to preserve dependency
+	// order for nuking.
+	for region, found := range foundByRegion {
+		if len(found) == 0 {
+			continue
+		}
+		sort.Slice(found, func(a, b int) bool { return found[a].idx < found[b].idx })
+		regionList := make([]*GcpResource, len(found))
+		for i, r := range found {
+			regionList[i] = r.res
+		}
+		allResources.Resources[region] = GcpResources{Resources: regionList}
 	}
 
 	logging.Info("Done searching for GCP resources")
@@ -159,10 +150,23 @@ func NukeAllResources(ctx context.Context, account *GcpProjectResources, regions
 	var mu sync.Mutex
 	var allErrors *multierror.Error
 
+	// Nuke regional resources concurrently, then the `global` pseudo-region last,
+	// since regional resources may depend on global ones.
+	regionalRegions := make([]string, 0, len(regions))
+	hasGlobal := false
+	for _, region := range regions {
+		if region == GlobalRegion {
+			hasGlobal = true
+			continue
+		}
+		regionalRegions = append(regionalRegions, region)
+	}
+
 	g := new(errgroup.Group)
 	g.SetLimit(parallelism)
 
-	for _, region := range regions {
+	for _, region := range regionalRegions {
+		region := region
 		g.Go(func() error {
 			if err := nukeAllResourcesInRegion(ctx, account, region, collector); err != nil {
 				mu.Lock()
@@ -175,6 +179,12 @@ func NukeAllResources(ctx context.Context, account *GcpProjectResources, regions
 
 	if err := g.Wait(); err != nil {
 		allErrors = multierror.Append(allErrors, err)
+	}
+
+	if hasGlobal {
+		if err := nukeAllResourcesInRegion(ctx, account, GlobalRegion, collector); err != nil {
+			allErrors = multierror.Append(allErrors, err)
+		}
 	}
 
 	// Emit NukeComplete event (triggers final output in renderers)

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/sirupsen/logrus v1.8.3
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.10.3
+	golang.org/x/sync v0.19.0
 	google.golang.org/api v0.247.0
 	google.golang.org/genproto v0.0.0-20250603155806-513f23925822
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217
@@ -151,7 +152,6 @@ require (
 	golang.org/x/exp v0.0.0-20221106115401-f9659909a136 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/term v0.38.0 // indirect
 	golang.org/x/text v0.32.0 // indirect

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gruntwork-io/cloud-nuke/config"
@@ -174,9 +175,11 @@ func TestResource_IsNukable(t *testing.T) {
 // Batch Deleter Tests
 
 func TestSimpleBatchDeleter(t *testing.T) {
-	deleteCount := 0
+	// SimpleBatchDeleter invokes deleteFn concurrently, so the mock must use a
+	// thread-safe counter.
+	var deleteCount atomic.Int64
 	deleter := SimpleBatchDeleter(func(ctx context.Context, client *mockClient, id *string) error {
-		deleteCount++
+		deleteCount.Add(1)
 		return nil
 	})
 
@@ -187,7 +190,7 @@ func TestSimpleBatchDeleter(t *testing.T) {
 	for _, result := range results {
 		assert.NoError(t, result.Error)
 	}
-	assert.Equal(t, 3, deleteCount)
+	assert.Equal(t, int64(3), deleteCount.Load())
 }
 
 func TestSequentialDeleter(t *testing.T) {

--- a/util/context.go
+++ b/util/context.go
@@ -3,7 +3,6 @@ package util
 import (
 	"context"
 	"errors"
-	"runtime"
 )
 
 // ContextKey is a custom type to avoid collisions when using context.WithValue
@@ -13,6 +12,13 @@ const (
 	ExcludeFirstSeenTagKey ContextKey = "exclude-first-seen-tag"
 	ParallelismKey         ContextKey = "parallelism"
 )
+
+// DefaultParallelism is the default number of concurrent scan/delete operations
+// when --parallelism is not set. The work is IO-bound (AWS/GCP API calls), so
+// this is intentionally a fixed value rather than being derived from CPU count
+// (GOMAXPROCS), which on container runners reflects the CPU quota, not the
+// concurrency this workload can usefully sustain.
+const DefaultParallelism = 10
 
 func GetBoolFromContext(ctx context.Context, key ContextKey) (bool, error) {
 	result, ok := ctx.Value(key).(bool)
@@ -24,10 +30,10 @@ func GetBoolFromContext(ctx context.Context, key ContextKey) (bool, error) {
 }
 
 // GetParallelism returns the parallelism value stored in ctx, falling back to
-// runtime.GOMAXPROCS(0) if none was set.
+// DefaultParallelism if none was set.
 func GetParallelism(ctx context.Context) int {
 	if v, ok := ctx.Value(ParallelismKey).(int); ok && v > 0 {
 		return v
 	}
-	return runtime.GOMAXPROCS(0)
+	return DefaultParallelism
 }


### PR DESCRIPTION
Stacked on top of #1144. Addresses the review points, verified against phxdevops.

What changed:
1. Default `--parallelism` is a fixed 10, not `GOMAXPROCS`. On container runners GOMAXPROCS reflects the CPU quota (measured 2 on a CircleCI `small`), not the IO concurrency this workload can use. Also exposes the flag on `inspect-aws` / `inspect-gcp`.
2. Single global concurrency cap. The scan now runs one errgroup over (region, type) instead of nested per-region and per-type limits, which multiplied to parallelism squared. Total in-flight calls are now bounded by `--parallelism`.
3. Adaptive retry. Adds `RetryModeAdaptive` + higher max attempts so the extra concurrency is absorbed by client-side rate limiting instead of surfacing as throttling errors (a throttled list silently skips that resource type).
4. Global nuked last. Regional regions nuke concurrently, then the `global` pseudo-region, preserving cross-region and global dependency order (IAM, RDS global clusters, peering). Within-region order was already preserved by the registry-index re-sort.
5. Telemetry race fix. Account ID is fetched once before the scan instead of from each region goroutine.
6. Made `TestSimpleBatchDeleter` thread-safe so `go test -race` passes.

Verification (read-only `inspect-aws` against phxdevops, 3 regions):

| parallelism | time | resources found | throttling |
|---|---|---|---|
| 1 | 255s | 88 | 0 |
| 10 | 53s | 88 | 0 |
| 20 | 53s | 88 | 0 |

~4.8x faster, identical results, no throttling. `go test -race` green on util/resource/commands/externalcreds. Nuke `global`-last validated by code and unit tests, not by a destructive run.

Ref: OSS-3751
