### PR TITLE
Parallelism follow-ups: fixed default + test-race fix

### DIFF
--- a/aws/query.go
+++ b/aws/query.go
@@ -49,7 +49,7 @@ func (q *Query) Validate() error {
 	q.Regions = targetRegions
 
 	if q.Parallelism < 0 {
-		return fmt.Errorf("--parallelism must be >= 0 (0 uses the GOMAXPROCS default)")
+		return fmt.Errorf("--parallelism must be >= 0 (0 uses the default)")
 	}
 
 	return nil

--- a/commands/flags.go
+++ b/commands/flags.go
@@ -1,8 +1,7 @@
 package commands
 
 import (
-	"runtime"
-
+	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/urfave/cli/v2"
 )
 
@@ -113,8 +112,8 @@ func CommonExecutionFlags() []cli.Flag {
 		},
 		&cli.IntFlag{
 			Name:  FlagParallelism,
-			Value: runtime.GOMAXPROCS(0),
-			Usage: "Number of resources to delete concurrently. Defaults to the value of GOMAXPROCS.",
+			Value: util.DefaultParallelism,
+			Usage: "Number of regions/resources to scan and delete concurrently. The work is IO-bound, so this is independent of CPU count.",
 		},
 	}
 }

--- a/gcp/query.go
+++ b/gcp/query.go
@@ -45,7 +45,7 @@ func (q *Query) Validate() error {
 	}
 
 	if q.Parallelism < 0 {
-		return fmt.Errorf("--parallelism must be >= 0 (0 uses the GOMAXPROCS default)")
+		return fmt.Errorf("--parallelism must be >= 0 (0 uses the default)")
 	}
 
 	return nil

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gruntwork-io/cloud-nuke/config"
@@ -174,9 +175,11 @@ func TestResource_IsNukable(t *testing.T) {
 // Batch Deleter Tests
 
 func TestSimpleBatchDeleter(t *testing.T) {
-	deleteCount := 0
+	// SimpleBatchDeleter invokes deleteFn concurrently, so the mock counter must
+	// be thread-safe (otherwise this races under `go test -race`).
+	var deleteCount atomic.Int64
 	deleter := SimpleBatchDeleter(func(ctx context.Context, client *mockClient, id *string) error {
-		deleteCount++
+		deleteCount.Add(1)
 		return nil
 	})
 
@@ -187,7 +190,7 @@ func TestSimpleBatchDeleter(t *testing.T) {
 	for _, result := range results {
 		assert.NoError(t, result.Error)
 	}
-	assert.Equal(t, 3, deleteCount)
+	assert.Equal(t, int64(3), deleteCount.Load())
 }
 
 func TestSequentialDeleter(t *testing.T) {

--- a/util/context.go
+++ b/util/context.go
@@ -3,7 +3,6 @@ package util
 import (
 	"context"
 	"errors"
-	"runtime"
 )
 
 // ContextKey is a custom type to avoid collisions when using context.WithValue
@@ -13,6 +12,13 @@ const (
 	ExcludeFirstSeenTagKey ContextKey = "exclude-first-seen-tag"
 	ParallelismKey         ContextKey = "parallelism"
 )
+
+// DefaultParallelism is the default number of concurrent scan/delete operations
+// when --parallelism is not set (or set to 0). The work is IO-bound (AWS/GCP API
+// calls), so this is a fixed value rather than being derived from CPU count
+// (GOMAXPROCS), which on container runners reflects the CPU quota (e.g. 1-2 on a
+// CircleCI "small"), not the concurrency this workload can usefully sustain.
+const DefaultParallelism = 10
 
 func GetBoolFromContext(ctx context.Context, key ContextKey) (bool, error) {
 	result, ok := ctx.Value(key).(bool)
@@ -24,10 +30,10 @@ func GetBoolFromContext(ctx context.Context, key ContextKey) (bool, error) {
 }
 
 // GetParallelism returns the parallelism value stored in ctx, falling back to
-// runtime.GOMAXPROCS(0) if none was set.
+// DefaultParallelism if none was set (or set to a non-positive value).
 func GetParallelism(ctx context.Context) int {
 	if v, ok := ctx.Value(ParallelismKey).(int); ok && v > 0 {
 		return v
 	}
-	return runtime.GOMAXPROCS(0)
+	return DefaultParallelism
 }


### PR DESCRIPTION
## Summary
Set cloud-nuke's default scan/delete parallelism to a fixed 10 instead of GOMAXPROCS, and fix a test-only data race. Follow-up to #1144.

## Intent
#1144 made scanning and nuking concurrent but defaulted `--parallelism` to `GOMAXPROCS`. These nuke jobs run on CircleCI `small`, where GOMAXPROCS resolves to the cgroup CPU quota (2), so any job that does not pass `--parallelism` gets only ~2-way concurrency, and batch deletes drop from a fixed 10 to 2. The work is IO-bound (AWS API calls), so the default should not track CPU count.

## Decision
Use a fixed `DefaultParallelism = 10` for both the flag default and the `GetParallelism` fallback. 10 was the sweet spot in benchmarking (20 was no faster). Adaptive retry was considered and intentionally left out: benchmarks showed 0 throttling at 10 and 20, so it is not needed for the default and would be unproven scope. It can be added if higher parallelism later causes throttling.

## What changed
- `commands/flags.go`: `--parallelism` default `GOMAXPROCS` -> `util.DefaultParallelism` (10).
- `util/context.go`: add `DefaultParallelism` const; `GetParallelism` falls back to it instead of GOMAXPROCS.
- `aws/query.go`, `gcp/query.go`: update the `--parallelism` validation message.
- `resource/resource_test.go`: make `TestSimpleBatchDeleter`'s counter atomic so `go test -race` is clean.

## Illustration
Default behavior (no `--parallelism` passed) on a CircleCI `small` runner:
```
before: GOMAXPROCS = 2   -> scan ~2-way,  batch deletes 2-way
after:  fixed 10         -> scan 10-way,  batch deletes 10-way
```

## Validation
- `go build ./...`, `go vet`: pass.
- `go test -race ./util/... ./resource/... ./externalcreds/... ./commands/...`: pass.
- CircleCI E2E on a real `small` runner (read-only `inspect-aws`, phxdevops account 087285199408, 3 regions). Built both binaries on a large runner (build OOMs on small), ran the scan on small. Runner confirmed at a 2-CPU quota (`cpu.max=200000/100000`):

  | binary | default | scan time | resources found | throttling |
  |---|---|---|---|---|
  | pre-#1148 (GOMAXPROCS) | 2 | 77s | 90 | 0 |
  | this PR | 10 | 32s | 90 | 0 |

  ~2.4x faster on the actual runner type, identical results, no throttling.

## Known limitations / follow-ups
- Adaptive retry deferred until throttling is actually observed at higher `--parallelism`.
- Cross-region globals (RDS global clusters, TGW/VPC peering) can hit transient dependency-violation errors under parallel regions. These are non-fatal and self-heal on the next run; ordering them "delete last" is a possible later refinement.

Ref: OSS-3751
