### PR TITLE
fix: restore first-seen tagging for ec2-subnet so --older-than works

### DIFF
--- a/aws/resources/ec2_subnet.go
+++ b/aws/resources/ec2_subnet.go
@@ -11,10 +11,12 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/resource"
 	"github.com/gruntwork-io/cloud-nuke/util"
+	"github.com/gruntwork-io/go-commons/errors"
 )
 
 // EC2SubnetAPI defines the interface for EC2 Subnet operations.
 type EC2SubnetAPI interface {
+	CreateTags(ctx context.Context, params *ec2.CreateTagsInput, optFns ...func(*ec2.Options)) (*ec2.CreateTagsOutput, error)
 	DeleteSubnet(ctx context.Context, params *ec2.DeleteSubnetInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSubnetOutput, error)
 	DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error)
 }
@@ -66,10 +68,13 @@ func listEC2Subnets(ctx context.Context, client EC2SubnetAPI, scope resource.Sco
 				continue
 			}
 
-			tagMap := util.ConvertTypesTagsToMap(subnet.Tags)
-
-			// Get first seen time from tags
-			firstSeenTime := getEC2SubnetFirstSeenTime(tagMap)
+			// Subnets have no creation timestamp, so age them via the
+			// first-seen tag, stamping it here on first scan.
+			firstSeenTime, err := util.GetOrCreateFirstSeen(ctx, client, subnet.SubnetId, util.ConvertTypesTagsToMap(subnet.Tags))
+			if err != nil {
+				logging.Error("unable to retrieve first seen tag")
+				return nil, errors.WithStackTrace(err)
+			}
 
 			if shouldIncludeEC2Subnet(subnet, firstSeenTime, cfg) {
 				subnetIds = append(subnetIds, subnet.SubnetId)
@@ -78,16 +83,6 @@ func listEC2Subnets(ctx context.Context, client EC2SubnetAPI, scope resource.Sco
 	}
 
 	return subnetIds, nil
-}
-
-// getEC2SubnetFirstSeenTime extracts the first seen time from tag map.
-func getEC2SubnetFirstSeenTime(tagMap map[string]string) *time.Time {
-	if firstSeenStr, ok := tagMap[util.FirstSeenTagKey]; ok {
-		if t, err := util.ParseTimestamp(aws.String(firstSeenStr)); err == nil {
-			return t
-		}
-	}
-	return nil
 }
 
 // shouldIncludeEC2Subnet determines if a subnet should be included based on config filters.

--- a/aws/resources/ec2_subnet_test.go
+++ b/aws/resources/ec2_subnet_test.go
@@ -4,18 +4,21 @@ import (
 	"context"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/resource"
+	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/stretchr/testify/require"
 )
 
 type mockEC2SubnetClient struct {
-	DescribeOutput ec2.DescribeSubnetsOutput
-	DeleteOutput   ec2.DeleteSubnetOutput
+	DescribeOutput  ec2.DescribeSubnetsOutput
+	DeleteOutput    ec2.DeleteSubnetOutput
+	CreateTagsCalls []ec2.CreateTagsInput
 }
 
 func (m *mockEC2SubnetClient) DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
@@ -24,6 +27,15 @@ func (m *mockEC2SubnetClient) DescribeSubnets(ctx context.Context, params *ec2.D
 
 func (m *mockEC2SubnetClient) DeleteSubnet(ctx context.Context, params *ec2.DeleteSubnetInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSubnetOutput, error) {
 	return &m.DeleteOutput, nil
+}
+
+func (m *mockEC2SubnetClient) CreateTags(ctx context.Context, params *ec2.CreateTagsInput, optFns ...func(*ec2.Options)) (*ec2.CreateTagsOutput, error) {
+	m.CreateTagsCalls = append(m.CreateTagsCalls, *params)
+	return &ec2.CreateTagsOutput{}, nil
+}
+
+func subnetTestContext() context.Context {
+	return context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, false)
 }
 
 func TestListEC2Subnets(t *testing.T) {
@@ -48,7 +60,7 @@ func TestListEC2Subnets(t *testing.T) {
 		},
 	}
 
