### PR TITLE
fix: delete VPC Lattice resource associations before service network

### DIFF
--- a/aws/resources/vpc_lattice_service_network.go
+++ b/aws/resources/vpc_lattice_service_network.go
@@ -23,6 +23,8 @@ type VPCLatticeServiceNetworkAPI interface {
 	DeleteServiceNetworkServiceAssociation(ctx context.Context, params *vpclattice.DeleteServiceNetworkServiceAssociationInput, optFns ...func(*vpclattice.Options)) (*vpclattice.DeleteServiceNetworkServiceAssociationOutput, error)
 	ListServiceNetworkVpcAssociations(ctx context.Context, params *vpclattice.ListServiceNetworkVpcAssociationsInput, optFns ...func(*vpclattice.Options)) (*vpclattice.ListServiceNetworkVpcAssociationsOutput, error)
 	DeleteServiceNetworkVpcAssociation(ctx context.Context, params *vpclattice.DeleteServiceNetworkVpcAssociationInput, optFns ...func(*vpclattice.Options)) (*vpclattice.DeleteServiceNetworkVpcAssociationOutput, error)
+	ListServiceNetworkResourceAssociations(ctx context.Context, params *vpclattice.ListServiceNetworkResourceAssociationsInput, optFns ...func(*vpclattice.Options)) (*vpclattice.ListServiceNetworkResourceAssociationsOutput, error)
+	DeleteServiceNetworkResourceAssociation(ctx context.Context, params *vpclattice.DeleteServiceNetworkResourceAssociationInput, optFns ...func(*vpclattice.Options)) (*vpclattice.DeleteServiceNetworkResourceAssociationOutput, error)
 	ListTagsForResource(ctx context.Context, params *vpclattice.ListTagsForResourceInput, optFns ...func(*vpclattice.Options)) (*vpclattice.ListTagsForResourceOutput, error)
 }
 
@@ -39,11 +41,13 @@ func NewVPCLatticeServiceNetwork() AwsResource {
 			return c.VPCLatticeServiceNetwork
 		},
 		Lister: listVPCLatticeServiceNetworks,
-		// A service network cannot be deleted while it still has service or VPC
-		// associations, so delete both, wait for them to clear, then delete it.
+		// A service network cannot be deleted while it still has service, VPC, or
+		// resource associations, so delete all of them, wait for them to clear,
+		// then delete it.
 		Nuker: resource.MultiStepDeleter(
 			deleteServiceAssociations,
 			deleteVpcAssociations,
+			deleteResourceAssociations,
 			waitForAssociationsDeleted,
 			deleteServiceNetwork,
 		),
@@ -135,8 +139,42 @@ func deleteVpcAssociations(ctx context.Context, client VPCLatticeServiceNetworkA
 	return nil
 }
 
