### PR TITLE
fix: delete VPC associations before nuking VPC Lattice service network

### DIFF
--- a/aws/resources/vpc_lattice_service_network.go
+++ b/aws/resources/vpc_lattice_service_network.go
@@ -2,11 +2,13 @@ package resources
 
 import (
 	"context"
+	goerr "errors"
 	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/resource"
@@ -139,37 +141,57 @@ func waitForAssociationsDeleted(ctx context.Context, client VPCLatticeServiceNet
 	for i := 0; i < 10; i++ {
 		remaining, err := countAssociations(ctx, client, id)
 		if err != nil {
-			// Error likely means the service network or its associations are gone
-			return nil //nolint:nilerr
+			// A not-found error means the service network (and its associations)
+			// are already gone; any other error is real and should surface.
+			var notFound *types.ResourceNotFoundException
+			if goerr.As(err, &notFound) {
+				return nil
+			}
+			return errors.WithStackTrace(err)
 		}
 		if remaining == 0 {
 			return nil
 		}
+
 		logging.Debugf("Waiting for associations to be deleted for service network %s...", aws.ToString(id))
-		time.Sleep(10 * time.Second)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(10 * time.Second):
+		}
 	}
 
 	return fmt.Errorf("timed out waiting for associations to be deleted for service network %s", aws.ToString(id))
 }
 
 // countAssociations returns the number of service plus VPC associations still