-	ids, err := listEC2Subnets(context.Background(), mock, resource.Scope{}, config.ResourceType{}, false)
+	ids, err := listEC2Subnets(subnetTestContext(), mock, resource.Scope{}, config.ResourceType{}, false)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"subnet-001", "subnet-002"}, aws.ToStringSlice(ids))
 }
@@ -81,7 +93,7 @@ func TestListEC2Subnets_WithFilter(t *testing.T) {
 		},
 	}
 
-	ids, err := listEC2Subnets(context.Background(), mock, resource.Scope{}, cfg, false)
+	ids, err := listEC2Subnets(subnetTestContext(), mock, resource.Scope{}, cfg, false)
 	require.NoError(t, err)
 	require.Equal(t, []string{"subnet-001"}, aws.ToStringSlice(ids))
 }
@@ -100,9 +112,67 @@ func TestListEC2Subnets_SkipsDefaultSubnets(t *testing.T) {
 	}
 
 	// defaultOnly=false: default subnets are skipped, non-default and nil are kept
-	ids, err := listEC2Subnets(context.Background(), mock, resource.Scope{}, config.ResourceType{}, false)
+	ids, err := listEC2Subnets(subnetTestContext(), mock, resource.Scope{}, config.ResourceType{}, false)
 	require.NoError(t, err)
 	require.Equal(t, []string{"subnet-custom", "subnet-nil"}, aws.ToStringSlice(ids))
