### PR TITLE
fix: treat fast-deleting service-linked roles as success on NoSuchEntity

### DIFF
--- a/aws/resources/iam_service_linked_role.go
+++ b/aws/resources/iam_service_linked_role.go
@@ -94,15 +94,24 @@ func deleteIAMServiceLinkedRole(ctx context.Context, client IAMServiceLinkedRole
 				// record is purged before we poll for its status, yielding a
 				// NoSuchEntity (404) error. That alone does not confirm the role is
 				// gone (the task ID could be invalid for other reasons), so verify the
-				// role itself no longer exists before reporting success.
+				// role itself via GetRole before reporting success.
 				var notFoundErr *types.NoSuchEntityException
 				if goerr.As(err, &notFoundErr) {
 					_, roleErr := client.GetRole(ctx, &iam.GetRoleInput{
 						RoleName: roleName,
 					})
 					var roleNotFound *types.NoSuchEntityException
-					if goerr.As(roleErr, &roleNotFound) {
+					switch {
+					case goerr.As(roleErr, &roleNotFound):
+						// Role is gone: deletion succeeded and AWS purged the task record.
 						return true, nil
+					case roleErr != nil:
+						// Could not confirm the role's state; surface the verification
+						// error rather than masking it with the task-not-found error.
+						return false, errors.WithStackTrace(roleErr)
+					default:
+						// Role still exists: the task record is missing but the role was not deleted.
+						return false, fmt.Errorf("deletion task for IAM ServiceLinked Role %s no longer exists but the role is still present", aws.ToString(roleName))
 					}
 				}
 				return false, errors.WithStackTrace(err)

--- a/aws/resources/iam_service_linked_role.go
+++ b/aws/resources/iam_service_linked_role.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	goerr "errors"
 	"fmt"
 	"strings"
 	"time"
@@ -19,6 +20,7 @@ import (
 // IAMServiceLinkedRolesAPI defines the interface for IAM Service Linked Role operations.
 type IAMServiceLinkedRolesAPI interface {
 	ListRoles(ctx context.Context, params *iam.ListRolesInput, optFns ...func(*iam.Options)) (*iam.ListRolesOutput, error)
+	GetRole(ctx context.Context, params *iam.GetRoleInput, optFns ...func(*iam.Options)) (*iam.GetRoleOutput, error)
 	DeleteServiceLinkedRole(ctx context.Context, params *iam.DeleteServiceLinkedRoleInput, optFns ...func(*iam.Options)) (*iam.DeleteServiceLinkedRoleOutput, error)
 	GetServiceLinkedRoleDeletionStatus(ctx context.Context, params *iam.GetServiceLinkedRoleDeletionStatusInput, optFns ...func(*iam.Options)) (*iam.GetServiceLinkedRoleDeletionStatusOutput, error)
 }
@@ -88,6 +90,21 @@ func deleteIAMServiceLinkedRole(ctx context.Context, client IAMServiceLinkedRole
 				DeletionTaskId: deletionData.DeletionTaskId,
 			})
 			if err != nil {
+				// Some roles delete so quickly on the AWS side that the deletion task
+				// record is purged before we poll for its status, yielding a
+				// NoSuchEntity (404) error. That alone does not confirm the role is
+				// gone (the task ID could be invalid for other reasons), so verify the
+				// role itself no longer exists before reporting success.
+				var notFoundErr *types.NoSuchEntityException
+				if goerr.As(err, &notFoundErr) {
+					_, roleErr := client.GetRole(ctx, &iam.GetRoleInput{
+						RoleName: roleName,
+					})
+					var roleNotFound *types.NoSuchEntityException
+					if goerr.As(roleErr, &roleNotFound) {
+						return true, nil
+					}
+				}
 				return false, errors.WithStackTrace(err)
 			}
 

--- a/aws/resources/iam_service_linked_role_test.go
+++ b/aws/resources/iam_service_linked_role_test.go
@@ -18,10 +18,17 @@ type mockedIAMServiceLinkedRoles struct {
 	ListRolesOutput                          iam.ListRolesOutput
 	DeleteServiceLinkedRoleOutput            iam.DeleteServiceLinkedRoleOutput
 	GetServiceLinkedRoleDeletionStatusOutput iam.GetServiceLinkedRoleDeletionStatusOutput
+	GetServiceLinkedRoleDeletionStatusErr    error
+	GetRoleOutput                            iam.GetRoleOutput
+	GetRoleErr                               error
 }
 
 func (m mockedIAMServiceLinkedRoles) ListRoles(ctx context.Context, params *iam.ListRolesInput, optFns ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
 	return &m.ListRolesOutput, nil
+}
+
+func (m mockedIAMServiceLinkedRoles) GetRole(ctx context.Context, params *iam.GetRoleInput, optFns ...func(*iam.Options)) (*iam.GetRoleOutput, error) {
+	return &m.GetRoleOutput, m.GetRoleErr
 }
 
 func (m mockedIAMServiceLinkedRoles) DeleteServiceLinkedRole(ctx context.Context, params *iam.DeleteServiceLinkedRoleInput, optFns ...func(*iam.Options)) (*iam.DeleteServiceLinkedRoleOutput, error) {
@@ -29,7 +36,7 @@ func (m mockedIAMServiceLinkedRoles) DeleteServiceLinkedRole(ctx context.Context
 }
 
 func (m mockedIAMServiceLinkedRoles) GetServiceLinkedRoleDeletionStatus(ctx context.Context, params *iam.GetServiceLinkedRoleDeletionStatusInput, optFns ...func(*iam.Options)) (*iam.GetServiceLinkedRoleDeletionStatusOutput, error) {
-	return &m.GetServiceLinkedRoleDeletionStatusOutput, nil
+	return &m.GetServiceLinkedRoleDeletionStatusOutput, m.GetServiceLinkedRoleDeletionStatusErr
 }
 
 func TestIAMServiceLinkedRoles_List(t *testing.T) {
@@ -107,4 +114,41 @@ func TestIAMServiceLinkedRoles_Delete(t *testing.T) {
 
 	err := deleteIAMServiceLinkedRole(context.Background(), client, aws.String("test-role1"))
 	require.NoError(t, err)
+}
+
+// TestIAMServiceLinkedRoles_DeleteTaskRecordPurged covers the case where AWS
+// deletes the role so quickly that the deletion task record is purged before we
+// poll, returning NoSuchEntity. When the role itself is also gone, this is a
+// success, not a failure.
+func TestIAMServiceLinkedRoles_DeleteTaskRecordPurged(t *testing.T) {
+	t.Parallel()
+	client := mockedIAMServiceLinkedRoles{
+		DeleteServiceLinkedRoleOutput: iam.DeleteServiceLinkedRoleOutput{
+			DeletionTaskId: aws.String("task/aws-service-role/organizations.amazonaws.com/AWSServiceRoleForOrganizations/test-task-id"),
+		},
+		GetServiceLinkedRoleDeletionStatusErr: &types.NoSuchEntityException{Message: aws.String("Cannot find deletion status for given id.")},
+		GetRoleErr:                            &types.NoSuchEntityException{Message: aws.String("The role does not exist.")},
+	}
+
+	err := deleteIAMServiceLinkedRole(context.Background(), client, aws.String("AWSServiceRoleForOrganizations"))
+	require.NoError(t, err)
+}
+
+// TestIAMServiceLinkedRoles_DeleteTaskMissingButRoleExists ensures we still
+// report a failure when the deletion task record is missing but the role is
+// actually still present.
+func TestIAMServiceLinkedRoles_DeleteTaskMissingButRoleExists(t *testing.T) {
+	t.Parallel()
+	client := mockedIAMServiceLinkedRoles{
+		DeleteServiceLinkedRoleOutput: iam.DeleteServiceLinkedRoleOutput{
+			DeletionTaskId: aws.String("task/aws-service-role/organizations.amazonaws.com/AWSServiceRoleForOrganizations/test-task-id"),
+		},
+		GetServiceLinkedRoleDeletionStatusErr: &types.NoSuchEntityException{Message: aws.String("Cannot find deletion status for given id.")},
+		GetRoleOutput: iam.GetRoleOutput{
+			Role: &types.Role{RoleName: aws.String("AWSServiceRoleForOrganizations")},
+		},
+	}
+
+	err := deleteIAMServiceLinkedRole(context.Background(), client, aws.String("AWSServiceRoleForOrganizations"))
+	require.Error(t, err)
 }

--- a/aws/resources/iam_service_linked_role_test.go
+++ b/aws/resources/iam_service_linked_role_test.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"testing"
 	"time"
@@ -151,4 +152,24 @@ func TestIAMServiceLinkedRoles_DeleteTaskMissingButRoleExists(t *testing.T) {
 
 	err := deleteIAMServiceLinkedRole(context.Background(), client, aws.String("AWSServiceRoleForOrganizations"))
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "still present")
+}
+
+// TestIAMServiceLinkedRoles_DeleteVerificationError ensures that when the
+// deletion task record is gone and the follow-up GetRole call fails with a
+// non-NoSuchEntity error (e.g. throttling), we surface that error instead of
+// silently treating the role as deleted.
+func TestIAMServiceLinkedRoles_DeleteVerificationError(t *testing.T) {
+	t.Parallel()
+	client := mockedIAMServiceLinkedRoles{
+		DeleteServiceLinkedRoleOutput: iam.DeleteServiceLinkedRoleOutput{
+			DeletionTaskId: aws.String("task/aws-service-role/organizations.amazonaws.com/AWSServiceRoleForOrganizations/test-task-id"),
+		},
+		GetServiceLinkedRoleDeletionStatusErr: &types.NoSuchEntityException{Message: aws.String("Cannot find deletion status for given id.")},
+		GetRoleErr:                            fmt.Errorf("Throttling: Rate exceeded"),
+	}
+
+	err := deleteIAMServiceLinkedRole(context.Background(), client, aws.String("AWSServiceRoleForOrganizations"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Rate exceeded")
 }


### PR DESCRIPTION
## Summary

Stop cloud-nuke from falsely reporting IAM service-linked role deletions as failures when AWS deletes the role faster than the first status poll.

## Intent

Fixes #1143. Some service-linked roles (AWSServiceRoleForOrganizations, AWSServiceRoleForSSO, AWSServiceRoleForSupport, AWSServiceRoleForTrustedAdvisor, etc.) delete near-instantaneously. AWS purges the deletion-task record before cloud-nuke polls GetServiceLinkedRoleDeletionStatus, which then returns 404 NoSuchEntity. The old code treated that 404 as a hard failure, so cloud-nuke exited non-zero and reported the roles as failed even though they were deleted. This regressed in v0.47.0 when #1046 replaced the hand-rolled poll loop (which had an initial 3s sleep that masked the race) with util.PollUntil (immediate first poll).

## Decision

On NoSuchEntity from the status poll, verify the role's actual existence with GetRole rather than assuming success. A 404 on the task record alone does not prove the role is gone (the task ID could be invalid for other reasons), so we confirm against the role itself.

GetRole has three outcomes, all handled explicitly:
- NoSuchEntity -> role is gone -> success
- role still present -> task record missing but role not deleted -> clear error
- any other error (e.g. throttling) -> surface that error rather than masking it with the original task-not-found error

Alternative considered: blindly treat the status-poll 404 as success. Rejected because it would hide genuine failures where the task ID was bad but the role still exists. Returning the original 404 when the role survives was also rejected during review (misleading message); we return a role-still-present error instead.

## What changed

- `aws/resources/iam_service_linked_role.go`: added GetRole to the IAMServiceLinkedRolesAPI interface; on NoSuchEntity from the status poll, branch on GetRole as described above.
- `aws/resources/iam_service_linked_role_test.go`: mock now supports injecting errors on GetServiceLinkedRoleDeletionStatus and GetRole; added three delete-path tests.

## Illustration

Before: status poll 404 -> hard failure (role was actually deleted)

After:
```
status poll 404 (NoSuchEntity)
  -> GetRole
       NoSuchEntity   -> success
       role present   -> error "role is still present"
       other error    -> propagate that error
```

## Validation

- Unit tests: `go test ./aws/resources/ -run TestIAMServiceLinkedRoles` — PASS (5 tests). Covers happy path, task-purged-and-role-gone (success), task-missing-but-role-present (error), and GetRole-fails (error surfaced).
- Build + vet + gofmt: `go build ./...`, `go vet ./aws/resources/`, `gofmt -l` — all clean.
- Local E2E (read-only) against the phxdevops test account (087285199408): `cloud-nuke inspect-aws --resource-type iam-service-linked-role` listed ~30 service-linked roles including the exact ones reported in the issue. Confirms the list/identify path works end-to-end with no regression.
- Not run: the actual nuke against live roles. The fast-delete race is non-deterministic and nuking would destroy real SLRs in the shared test account. The deletion branch is covered by unit tests instead.

## Known limitations / follow-ups

- The 404-then-verify branch is exercised only by unit tests; the real race was not reproduced live (non-deterministic, destructive). No follow-up planned unless it recurs in the field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Enhanced IAM Service Linked Role deletion** – Improved reliability of the deletion process by adding verification when deletion status checks return not found, ensuring proper confirmation of role removal in edge cases such as rapid purges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->