### PR TITLE
fix: strip :* suffix from log group ARN before listing tags

### DIFF
--- a/aws/resources/cloudwatch_loggroup.go
+++ b/aws/resources/cloudwatch_loggroup.go
@@ -57,14 +57,22 @@ func listCloudWatchLogGroups(ctx context.Context, client CloudWatchLogGroupsAPI,
 				creationTime = aws.Time(time.Unix(0, aws.ToInt64(logGroup.CreationTime)*int64(time.Millisecond)))
 			}
 
-			// DescribeLogGroups returns ARNs with a trailing ":*" suffix (e.g.
-			// "arn:aws:logs:us-east-1:123:log-group:/aws/eks/x:*"), but ListTagsForResource
-			// rejects that form with "Invalid resourceArn". Strip the suffix before the call.
+			// ListTagsForResource requires the ARN form without the trailing ":*" suffix.
+			// DescribeLogGroups returns that form in LogGroupArn; the older Arn field carries
+			// the ":*" suffix (e.g. ".../log-group:/aws/eks/x:*"), which the tagging API rejects
+			// with "Invalid resourceArn". Prefer LogGroupArn, falling back to a trimmed Arn.
+			resourceArn := aws.ToString(logGroup.LogGroupArn)
+			if resourceArn == "" {
+				resourceArn = strings.TrimSuffix(aws.ToString(logGroup.Arn), ":*")
+			}
+
 			tagsOutput, err := client.ListTagsForResource(ctx, &cloudwatchlogs.ListTagsForResourceInput{
-				ResourceArn: aws.String(strings.TrimSuffix(aws.ToString(logGroup.Arn), ":*")),
+				ResourceArn: aws.String(resourceArn),
 			})
 			if err != nil {
-				logging.Debugf("[cloudwatch-loggroup] Failed to list tags for log group %s: %s", aws.ToString(logGroup.LogGroupName), err)
+				// Skip rather than risk nuking a log group whose tags we couldn't read (it may
+				// carry an exclude tag). Log at Warn so the skip is visible, not silent.
+				logging.Warnf("[cloudwatch-loggroup] Skipping log group %s: failed to list tags: %s", aws.ToString(logGroup.LogGroupName), err)
 				continue
 			}
 

--- a/aws/resources/cloudwatch_loggroup.go
+++ b/aws/resources/cloudwatch_loggroup.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -56,8 +57,11 @@ func listCloudWatchLogGroups(ctx context.Context, client CloudWatchLogGroupsAPI,
 				creationTime = aws.Time(time.Unix(0, aws.ToInt64(logGroup.CreationTime)*int64(time.Millisecond)))
 			}
 