+}
+
+// Regression test for https://github.com/gruntwork-io/cloud-nuke/issues/1153:
+// subnets without a first-seen tag must get one stamped during listing, so a
+// time filter (--older-than) can pick them up on a later run instead of
+// excluding them forever.
+func TestListEC2Subnets_StampsFirstSeenTag(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	mock := &mockEC2SubnetClient{
+		DescribeOutput: ec2.DescribeSubnetsOutput{
+			Subnets: []types.Subnet{
+				{SubnetId: aws.String("subnet-untagged")},
+				{
+					SubnetId: aws.String("subnet-old"),
+					Tags: []types.Tag{
+						{Key: aws.String(util.FirstSeenTagKey), Value: aws.String(util.FormatTimestamp(now.Add(-24 * time.Hour)))},
+					},
+				},
+			},
+		},
+	}
+
+	// Equivalent of --older-than 12h: exclude anything first seen after now-12h.
+	excludeAfter := now.Add(-12 * time.Hour)
+	cfg := config.ResourceType{
+		ExcludeRule: config.FilterRule{TimeAfter: &excludeAfter},
+	}
+
+	ids, err := listEC2Subnets(subnetTestContext(), mock, resource.Scope{}, cfg, false)
+	require.NoError(t, err)
+
+	// The subnet first seen 24h ago passes the 12h filter; the untagged one is
+	// first seen "now", so it is excluded this run but tagged for future runs.
+	require.Equal(t, []string{"subnet-old"}, aws.ToStringSlice(ids))
+	require.Len(t, mock.CreateTagsCalls, 1)
+	require.Equal(t, []string{"subnet-untagged"}, mock.CreateTagsCalls[0].Resources)
+	require.Equal(t, util.FirstSeenTagKey, aws.ToString(mock.CreateTagsCalls[0].Tags[0].Key))
+}
+
+func TestListEC2Subnets_ExcludeFirstSeenTag(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEC2SubnetClient{
+		DescribeOutput: ec2.DescribeSubnetsOutput{
+			Subnets: []types.Subnet{
+				{SubnetId: aws.String("subnet-untagged")},
+			},
+		},
+	}
+
+	// With --exclude-first-seen, listing must not write any tags.
+	ctx := context.WithValue(context.Background(), util.ExcludeFirstSeenTagKey, true)
+	ids, err := listEC2Subnets(ctx, mock, resource.Scope{}, config.ResourceType{}, false)
+	require.NoError(t, err)
+	require.Equal(t, []string{"subnet-untagged"}, aws.ToStringSlice(ids))
+	require.Empty(t, mock.CreateTagsCalls)
 }
 
 func TestDeleteSubnet(t *testing.T) {

--- a/util/time.go
+++ b/util/time.go
@@ -30,6 +30,16 @@ const (
 	iso8601Bare = "2006-01-02T15:04:05"
 )
 
+// ec2CreateTagsAPI matches any EC2-compatible client (including mocks) that can
+// tag resources, so GetOrCreateFirstSeen can stamp the first-seen tag without
+// requiring the concrete *ec2.Client type.
+type ec2CreateTagsAPI interface {
+	CreateTags(ctx context.Context, params *ec2v2.CreateTagsInput, optFns ...func(*ec2v2.Options)) (*ec2v2.CreateTagsOutput, error)
+}
+
+// Ensure the real EC2 client keeps satisfying the interface if the SDK signature changes.
+var _ ec2CreateTagsAPI = (*ec2v2.Client)(nil)
+
 func IsFirstSeenTag(key *string) bool {
 	return aws.ToString(key) == FirstSeenTagKey
 }
@@ -86,7 +96,7 @@ func GetOrCreateFirstSeen(ctx context.Context, client interface{}, identifier *s
 		firstSeenTime = &now
 
 		switch v := client.(type) {
-		case *ec2v2.Client:
+		case ec2CreateTagsAPI:
 			_, err = v.CreateTags(ctx, &ec2v2.CreateTagsInput{
 				Resources: []string{*identifier},
 				Tags: []ec2types.Tag{


### PR DESCRIPTION
Fixes #1153

## Problem

Subnets have no creation timestamp, so cloud-nuke ages them via a `cloud-nuke-first-seen` tag stamped on first scan. #992 rewrote `ec2_subnet.go` to only read the tag, so nothing writes it anymore. `config.ShouldInclude` then excludes any untagged subnet when a time filter is set, so `--resource-type ec2-subnet --older-than 12h` always found 0 resources.

## Fix

Restore the write path via `util.GetOrCreateFirstSeen`, the same helper security-group, vpc, and eip use. To make that path unit-testable, `util/time.go` now matches the EC2 client by a `CreateTags` interface instead of the concrete `*ec2.Client` (a compile-time assertion keeps the real client covered). Behavior for the real client is unchanged.

```
scan 1: no tag  -> stamp first-seen=now -> excluded (too new)
scan 2 (>12h):  tag read              -> listed for deletion
```

Note: listing subnets now needs `ec2:CreateTags` unless `--exclude-first-seen` is set, same as every other first-seen resource.

## Validation

- Unit: `go test ./aws/resources -run Subnet -race`, `./util`, `./config` pass. Regression test confirmed to fail on the pre-fix lister.
- E2E on the phxdevops test account (us-east-1, throwaway VPC/subnets, scoped by config regex):
  - inspect stamps `cloud-nuke-first-seen` on first scan; re-scan does not overwrite it (aging works).
  - `--older-than 12h --force` deletes a backdated subnet while a fresh one survives.
  - `--exclude-first-seen` writes no tag and lists nothing.

## Follow-ups (separate PRs)

- `ec2_egress_only_igw.go`: #992 dropped its first-seen call entirely, same bug class.
- `TestListECSClusters` time-filter subtests fail on master (ECS lister filters on time before it has a timestamp); pre-existing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subnet listings now automatically record a “first seen” tag when one is missing, helping track when resources were first observed.

* **Bug Fixes**
  * Improved subnet filtering so recently seen subnets can be excluded consistently.
  * Listing now handles tag updates more reliably and avoids failures when first-seen data can’t be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->