### PR TITLE
fix: keep polling service-linked-role delete on read-after-write lag

### DIFF
--- a/aws/resources/iam_service_linked_role.go
+++ b/aws/resources/iam_service_linked_role.go
@@ -94,7 +94,9 @@ func deleteIAMServiceLinkedRole(ctx context.Context, client IAMServiceLinkedRole
 				// record is purged before we poll for its status, yielding a
 				// NoSuchEntity (404) error. That alone does not confirm the role is
 				// gone (the task ID could be invalid for other reasons), so verify the
-				// role itself via GetRole before reporting success.
+				// role itself via GetRole before reporting success. This requires the
+				// iam:GetRole permission in addition to the service-linked-role
+				// deletion permissions.
 				var notFoundErr *types.NoSuchEntityException
 				if goerr.As(err, &notFoundErr) {
 					_, roleErr := client.GetRole(ctx, &iam.GetRoleInput{
@@ -110,8 +112,14 @@ func deleteIAMServiceLinkedRole(ctx context.Context, client IAMServiceLinkedRole
 						// error rather than masking it with the task-not-found error.
 						return false, errors.WithStackTrace(roleErr)
 					default:
-						// Role still exists: the task record is missing but the role was not deleted.
-						return false, fmt.Errorf("deletion task for IAM ServiceLinked Role %s no longer exists but the role is still present", aws.ToString(roleName))
+						// The task record is gone but GetRole still sees the role. AWS
+						// already accepted the deletion, so this is almost always IAM
+						// read-after-write lag rather than a real failure. Keep polling
+						// (as we do for an in-progress deletion): the role should
+						// disappear on a later check, and the surrounding timeout still
+						// bounds a genuinely stuck delete.
+						logging.Debugf("Deletion task for IAM ServiceLinked Role %s is gone but the role is still visible; retrying", aws.ToString(roleName))
+						return false, nil
 					}
 				}
 				return false, errors.WithStackTrace(err)

--- a/aws/resources/iam_service_linked_role_test.go
+++ b/aws/resources/iam_service_linked_role_test.go
@@ -22,6 +22,12 @@ type mockedIAMServiceLinkedRoles struct {
 	GetServiceLinkedRoleDeletionStatusErr    error
 	GetRoleOutput                            iam.GetRoleOutput
 	GetRoleErr                               error
+	// GetRoleErrSeq, when set, overrides GetRoleErr and returns one entry per
+	// GetRole call (the final entry repeats). This lets a test model GetRole
+	// results that change across poll iterations, e.g. IAM read-after-write lag
+	// where the role is briefly still visible before the delete propagates.
+	GetRoleErrSeq []error
+	getRoleCalls  *int
 }
 
 func (m mockedIAMServiceLinkedRoles) ListRoles(ctx context.Context, params *iam.ListRolesInput, optFns ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
@@ -29,7 +35,19 @@ func (m mockedIAMServiceLinkedRoles) ListRoles(ctx context.Context, params *iam.
 }
 
 func (m mockedIAMServiceLinkedRoles) GetRole(ctx context.Context, params *iam.GetRoleInput, optFns ...func(*iam.Options)) (*iam.GetRoleOutput, error) {
-	return &m.GetRoleOutput, m.GetRoleErr
+	err := m.GetRoleErr
+	if len(m.GetRoleErrSeq) > 0 {
+		i := *m.getRoleCalls
+		if i >= len(m.GetRoleErrSeq) {
+			i = len(m.GetRoleErrSeq) - 1
+		}
+		*m.getRoleCalls++
+		err = m.GetRoleErrSeq[i]
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &m.GetRoleOutput, nil
 }
 
 func (m mockedIAMServiceLinkedRoles) DeleteServiceLinkedRole(ctx context.Context, params *iam.DeleteServiceLinkedRoleInput, optFns ...func(*iam.Options)) (*iam.DeleteServiceLinkedRoleOutput, error) {
@@ -135,11 +153,14 @@ func TestIAMServiceLinkedRoles_DeleteTaskRecordPurged(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestIAMServiceLinkedRoles_DeleteTaskMissingButRoleExists ensures we still
-// report a failure when the deletion task record is missing but the role is
-// actually still present.
-func TestIAMServiceLinkedRoles_DeleteTaskMissingButRoleExists(t *testing.T) {
+// TestIAMServiceLinkedRoles_DeleteTaskMissingRoleLagThenGone covers the case
+// where the deletion task record is purged but GetRole still briefly sees the
+// role due to IAM read-after-write lag. AWS already accepted the deletion, so
+// polling should continue rather than fail, and the next check (once the role
+// is gone) reports success.
+func TestIAMServiceLinkedRoles_DeleteTaskMissingRoleLagThenGone(t *testing.T) {
 	t.Parallel()
+	calls := 0
 	client := mockedIAMServiceLinkedRoles{
 		DeleteServiceLinkedRoleOutput: iam.DeleteServiceLinkedRoleOutput{
 			DeletionTaskId: aws.String("task/aws-service-role/organizations.amazonaws.com/AWSServiceRoleForOrganizations/test-task-id"),
@@ -148,11 +169,13 @@ func TestIAMServiceLinkedRoles_DeleteTaskMissingButRoleExists(t *testing.T) {
 		GetRoleOutput: iam.GetRoleOutput{
 			Role: &types.Role{RoleName: aws.String("AWSServiceRoleForOrganizations")},
 		},
+		// First GetRole still sees the role (lag); the second confirms it is gone.
+		GetRoleErrSeq: []error{nil, &types.NoSuchEntityException{Message: aws.String("The role does not exist.")}},
+		getRoleCalls:  &calls,
 	}
 
 	err := deleteIAMServiceLinkedRole(context.Background(), client, aws.String("AWSServiceRoleForOrganizations"))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "still present")
+	require.NoError(t, err)
 }
 
 // TestIAMServiceLinkedRoles_DeleteVerificationError ensures that when the
@@ -166,10 +189,10 @@ func TestIAMServiceLinkedRoles_DeleteVerificationError(t *testing.T) {
 			DeletionTaskId: aws.String("task/aws-service-role/organizations.amazonaws.com/AWSServiceRoleForOrganizations/test-task-id"),
 		},
 		GetServiceLinkedRoleDeletionStatusErr: &types.NoSuchEntityException{Message: aws.String("Cannot find deletion status for given id.")},
-		GetRoleErr:                            fmt.Errorf("Throttling: Rate exceeded"),
+		GetRoleErr:                            fmt.Errorf("throttling: rate exceeded"),
 	}
 
 	err := deleteIAMServiceLinkedRole(context.Background(), client, aws.String("AWSServiceRoleForOrganizations"))
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Rate exceeded")
+	require.Contains(t, err.Error(), "rate exceeded")
 }


### PR DESCRIPTION
Follow-up to #1147 (merged). Based on master.

## Summary

Addresses review feedback on #1147 and one correctness gap found while reviewing that change.

## Intent

#1147 fixed false failures when a service-linked role deletes faster than the first status poll, by verifying the role via GetRole on a NoSuchEntity from GetServiceLinkedRoleDeletionStatus. Reviewing it surfaced a residual: the "task gone but role still present" branch returned a hard error, and PollUntil treats any returned error as terminal. IAM is eventually consistent, so a GetRole issued right after a fast delete can still see the role for a moment, which would turn read-after-write lag into the same false failure #1147 set out to remove.

## Decision

Treat "task record gone, role still visible" as propagation lag and keep polling, the same way an in-progress deletion is handled (return false, nil). AWS has already accepted the deletion when the task record is purged, so a persistent "still present" state is implausible, and the existing 5 minute poll timeout still bounds a genuinely stuck delete. This fully closes the false-failure class rather than narrowing it.

Alternative considered: keep the fail-fast error. Rejected because the most likely cause of "still present" here is lag, not a real failure, so failing fast reintroduces the bug in a smaller window.

## What changed

- aws/resources/iam_service_linked_role.go: the "role still present" branch now logs and returns false, nil to continue polling instead of returning an error. Added a note that the verification requires iam:GetRole.
- aws/resources/iam_service_linked_role_test.go: replaced the "still present returns error" test with one that models read-after-write lag (GetRole sees the role once, then NoSuchEntity) and asserts success. Mock GetRole gained a per-call result sequence. Lowercased a throttling error string per review (Go convention).

## Illustration

```
status poll -> NoSuchEntity (task purged)
  -> GetRole
       NoSuchEntity        -> success
       role still visible  -> keep polling (lag), bounded by timeout   <- changed
       other error         -> propagate
```

## Validation

- Unit tests: go test ./aws/resources/ -run TestIAMServiceLinkedRoles -v, PASS (5). The lag test takes ~3s, confirming it retried across a poll interval and then succeeded rather than passing trivially.
- gofmt, go vet ./aws/resources/, go build ./...: clean (re-run after rebasing onto current master).
- Local read-only E2E against phxdevops (087285199408): inspect-aws --resource-type iam-service-linked-role listed ~40 service-linked roles including AWSServiceRoleForOrganizations, AWSServiceRoleForSSO, AWSServiceRoleForSupport, AWSServiceRoleForTrustedAdvisor. List/identify path works with no regression.
- Not run: live nuke. The fast-delete race is non-deterministic and destructive in a shared account, so the delete branch is covered by unit tests.

## Known limitations / follow-ups

- A genuinely stuck "role still present" state now surfaces only at the 5 minute timeout rather than immediately. This matches existing in-progress handling and is the intended tradeoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Improved IAM role deletion verification** – Enhanced the deletion process to gracefully handle temporary inconsistencies when verifying role state, accounting for AWS IAM's eventual consistency. The system now retries rather than immediately failing when encountering transient delays, improving reliability of role deletion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->