-// attached to the service network.
+// attached to the service network, across all pages.
 func countAssociations(ctx context.Context, client VPCLatticeServiceNetworkAPI, id *string) (int, error) {
-	services, err := client.ListServiceNetworkServiceAssociations(ctx, &vpclattice.ListServiceNetworkServiceAssociationsInput{
+	total := 0
+
+	servicePaginator := vpclattice.NewListServiceNetworkServiceAssociationsPaginator(client, &vpclattice.ListServiceNetworkServiceAssociationsInput{
 		ServiceNetworkIdentifier: id,
 	})
-	if err != nil {
-		return 0, err
+	for servicePaginator.HasMorePages() {
+		page, err := servicePaginator.NextPage(ctx)
+		if err != nil {
+			return 0, err
+		}
+		total += len(page.Items)
 	}
 
-	vpcs, err := client.ListServiceNetworkVpcAssociations(ctx, &vpclattice.ListServiceNetworkVpcAssociationsInput{
+	vpcPaginator := vpclattice.NewListServiceNetworkVpcAssociationsPaginator(client, &vpclattice.ListServiceNetworkVpcAssociationsInput{
 		ServiceNetworkIdentifier: id,
 	})
-	if err != nil {
-		return 0, err
+	for vpcPaginator.HasMorePages() {
+		page, err := vpcPaginator.NextPage(ctx)
+		if err != nil {
+			return 0, err
+		}
+		total += len(page.Items)
 	}
 
-	return len(services.Items) + len(vpcs.Items), nil
+	return total, nil
 }
 
 // deleteServiceNetwork deletes the VPC Lattice Service Network.

--- a/aws/resources/vpc_lattice_service_network.go
+++ b/aws/resources/vpc_lattice_service_network.go
@@ -19,6 +19,8 @@ type VPCLatticeServiceNetworkAPI interface {
 	DeleteServiceNetwork(ctx context.Context, params *vpclattice.DeleteServiceNetworkInput, optFns ...func(*vpclattice.Options)) (*vpclattice.DeleteServiceNetworkOutput, error)
 	ListServiceNetworkServiceAssociations(ctx context.Context, params *vpclattice.ListServiceNetworkServiceAssociationsInput, optFns ...func(*vpclattice.Options)) (*vpclattice.ListServiceNetworkServiceAssociationsOutput, error)
 	DeleteServiceNetworkServiceAssociation(ctx context.Context, params *vpclattice.DeleteServiceNetworkServiceAssociationInput, optFns ...func(*vpclattice.Options)) (*vpclattice.DeleteServiceNetworkServiceAssociationOutput, error)
+	ListServiceNetworkVpcAssociations(ctx context.Context, params *vpclattice.ListServiceNetworkVpcAssociationsInput, optFns ...func(*vpclattice.Options)) (*vpclattice.ListServiceNetworkVpcAssociationsOutput, error)
+	DeleteServiceNetworkVpcAssociation(ctx context.Context, params *vpclattice.DeleteServiceNetworkVpcAssociationInput, optFns ...func(*vpclattice.Options)) (*vpclattice.DeleteServiceNetworkVpcAssociationOutput, error)
 	ListTagsForResource(ctx context.Context, params *vpclattice.ListTagsForResourceInput, optFns ...func(*vpclattice.Options)) (*vpclattice.ListTagsForResourceOutput, error)
 }
 
@@ -35,10 +37,12 @@ func NewVPCLatticeServiceNetwork() AwsResource {
 			return c.VPCLatticeServiceNetwork
 		},
 		Lister: listVPCLatticeServiceNetworks,
-		// Service network deletion requires: delete associations → wait → delete network
+		// A service network cannot be deleted while it still has service or VPC
+		// associations, so delete both, wait for them to clear, then delete it.
 		Nuker: resource.MultiStepDeleter(
 			deleteServiceAssociations,
-			waitForServiceAssociationsDeleted,
+			deleteVpcAssociations,
+			waitForAssociationsDeleted,
 			deleteServiceNetwork,
 		),
 	})
@@ -103,25 +107,69 @@ func deleteServiceAssociations(ctx context.Context, client VPCLatticeServiceNetw
 	return nil
 }
 
-// waitForServiceAssociationsDeleted polls until all service associations are deleted.
-// Times out after 100 seconds.
-func waitForServiceAssociationsDeleted(ctx context.Context, client VPCLatticeServiceNetworkAPI, id *string) error {
-	for i := 0; i < 10; i++ {
-		output, err := client.ListServiceNetworkServiceAssociations(ctx, &vpclattice.ListServiceNetworkServiceAssociationsInput{
-			ServiceNetworkIdentifier: id,
-		})
+// deleteVpcAssociations deletes all VPC associations for the given service network.
+// Service network cannot be deleted while associations exist.
+func deleteVpcAssociations(ctx context.Context, client VPCLatticeServiceNetworkAPI, id *string) error {
+	paginator := vpclattice.NewListServiceNetworkVpcAssociationsPaginator(client, &vpclattice.ListServiceNetworkVpcAssociationsInput{
+		ServiceNetworkIdentifier: id,
+	})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			// Error likely means service network doesn't exist or associations are gone
+			return errors.WithStackTrace(err)
+		}
+
+		for _, item := range page.Items {
+			logging.Debugf("Deleting VPC association %s for service network %s", aws.ToString(item.Id), aws.ToString(id))
+			if _, err := client.DeleteServiceNetworkVpcAssociation(ctx, &vpclattice.DeleteServiceNetworkVpcAssociationInput{
+				ServiceNetworkVpcAssociationIdentifier: item.Id,
+			}); err != nil {
+				return errors.WithStackTrace(err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// waitForAssociationsDeleted polls until all service and VPC associations are
+// deleted. Times out after 100 seconds.
+func waitForAssociationsDeleted(ctx context.Context, client VPCLatticeServiceNetworkAPI, id *string) error {
+	for i := 0; i < 10; i++ {
+		remaining, err := countAssociations(ctx, client, id)
+		if err != nil {
+			// Error likely means the service network or its associations are gone
 			return nil //nolint:nilerr
 		}
-		if len(output.Items) == 0 {
+		if remaining == 0 {
 			return nil
 		}
-		logging.Debugf("Waiting for service associations to be deleted for service network %s...", aws.ToString(id))
+		logging.Debugf("Waiting for associations to be deleted for service network %s...", aws.ToString(id))
 		time.Sleep(10 * time.Second)
 	}
 
-	return fmt.Errorf("timed out waiting for service associations to be deleted for service network %s", aws.ToString(id))
+	return fmt.Errorf("timed out waiting for associations to be deleted for service network %s", aws.ToString(id))
+}
+
+// countAssociations returns the number of service plus VPC associations still
+// attached to the service network.
+func countAssociations(ctx context.Context, client VPCLatticeServiceNetworkAPI, id *string) (int, error) {
+	services, err := client.ListServiceNetworkServiceAssociations(ctx, &vpclattice.ListServiceNetworkServiceAssociationsInput{
+		ServiceNetworkIdentifier: id,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	vpcs, err := client.ListServiceNetworkVpcAssociations(ctx, &vpclattice.ListServiceNetworkVpcAssociationsInput{
+		ServiceNetworkIdentifier: id,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return len(services.Items) + len(vpcs.Items), nil
 }
 
 // deleteServiceNetwork deletes the VPC Lattice Service Network.

--- a/aws/resources/vpc_lattice_service_network_test.go
+++ b/aws/resources/vpc_lattice_service_network_test.go
@@ -19,9 +19,12 @@ type mockedVPCLatticeServiceNetwork struct {
 	DeleteServiceNetworkOutput                   vpclattice.DeleteServiceNetworkOutput
 	ListServiceNetworkServiceAssociationsOutput  vpclattice.ListServiceNetworkServiceAssociationsOutput
 	DeleteServiceNetworkServiceAssociationOutput vpclattice.DeleteServiceNetworkServiceAssociationOutput
+	ListServiceNetworkVpcAssociationsOutput      vpclattice.ListServiceNetworkVpcAssociationsOutput
+	DeleteServiceNetworkVpcAssociationOutput     vpclattice.DeleteServiceNetworkVpcAssociationOutput
 
 	// Track calls to simulate associations being deleted
-	listAssociationsCalls int
+	listAssociationsCalls    int
+	listVpcAssociationsCalls int
 }
 
 func (m *mockedVPCLatticeServiceNetwork) ListServiceNetworks(ctx context.Context, params *vpclattice.ListServiceNetworksInput, optFns ...func(*vpclattice.Options)) (*vpclattice.ListServiceNetworksOutput, error) {
@@ -43,6 +46,19 @@ func (m *mockedVPCLatticeServiceNetwork) ListServiceNetworkServiceAssociations(c
 
 func (m *mockedVPCLatticeServiceNetwork) DeleteServiceNetworkServiceAssociation(ctx context.Context, params *vpclattice.DeleteServiceNetworkServiceAssociationInput, optFns ...func(*vpclattice.Options)) (*vpclattice.DeleteServiceNetworkServiceAssociationOutput, error) {
 	return &m.DeleteServiceNetworkServiceAssociationOutput, nil
+}
+
+func (m *mockedVPCLatticeServiceNetwork) ListServiceNetworkVpcAssociations(ctx context.Context, params *vpclattice.ListServiceNetworkVpcAssociationsInput, optFns ...func(*vpclattice.Options)) (*vpclattice.ListServiceNetworkVpcAssociationsOutput, error) {
+	m.listVpcAssociationsCalls++
+	// First call returns associations, subsequent calls return empty (simulating deletion)
+	if m.listVpcAssociationsCalls <= 1 {
+		return &m.ListServiceNetworkVpcAssociationsOutput, nil
+	}
+	return &vpclattice.ListServiceNetworkVpcAssociationsOutput{Items: []types.ServiceNetworkVpcAssociationSummary{}}, nil
+}
+
+func (m *mockedVPCLatticeServiceNetwork) DeleteServiceNetworkVpcAssociation(ctx context.Context, params *vpclattice.DeleteServiceNetworkVpcAssociationInput, optFns ...func(*vpclattice.Options)) (*vpclattice.DeleteServiceNetworkVpcAssociationOutput, error) {
+	return &m.DeleteServiceNetworkVpcAssociationOutput, nil
 }
 
 func (m *mockedVPCLatticeServiceNetwork) ListTagsForResource(ctx context.Context, params *vpclattice.ListTagsForResourceInput, optFns ...func(*vpclattice.Options)) (*vpclattice.ListTagsForResourceOutput, error) {
@@ -147,6 +163,22 @@ func TestVPCLatticeServiceNetwork_DeleteServiceAssociations(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestVPCLatticeServiceNetwork_DeleteVpcAssociations(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockedVPCLatticeServiceNetwork{
+		ListServiceNetworkVpcAssociationsOutput: vpclattice.ListServiceNetworkVpcAssociationsOutput{
+			Items: []types.ServiceNetworkVpcAssociationSummary{
+				{Id: aws.String("snva-123456")},
+				{Id: aws.String("snva-789012")},
+			},
+		},
+	}
+
+	err := deleteVpcAssociations(context.Background(), mock, aws.String("sn-test"))
+	require.NoError(t, err)
+}
+
 func TestVPCLatticeServiceNetwork_DeleteNetwork(t *testing.T) {
 	t.Parallel()
 
@@ -158,13 +190,19 @@ func TestVPCLatticeServiceNetwork_DeleteNetwork(t *testing.T) {
 func TestVPCLatticeServiceNetwork_MultiStepDeleter(t *testing.T) {
 	t.Parallel()
 
+	// Both association types are populated so the deleter must clear service and
+	// VPC associations before the network delete succeeds (regression for the
+	// 409 "has VPC(s) associated" failure caused by leftover VPC associations).
 	mock := &mockedVPCLatticeServiceNetwork{
 		ListServiceNetworkServiceAssociationsOutput: vpclattice.ListServiceNetworkServiceAssociationsOutput{
-			Items: []types.ServiceNetworkServiceAssociationSummary{},
+			Items: []types.ServiceNetworkServiceAssociationSummary{{Id: aws.String("snsa-1")}},
+		},
+		ListServiceNetworkVpcAssociationsOutput: vpclattice.ListServiceNetworkVpcAssociationsOutput{
+			Items: []types.ServiceNetworkVpcAssociationSummary{{Id: aws.String("snva-1")}},
 		},
 	}
 
-	nuker := resource.MultiStepDeleter(deleteServiceAssociations, waitForServiceAssociationsDeleted, deleteServiceNetwork)
+	nuker := resource.MultiStepDeleter(deleteServiceAssociations, deleteVpcAssociations, waitForAssociationsDeleted, deleteServiceNetwork)
 	results := nuker(context.Background(), mock, resource.Scope{Region: "us-east-1"}, "vpc-lattice-service-network", []*string{aws.String("sn-test")})
 
 	require.Len(t, results, 1)


### PR DESCRIPTION
## What

Fixes the nightly PhxDevOps nuke failure where `vpc-lattice-service-network` deletion errors with a 409 `ConflictException`. cloud-nuke now removes VPC associations (not just service associations) before deleting a service network.

## Why

A VPC Lattice service network cannot be deleted while it still has associations, and there are two kinds: service associations and VPC associations. The nuker deleted service associations but never touched VPC associations, so `DeleteServiceNetwork` failed:

```
step 3: VPC Lattice DeleteServiceNetwork → 409 ConflictException:
ServiceNetwork sn-... has VPC(s) associated
```

That error is fatal, so it failed the entire nuke job. The scheduled "Nuke: PhxDevOps" workflow has been red on every run because of this.

## How

- Add `ListServiceNetworkVpcAssociations` / `DeleteServiceNetworkVpcAssociation` to the resource interface.
- Add a `deleteVpcAssociations` step.
- Replace the service-only wait with `waitForAssociationsDeleted`, which polls until both service and VPC associations are gone.

New step order: delete service associations, delete VPC associations, wait for both to clear, delete the network.

## Testing

Unit tests: added a `deleteVpcAssociations` test and updated the multi-step test so both association types are present, exercising the full teardown.

Manual before/after on a real account, using a service network with an ACTIVE VPC association:

1. Unfixed binary: `DeleteServiceNetwork` returned 409 `has VPC(s) associated`, network survived.
2. Fixed binary, same network: deleted the VPC association, waited for it to clear, deleted the network. Confirmed both gone via the API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved VPC Lattice service network deletion to handle cases where VPC associations still exist.
  - Deletion flow now clears both service and VPC associations before removing the network.
  - Enhanced cleanup waiting ensures the network is only finalized after all related associations are fully removed.
- **Tests**
  - Added unit coverage for deleting VPC associations.
  - Updated multi-step cleanup tests to validate combined service + VPC association handling, including the previously missed failure scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->