### PR TITLE
fix: clean up leaked IAM groups in scheduled nuke jobs (OSS-4024)

### DIFF
--- a/.github/nuke_config.yml
+++ b/.github/nuke_config.yml
@@ -67,7 +67,18 @@ IAMUsers:
       - "^circle-ci-test$"
 
 IAMGroups:
-  # Delete all groups - no infrastructure groups to protect
+  # IAM groups do not support tags, so the per-repo CircleCI cleanup jobs (which
+  # filter by the gw:repo tag) skip them and they leak until the account hits the
+  # GroupsPerAccount quota (OSS-4024). They are cleaned up here instead.
+  #
+  # Unlike the other resource types in this file, this is an allowlist rather than
+  # a blocklist: only groups matching a known test naming convention are deleted,
+  # so any real group is protected by default. Broaden this list as other repos'
+  # test group names are confirmed.
+  include:
+    names_regex:
+      # terraform-aws-security: "<uniqueId>-test-group-number-N", "test-group-<id>"
+      - "test-group"
 
 IAMRoles:
   exclude:

--- a/.github/workflows/nuke-account.yml
+++ b/.github/workflows/nuke-account.yml
@@ -28,7 +28,6 @@ env:
   # Resources excluded across all accounts to prevent breaking infrastructure
   COMMON_EXCLUDES: >-
     --exclude-resource-type iam-user
-    --exclude-resource-type iam-group
     --exclude-resource-type iam-role
     --exclude-resource-type iam-service-linked-role
     --exclude-resource-type oidc-provider


### PR DESCRIPTION
## Problem

IAM groups do not support tags, so the per-repo CircleCI cleanup jobs that filter by `--include-tag "gw:repo=..."` exclude them for safety:

```
Resource does not support tag filtering but include tag filters are specified - excluding for safety
```

The account-wide guardrail did not clean them either, because of a contradiction between two files:

```yaml
# .github/nuke_config.yml
IAMGroups:
  # Delete all groups - no infrastructure groups to protect   <-- intent: delete
```
```yaml
# .github/workflows/nuke-account.yml
COMMON_EXCLUDES: ... --exclude-resource-type iam-group ...    <-- type never processed
```

The CLI exclusion wins, so the `IAMGroups` block was dead code and has never executed. Nothing cleaned up IAM groups in any account. They accumulated until ConfigTests (677276116620) hit the `GroupsPerAccount` quota and `CreateGroup` began failing, which blocked the terraform-aws-security test suite:

```
Error: creating IAM Group (dxlh8x-test-group-number-3): CreateGroup, 409 LimitExceeded:
Cannot exceed quota for GroupsPerAccount
```

Ref: OSS-4024, OSS-4031.

## Fix

- Drop `iam-group` from `COMMON_EXCLUDES` so the type is processed. This follows the established pattern of enabling types individually once verified, as done for subnets/NAT (#1024), Route 53 (#1026), and IAM policies (#1112). The blanket list came in wholesale with #997.
- Scope `IAMGroups` with an **allowlist** instead of the previously declared delete-all. Only groups matching a known test naming convention are deleted; any real group is protected by default.

Delete-all was not safe to rely on. The "no infrastructure groups to protect" comment had never actually been exercised (the type was CLI-excluded the whole time), and it could not be verified for ConfigTests or Sandbox. The guardrail protects an IAM user `^circle-ci-test$`, so a real CI identity exists in those accounts; if its permissions came from a group membership, delete-all would strip CI permissions for ~20 repos every 3 hours. The allowlist gets the same cleanup with none of that risk.

## Why here rather than in each consumer repo

Untaggable resources cannot be isolated by the `gw:repo` tag, so consumers have no good mechanism for them. Handling them centrally fixes every account and every consumer repo on the existing 3h cadence, with the naming conventions in one place. Taggable resources stay with the per-repo tag-filtered jobs as before.

## Testing

Verified end to end against phxdevops using the real `.github/nuke_config.yml`:

- Created four IAM groups: `oss4024-test-group-number-1` and `gw-test-group-alpha` (match), `oss4024-real-admins` and `circle-ci-test-perms` (do not match).
- The run found exactly the two matching groups and deleted them.
- Both non-matching groups survived, confirming unknown/real groups are protected by the allowlist.
- Account restored to its original state afterwards.

Also confirmed phxdevops has no IAM groups in normal operation and no IAM user (including `circle-ci-test`) depends on group membership.

## Follow-up

The allowlist currently carries only terraform-aws-security's `test-group` convention. Other repos whose tests create IAM groups will need their patterns added. OSS-4031 tracks inventorying ConfigTests and Sandbox, which would also tell us whether delete-all is genuinely safe and could replace the allowlist later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated account cleanup to target only IAM groups matching the test-group naming convention.
  * Removed the broad exclusion that prevented IAM group cleanup.
  * Preserved existing cleanup execution, reporting, and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->