-// waitForAssociationsDeleted polls until all service and VPC associations are
-// deleted. Times out after 100 seconds.
+// deleteResourceAssociations deletes all resource-configuration associations for
+// the given service network. A service network cannot be deleted while
+// associations exist. Managed associations (created by Amazon for RAM-shared
+// resource configurations) cannot be deleted from the service network side, so
+// they are skipped with a warning rather than triggering a hard failure.
+func deleteResourceAssociations(ctx context.Context, client VPCLatticeServiceNetworkAPI, id *string) error {
+	paginator := vpclattice.NewListServiceNetworkResourceAssociationsPaginator(client, &vpclattice.ListServiceNetworkResourceAssociationsInput{
+		ServiceNetworkIdentifier: id,
+	})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return errors.WithStackTrace(err)
+		}
+
+		for _, item := range page.Items {
+			if aws.ToBool(item.IsManagedAssociation) {
+				logging.Warnf("Skipping managed resource association %s for service network %s; it must be removed by the resource configuration owner", aws.ToString(item.Id), aws.ToString(id))
+				continue
+			}
+
+			logging.Debugf("Deleting resource association %s for service network %s", aws.ToString(item.Id), aws.ToString(id))
+			if _, err := client.DeleteServiceNetworkResourceAssociation(ctx, &vpclattice.DeleteServiceNetworkResourceAssociationInput{
+				ServiceNetworkResourceAssociationIdentifier: item.Id,
+			}); err != nil {
+				return errors.WithStackTrace(err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// waitForAssociationsDeleted polls until all service, VPC, and resource
+// associations are deleted. Times out after 100 seconds.
 func waitForAssociationsDeleted(ctx context.Context, client VPCLatticeServiceNetworkAPI, id *string) error {
 	for i := 0; i < 10; i++ {
 		remaining, err := countAssociations(ctx, client, id)
@@ -164,8 +202,10 @@ func waitForAssociationsDeleted(ctx context.Context, client VPCLatticeServiceNet
 	return fmt.Errorf("timed out waiting for associations to be deleted for service network %s", aws.ToString(id))
 }
 
-// countAssociations returns the number of service plus VPC associations still
-// attached to the service network, across all pages.
+// countAssociations returns the number of service, VPC, and deletable resource
+// associations still attached to the service network, across all pages. Managed
+// resource associations are excluded because they cannot be deleted from the
+// service network side, so waiting on them would only ever time out.
 func countAssociations(ctx context.Context, client VPCLatticeServiceNetworkAPI, id *string) (int, error) {
 	total := 0
 
@@ -189,6 +229,22 @@ func countAssociations(ctx context.Context, client VPCLatticeServiceNetworkAPI, 
 			return 0, err
 		}
 		total += len(page.Items)
+	}
+
+	resourcePaginator := vpclattice.NewListServiceNetworkResourceAssociationsPaginator(client, &vpclattice.ListServiceNetworkResourceAssociationsInput{
+		ServiceNetworkIdentifier: id,
+	})
+	for resourcePaginator.HasMorePages() {
+		page, err := resourcePaginator.NextPage(ctx)
+		if err != nil {
+			return 0, err
+		}
+		for _, item := range page.Items {
+			if aws.ToBool(item.IsManagedAssociation) {
+				continue
+			}
+			total++
+		}
 	}
 
 	return total, nil

--- a/aws/resources/vpc_lattice_service_network_test.go
+++ b/aws/resources/vpc_lattice_service_network_test.go
@@ -22,9 +22,13 @@ type mockedVPCLatticeServiceNetwork struct {
 	ListServiceNetworkVpcAssociationsOutput      vpclattice.ListServiceNetworkVpcAssociationsOutput
 	DeleteServiceNetworkVpcAssociationOutput     vpclattice.DeleteServiceNetworkVpcAssociationOutput
 
+	ListServiceNetworkResourceAssociationsOutput  vpclattice.ListServiceNetworkResourceAssociationsOutput
+	DeleteServiceNetworkResourceAssociationOutput vpclattice.DeleteServiceNetworkResourceAssociationOutput
+
 	// Track calls to simulate associations being deleted
-	listAssociationsCalls    int
-	listVpcAssociationsCalls int
+	listAssociationsCalls         int
+	listVpcAssociationsCalls      int
+	listResourceAssociationsCalls int
 }
 
 func (m *mockedVPCLatticeServiceNetwork) ListServiceNetworks(ctx context.Context, params *vpclattice.ListServiceNetworksInput, optFns ...func(*vpclattice.Options)) (*vpclattice.ListServiceNetworksOutput, error) {
@@ -59,6 +63,19 @@ func (m *mockedVPCLatticeServiceNetwork) ListServiceNetworkVpcAssociations(ctx c
 
 func (m *mockedVPCLatticeServiceNetwork) DeleteServiceNetworkVpcAssociation(ctx context.Context, params *vpclattice.DeleteServiceNetworkVpcAssociationInput, optFns ...func(*vpclattice.Options)) (*vpclattice.DeleteServiceNetworkVpcAssociationOutput, error) {
 	return &m.DeleteServiceNetworkVpcAssociationOutput, nil
+}
+
+func (m *mockedVPCLatticeServiceNetwork) ListServiceNetworkResourceAssociations(ctx context.Context, params *vpclattice.ListServiceNetworkResourceAssociationsInput, optFns ...func(*vpclattice.Options)) (*vpclattice.ListServiceNetworkResourceAssociationsOutput, error) {
+	m.listResourceAssociationsCalls++
+	// First call returns associations, subsequent calls return empty (simulating deletion)
+	if m.listResourceAssociationsCalls <= 1 {
+		return &m.ListServiceNetworkResourceAssociationsOutput, nil
+	}
+	return &vpclattice.ListServiceNetworkResourceAssociationsOutput{Items: []types.ServiceNetworkResourceAssociationSummary{}}, nil
+}
+
+func (m *mockedVPCLatticeServiceNetwork) DeleteServiceNetworkResourceAssociation(ctx context.Context, params *vpclattice.DeleteServiceNetworkResourceAssociationInput, optFns ...func(*vpclattice.Options)) (*vpclattice.DeleteServiceNetworkResourceAssociationOutput, error) {
+	return &m.DeleteServiceNetworkResourceAssociationOutput, nil
 }
 
 func (m *mockedVPCLatticeServiceNetwork) ListTagsForResource(ctx context.Context, params *vpclattice.ListTagsForResourceInput, optFns ...func(*vpclattice.Options)) (*vpclattice.ListTagsForResourceOutput, error) {
@@ -179,6 +196,25 @@ func TestVPCLatticeServiceNetwork_DeleteVpcAssociations(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestVPCLatticeServiceNetwork_DeleteResourceAssociations(t *testing.T) {
+	t.Parallel()
+
+	// A managed association is included to confirm it is skipped rather than
+	// deleted (it cannot be deleted from the service network side).
+	mock := &mockedVPCLatticeServiceNetwork{
+		ListServiceNetworkResourceAssociationsOutput: vpclattice.ListServiceNetworkResourceAssociationsOutput{
+			Items: []types.ServiceNetworkResourceAssociationSummary{
+				{Id: aws.String("snra-123456")},
+				{Id: aws.String("snra-789012")},
+				{Id: aws.String("snra-managed"), IsManagedAssociation: aws.Bool(true)},
+			},
+		},
+	}
+
+	err := deleteResourceAssociations(context.Background(), mock, aws.String("sn-test"))
+	require.NoError(t, err)
+}
+
 func TestVPCLatticeServiceNetwork_DeleteNetwork(t *testing.T) {
 	t.Parallel()
 
@@ -190,9 +226,10 @@ func TestVPCLatticeServiceNetwork_DeleteNetwork(t *testing.T) {
 func TestVPCLatticeServiceNetwork_MultiStepDeleter(t *testing.T) {
 	t.Parallel()
 
-	// Both association types are populated so the deleter must clear service and
-	// VPC associations before the network delete succeeds (regression for the
-	// 409 "has VPC(s) associated" failure caused by leftover VPC associations).
+	// All three association types are populated so the deleter must clear
+	// service, VPC, and resource associations before the network delete succeeds
+	// (regression for the 409 "has ...associated" failures caused by leftover
+	// associations of each kind).
 	mock := &mockedVPCLatticeServiceNetwork{
 		ListServiceNetworkServiceAssociationsOutput: vpclattice.ListServiceNetworkServiceAssociationsOutput{
 			Items: []types.ServiceNetworkServiceAssociationSummary{{Id: aws.String("snsa-1")}},
@@ -200,9 +237,12 @@ func TestVPCLatticeServiceNetwork_MultiStepDeleter(t *testing.T) {
 		ListServiceNetworkVpcAssociationsOutput: vpclattice.ListServiceNetworkVpcAssociationsOutput{
 			Items: []types.ServiceNetworkVpcAssociationSummary{{Id: aws.String("snva-1")}},
 		},
+		ListServiceNetworkResourceAssociationsOutput: vpclattice.ListServiceNetworkResourceAssociationsOutput{
+			Items: []types.ServiceNetworkResourceAssociationSummary{{Id: aws.String("snra-1")}},
+		},
 	}
 
-	nuker := resource.MultiStepDeleter(deleteServiceAssociations, deleteVpcAssociations, waitForAssociationsDeleted, deleteServiceNetwork)
+	nuker := resource.MultiStepDeleter(deleteServiceAssociations, deleteVpcAssociations, deleteResourceAssociations, waitForAssociationsDeleted, deleteServiceNetwork)
 	results := nuker(context.Background(), mock, resource.Scope{Region: "us-east-1"}, "vpc-lattice-service-network", []*string{aws.String("sn-test")})
 
 	require.Len(t, results, 1)


### PR DESCRIPTION
## Problem

The scheduled `Nuke: PhxDevOps` workflow has failed on every run since 2026-07-10. The `us-east-1` job exits 1 on a single hard error:

```
[Failed] vpc-lattice-service-network .../sn-0c5fec7b6efad7713:
  DeleteServiceNetwork -> 409 ConflictException:
  ServiceNetwork sn-0c5fec7b6efad7713 has resource(s) associated.
```

A VPC Lattice service network cannot be deleted while it has associations. The nuker already deleted service and VPC associations, but not resource associations (resource configurations attached to the network). Any service network with an attached resource configuration therefore failed every run and wedged the entire region job. This is the same class of bug that was previously fixed for VPC associations, now recurring for the newer resource-association type.

## Fix

- Add a `deleteResourceAssociations` step to the service network `MultiStepDeleter`, before the wait step.
- Include non-managed resource associations in `countAssociations` so `waitForAssociationsDeleted` waits for them to clear.
- Skip managed associations (created by Amazon for RAM-shared resource configurations) with a warning, since they can only be removed by the resource configuration owner and would otherwise cause a hard failure or a guaranteed wait timeout.

## Testing

- Unit tests: added `TestVPCLatticeServiceNetwork_DeleteResourceAssociations` (covers the managed-skip path) and extended the multi-step regression test to populate all three association types. All pass.
- End to end against phxdevops: the previously stuck `sn-0c5fec7b6efad7713` now deletes cleanly. Debug log confirms the sequence: delete resource association `snra-0558a42b0a3be9a1b`, wait, delete service network. Verified in AWS that the service network is gone.

## Follow-up

cloud-nuke has no nuker for `vpc-lattice-resource-configuration`, so the orphaned resource configuration (`tcp-service`, `rcfg-08ec86bdee2314918`) still lingers. It no longer blocks the service network deletion, but it is never cleaned up. Worth a separate issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service network deletion now removes eligible resource associations before deleting the network.
  * Managed resource associations are preserved and no longer cause deletion operations to time out.
  * Deletion workflows now correctly account for service, VPC, and resource associations across paginated results.

* **Tests**
  * Added coverage for resource-association cleanup and managed-association handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->