+			// DescribeLogGroups returns ARNs with a trailing ":*" suffix (e.g.
+			// "arn:aws:logs:us-east-1:123:log-group:/aws/eks/x:*"), but ListTagsForResource
+			// rejects that form with "Invalid resourceArn". Strip the suffix before the call.
 			tagsOutput, err := client.ListTagsForResource(ctx, &cloudwatchlogs.ListTagsForResourceInput{
-				ResourceArn: logGroup.Arn,
+				ResourceArn: aws.String(strings.TrimSuffix(aws.ToString(logGroup.Arn), ":*")),
 			})
 			if err != nil {
 				logging.Debugf("[cloudwatch-loggroup] Failed to list tags for log group %s: %s", aws.ToString(logGroup.LogGroupName), err)

--- a/aws/resources/cloudwatch_loggroup_test.go
+++ b/aws/resources/cloudwatch_loggroup_test.go
@@ -2,7 +2,9 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,7 +31,16 @@ func (m *mockCloudWatchLogGroupsClient) DeleteLogGroup(ctx context.Context, para
 }
 
 func (m *mockCloudWatchLogGroupsClient) ListTagsForResource(ctx context.Context, params *cloudwatchlogs.ListTagsForResourceInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.ListTagsForResourceOutput, error) {
-	if aws.ToString(params.ResourceArn) == "arn:aws:logs:us-east-1:123456789:log-group:log-group-2" {
+	arn := aws.ToString(params.ResourceArn)
+	// A trailing ":*" means the caller failed to normalize the ARN; mimic the real API,
+	// which rejects that form with "Invalid resourceArn" (the root cause of issue #1150).
+	if strings.HasSuffix(arn, ":*") {
+		return nil, fmt.Errorf("ValidationException: Invalid resourceArn: %s", arn)
+	}
+	if strings.HasSuffix(arn, "tag-error") {
+		return nil, fmt.Errorf("ServiceUnavailableException")
+	}
+	if arn == "arn:aws:logs:us-east-1:123456789:log-group:log-group-2" {
 		return &cloudwatchlogs.ListTagsForResourceOutput{Tags: map[string]string{"env": "prod"}}, nil
 	}
 	return &cloudwatchlogs.ListTagsForResourceOutput{Tags: map[string]string{"env": "dev"}}, nil
@@ -94,9 +105,10 @@ func TestListCloudWatchLogGroups_TagInclusionFilter(t *testing.T) {
 	mock := &mockCloudWatchLogGroupsClient{
 		DescribeLogGroupsOutput: cloudwatchlogs.DescribeLogGroupsOutput{
 			LogGroups: []types.LogGroup{
-				// DescribeLogGroups returns ARNs with a trailing ":*" suffix, which must be
-				// stripped before calling ListTagsForResource (see issue #1150).
-				{LogGroupName: aws.String("log-group-1"), Arn: aws.String("arn:aws:logs:us-east-1:123456789:log-group:log-group-1:*"), CreationTime: aws.Int64(now)},
+				// log-group-1 exercises the LogGroupArn path (suffix-free, as DescribeLogGroups
+				// returns it). log-group-2 omits LogGroupArn to exercise the Arn fallback, whose
+				// trailing ":*" must be stripped before ListTagsForResource (see issue #1150).
+				{LogGroupName: aws.String("log-group-1"), LogGroupArn: aws.String("arn:aws:logs:us-east-1:123456789:log-group:log-group-1"), Arn: aws.String("arn:aws:logs:us-east-1:123456789:log-group:log-group-1:*"), CreationTime: aws.Int64(now)},
 				{LogGroupName: aws.String("log-group-2"), Arn: aws.String("arn:aws:logs:us-east-1:123456789:log-group:log-group-2:*"), CreationTime: aws.Int64(now)},
 			},
 		},
@@ -113,6 +125,26 @@ func TestListCloudWatchLogGroups_TagInclusionFilter(t *testing.T) {
 	names, err := listCloudWatchLogGroups(context.Background(), mock, resource.Scope{}, cfg)
 	require.NoError(t, err)
 	require.Equal(t, []string{"log-group-2"}, aws.ToStringSlice(names))
+}
+
+func TestListCloudWatchLogGroups_SkipsOnTagListError(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UnixMilli()
+	mock := &mockCloudWatchLogGroupsClient{
+		DescribeLogGroupsOutput: cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []types.LogGroup{
+				{LogGroupName: aws.String("log-group-ok"), LogGroupArn: aws.String("arn:aws:logs:us-east-1:123456789:log-group:log-group-ok"), CreationTime: aws.Int64(now)},
+				{LogGroupName: aws.String("log-group-tag-error"), LogGroupArn: aws.String("arn:aws:logs:us-east-1:123456789:log-group:log-group-tag-error"), CreationTime: aws.Int64(now)},
+			},
+		},
+	}
+
+	// A log group whose tags cannot be read is skipped rather than nuked, since it may
+	// carry an exclude tag we could not observe.
+	names, err := listCloudWatchLogGroups(context.Background(), mock, resource.Scope{}, config.ResourceType{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"log-group-ok"}, aws.ToStringSlice(names))
 }
 
 func TestDeleteCloudWatchLogGroup(t *testing.T) {

--- a/aws/resources/cloudwatch_loggroup_test.go
+++ b/aws/resources/cloudwatch_loggroup_test.go
@@ -94,8 +94,10 @@ func TestListCloudWatchLogGroups_TagInclusionFilter(t *testing.T) {
 	mock := &mockCloudWatchLogGroupsClient{
 		DescribeLogGroupsOutput: cloudwatchlogs.DescribeLogGroupsOutput{
 			LogGroups: []types.LogGroup{
-				{LogGroupName: aws.String("log-group-1"), Arn: aws.String("arn:aws:logs:us-east-1:123456789:log-group:log-group-1"), CreationTime: aws.Int64(now)},
-				{LogGroupName: aws.String("log-group-2"), Arn: aws.String("arn:aws:logs:us-east-1:123456789:log-group:log-group-2"), CreationTime: aws.Int64(now)},
+				// DescribeLogGroups returns ARNs with a trailing ":*" suffix, which must be
+				// stripped before calling ListTagsForResource (see issue #1150).
+				{LogGroupName: aws.String("log-group-1"), Arn: aws.String("arn:aws:logs:us-east-1:123456789:log-group:log-group-1:*"), CreationTime: aws.Int64(now)},
+				{LogGroupName: aws.String("log-group-2"), Arn: aws.String("arn:aws:logs:us-east-1:123456789:log-group:log-group-2:*"), CreationTime: aws.Int64(now)},
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #1150

## Problem

`cloudwatch-loggroup` silently deletes nothing. `DescribeLogGroups` returns the `Arn` field with a trailing `:*` suffix (e.g. `arn:aws:logs:us-east-1:123:log-group:/aws/eks/x:*`), but `ListTagsForResource` rejects that form with `ValidationException: Invalid resourceArn`. The error was caught and the log group skipped via `continue`, so no matching log group was ever returned for deletion. Regression introduced in #1103, which added the tag-listing call.

## Fix

- Use the `LogGroupArn` field, which AWS returns without the `:*` suffix specifically for the tagging-API `resourceArn`, falling back to a trimmed `Arn` only when `LogGroupArn` is absent.
- Raise the tag-list failure log from Debug to Warn. The skip is intentional (a log group whose tags we cannot read may carry an exclude tag, so failing closed is safer for a destructive tool), but it should be visible rather than silent.

## Testing

- `TestListCloudWatchLogGroups_TagInclusionFilter` covers both the `LogGroupArn` path and the `Arn` fallback. The mock now rejects any `:*`-suffixed ARN, so a regression to the unnormalized ARN fails the suite.
- `TestListCloudWatchLogGroups_SkipsOnTagListError` covers the skip-on-error path.
- Verified end-to-end against a live AWS account: the pre-fix binary reports `Invalid resourceArn` for every log group and finds none; the fixed binary finds and deletes the target group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed CloudWatch Log Group tag retrieval by correctly handling trailing ARN suffixes returned during log-group discovery.
  * Improved resilience when tag listing fails by skipping the affected log group instead of failing the entire tag retrieval process.
  * Updated and added tests to cover ARN suffix handling and skip-on-tag-error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->