### PR TITLE
fix: match KMS name filters against bare alias name as well as full alias

### DIFF
--- a/.github/nuke_config.yml
+++ b/.github/nuke_config.yml
@@ -131,8 +131,8 @@ KMSCustomerKeys:
   exclude:
     names_regex:
       # Shared test key referenced by multiple repos (terragrunt, terraform-aws-security, terraform-aws-eks, etc.)
-      # NOTE: KMS keys are matched on the full alias returned by ListAliases, which includes the
-      # "alias/" prefix. Patterns here must account for it or they will never match.
+      # Either "^alias/dedicated-test-key$" or "^dedicated-test-key$" matches. The prefixed
+      # form is spelled out here so the exclusion holds regardless of cloud-nuke version.
       - "^alias/dedicated-test-key$"
 
 VPC:

--- a/.github/nuke_config.yml
+++ b/.github/nuke_config.yml
@@ -131,7 +131,9 @@ KMSCustomerKeys:
   exclude:
     names_regex:
       # Shared test key referenced by multiple repos (terragrunt, terraform-aws-security, terraform-aws-eks, etc.)
-      - "^dedicated-test-key$"
+      # NOTE: KMS keys are matched on the full alias returned by ListAliases, which includes the
+      # "alias/" prefix. Patterns here must account for it or they will never match.
+      - "^alias/dedicated-test-key$"
 
 VPC:
   exclude:

--- a/aws/resources/kms_customer_key.go
+++ b/aws/resources/kms_customer_key.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
@@ -125,22 +126,59 @@ func getKeyAliasesMap(ctx context.Context, client KmsCustomerKeysAPI) (map[strin
 	return keyAliases, nil
 }
 
-// shouldIncludeKey determines if a key should be included for deletion.
-func shouldIncludeKey(ctx context.Context, client KmsCustomerKeysAPI, keyId string, aliases []string, cfg config.ResourceType, includeUnaliasedKeys bool) (bool, error) {
-	// Skip keys without aliases unless explicitly configured to include them
-	if len(aliases) == 0 && !includeUnaliasedKeys {
-		return false, nil
-	}
+// kmsAliasPrefix is the prefix AWS returns on every alias from ListAliases.
+const kmsAliasPrefix = "alias/"
 
-	// Check if any alias matches the name filter
-	matchedByName := len(aliases) == 0 && includeUnaliasedKeys // Unaliased keys pass if configured
+// aliasNameCandidates returns the strings that name filters are matched against for a
+// given set of aliases. AWS reports aliases as "alias/my-key", but the "alias/" prefix is
+// an API artifact rather than part of the name users think in, so both the full alias and
+// the bare name are considered. A pattern matching either form applies to the key.
+func aliasNameCandidates(aliases []string) []string {
+	candidates := make([]string, 0, len(aliases)*2)
 	for _, alias := range aliases {
-		if config.ShouldInclude(&alias, cfg.IncludeRule.NamesRegExp, cfg.ExcludeRule.NamesRegExp) {
-			matchedByName = true
-			break
+		candidates = append(candidates, alias)
+		if bare := strings.TrimPrefix(alias, kmsAliasPrefix); bare != alias {
+			candidates = append(candidates, bare)
 		}
 	}
-	if !matchedByName {
+	return candidates
+}
+
+// matchesNameFilters reports whether a key passes the configured name filters.
+//
+// An exclude rule matching any form of any alias protects the whole key, so that a key
+// carrying several aliases cannot be deleted just because one of its other aliases was
+// not excluded. When include rules are present, at least one form must match.
+func matchesNameFilters(aliases []string, cfg config.ResourceType) bool {
+	candidates := aliasNameCandidates(aliases)
+
+	for _, name := range candidates {
+		if !config.ShouldInclude(&name, nil, cfg.ExcludeRule.NamesRegExp) {
+			return false
+		}
+	}
+
+	if len(cfg.IncludeRule.NamesRegExp) == 0 {
+		return true
+	}
+
+	for _, name := range candidates {
+		if config.ShouldInclude(&name, cfg.IncludeRule.NamesRegExp, nil) {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldIncludeKey determines if a key should be included for deletion.
+func shouldIncludeKey(ctx context.Context, client KmsCustomerKeysAPI, keyId string, aliases []string, cfg config.ResourceType, includeUnaliasedKeys bool) (bool, error) {
+	// Skip keys without aliases unless explicitly configured to include them. Unaliased
+	// keys have no name to match, so they bypass name filtering entirely.
+	if len(aliases) == 0 {
+		if !includeUnaliasedKeys {
+			return false, nil
+		}
+	} else if !matchesNameFilters(aliases, cfg) {
 		return false, nil
 	}
 

--- a/aws/resources/kms_customer_key_test.go
+++ b/aws/resources/kms_customer_key_test.go
@@ -196,6 +196,41 @@ func TestListKmsCustomerKeys_MultiAliasExclusion(t *testing.T) {
 	require.Equal(t, []string{otherKey}, aws.ToStringSlice(names))
 }
 
+// TestMatchesNameFilters_ExclusionIsAlwaysHonored pins the safety property that matters
+// most for a deletion tool: whenever an exclude rule matches any form of any alias on a
+// key, the key is protected. Regressing this silently deletes keys operators believe are
+// safe, which is exactly how dedicated-test-key was lost.
+func TestMatchesNameFilters_ExclusionIsAlwaysHonored(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		aliases []string
+		exclude string
+	}{
+		{"bare name, anchored", []string{"alias/dedicated-test-key"}, `^dedicated-test-key$`},
+		{"full alias, anchored", []string{"alias/dedicated-test-key"}, `^alias/dedicated-test-key$`},
+		{"unanchored substring", []string{"alias/dedicated-test-key"}, `dedicated-test-key`},
+		{"prefix wildcard", []string{"alias/dedicated-test-key"}, `^alias/`},
+		{"match everything", []string{"alias/dedicated-test-key"}, `.*`},
+		{"excluded alias listed first", []string{"alias/dedicated-test-key", "alias/other"}, `^dedicated-test-key$`},
+		{"excluded alias listed second", []string{"alias/other", "alias/dedicated-test-key"}, `^dedicated-test-key$`},
+		{"excluded alias among several", []string{"alias/a", "alias/b", "alias/dedicated-test-key"}, `^dedicated-test-key$`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					NamesRegExp: []config.Expression{{RE: *regexp.MustCompile(tc.exclude)}},
+				},
+			}
+			require.False(t, matchesNameFilters(tc.aliases, cfg),
+				"exclude %q must protect a key with aliases %v", tc.exclude, tc.aliases)
+		})
+	}
+}
+
 func TestListKmsCustomerKeys_IncludeUnaliasedKeys(t *testing.T) {
 	t.Parallel()
 

--- a/aws/resources/kms_customer_key_test.go
+++ b/aws/resources/kms_customer_key_test.go
@@ -92,10 +92,39 @@ func TestListKmsCustomerKeys(t *testing.T) {
 			},
 			expected: []string{key2},
 		},
+		// Anchored patterns written against the full alias must keep working, since
+		// existing configs rely on the "alias/" prefix being matchable.
+		"prefixedAnchoredExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					NamesRegExp: []config.Expression{{RE: *regexp.MustCompile(`^alias/key1$`)}},
+				},
+			},
+			expected: []string{key2},
+		},
+		// Anchored patterns written against the bare name must also work. Before this was
+		// supported, a pattern like "^key1$" silently matched nothing and the key was
+		// deleted despite an exclusion being configured.
+		"bareNameAnchoredExclusionFilter": {
+			configObj: config.ResourceType{
+				ExcludeRule: config.FilterRule{
+					NamesRegExp: []config.Expression{{RE: *regexp.MustCompile(`^key1$`)}},
+				},
+			},
+			expected: []string{key2},
+		},
 		"nameInclusionFilter": {
 			configObj: config.ResourceType{
 				IncludeRule: config.FilterRule{
 					NamesRegExp: []config.Expression{{RE: *regexp.MustCompile(".*key1")}},
+				},
+			},
+			expected: []string{key1},
+		},
+		"bareNameAnchoredInclusionFilter": {
+			configObj: config.ResourceType{
+				IncludeRule: config.FilterRule{
+					NamesRegExp: []config.Expression{{RE: *regexp.MustCompile(`^key1$`)}},
 				},
 			},
 			expected: []string{key1},
@@ -117,6 +146,54 @@ func TestListKmsCustomerKeys(t *testing.T) {
 			require.Equal(t, tc.expected, aws.ToStringSlice(names))
 		})
 	}
+}
+
+// TestListKmsCustomerKeys_MultiAliasExclusion covers a key carrying more than one alias.
+// An exclusion matching any one of them protects the key, so a key cannot be deleted
+// merely because one of its other aliases was not excluded.
+func TestListKmsCustomerKeys_MultiAliasExclusion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	protectedKey, otherKey := "protected", "other"
+
+	mock := &mockKmsClient{
+		ListKeysOutput: kms.ListKeysOutput{
+			Keys: []types.KeyListEntry{
+				{KeyId: aws.String(protectedKey)},
+				{KeyId: aws.String(otherKey)},
+			},
+		},
+		ListAliasesOutput: kms.ListAliasesOutput{
+			Aliases: []types.AliasListEntry{
+				{AliasName: aws.String("alias/dedicated-test-key"), TargetKeyId: aws.String(protectedKey)},
+				{AliasName: aws.String("alias/some-other-name"), TargetKeyId: aws.String(protectedKey)},
+				{AliasName: aws.String("alias/unrelated"), TargetKeyId: aws.String(otherKey)},
+			},
+		},
+		DescribeKeyOutput: map[string]kms.DescribeKeyOutput{
+			protectedKey: {KeyMetadata: &types.KeyMetadata{
+				KeyId:        aws.String(protectedKey),
+				KeyManager:   types.KeyManagerTypeCustomer,
+				CreationDate: aws.Time(now),
+			}},
+			otherKey: {KeyMetadata: &types.KeyMetadata{
+				KeyId:        aws.String(otherKey),
+				KeyManager:   types.KeyManagerTypeCustomer,
+				CreationDate: aws.Time(now),
+			}},
+		},
+	}
+
+	cfg := config.ResourceType{
+		ExcludeRule: config.FilterRule{
+			NamesRegExp: []config.Expression{{RE: *regexp.MustCompile(`^dedicated-test-key$`)}},
+		},
+	}
+
+	names, err := listKmsCustomerKeys(context.Background(), mock, cfg, false)
+	require.NoError(t, err)
+	require.Equal(t, []string{otherKey}, aws.ToStringSlice(names))
 }
 
 func TestListKmsCustomerKeys_IncludeUnaliasedKeys(t *testing.T) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,6 +40,22 @@ S3:
 
 Filtering is **commutative** — include and exclude filters can be applied in any order with the same result. In the example above, buckets matching `^alb-.*-access-logs$` are included unless they also match `public` or `prod`.
 
+Patterns are not implicitly anchored: they match anywhere in the name unless you add `^` and `$` yourself.
+
+#### KMS key names
+
+KMS customer-managed keys are matched by alias. AWS returns aliases with an `alias/` prefix, so both the full alias and the bare name are matched, and a pattern matching either form applies. These are equivalent:
+
+```yaml
+KMSCustomerKeys:
+  exclude:
+    names_regex:
+      - ^alias/my-key$
+      - ^my-key$
+```
+
+When a key carries several aliases, an exclusion matching any one of them protects the key.
+
 ### time_after / time_before
 
 Filter resources by creation time.


### PR DESCRIPTION
KMS customer keys are filtered on the alias returned by `ListAliases`, which carries an `alias/` prefix. A pattern written against the name users actually think in, such as `^dedicated-test-key$`, silently matched nothing, so keys were deleted despite an exclusion being configured.

That is what happened to the shared `dedicated-test-key` in PhxDevOps. The exclusion added in #1025 never took effect, and the key has been nuked repeatedly since, breaking terraform-aws-service-catalog tests and others that reference it.

Confirmed in CloudTrail. `ScheduleKeyDeletion` is the only path to deleting a KMS key, and over the last 90 days the `cloud-nuke-gha` role hit this key twice, each time within hours of a manual recreation:

| When (EDT) | Actor | Event |
| --- | --- | --- |
| 2026-05-26 14:16 | george (SSO) | creates key + alias |
| 2026-05-26 17:38 | cloud-nuke-gha | schedules deletion |
| 2026-07-25 12:48 | george (SSO) | creates key + alias |
| 2026-07-25 17:21 | cloud-nuke-gha | schedules deletion |

## Changes

- Name filters match against both the full alias and the bare name, so either form works. Patterns written against the prefixed form keep working unchanged.
- Exclusions are evaluated across every alias on a key. If any alias matches an exclude rule the key is protected, rather than being deleted because some other alias on it was not excluded.
- Documented the behavior in `docs/configuration.md`, which previously only said "match resources by name" and never mentioned the prefix.
- Fixed the PhxDevOps config entry. It spells out the prefixed form so the exclusion holds regardless of cloud-nuke version.

## Compatibility

Nothing that matches today stops matching, so no existing exclusion silently weakens. The existing `nameExclusionFilter` test, which uses `alias/key1`, passes unchanged.

One behavior change worth a changelog note: an **include** rule written against a bare name previously matched nothing and now matches, so such a rule will start selecting keys for deletion as its author intended. Exclusions only ever become more protective.

## Verification

- Three new test cases fail against the old code and pass against the new one: bare-name exclusion, bare-name inclusion, and multi-alias exclusion. Every pre-existing KMS test passes against both.
- Loaded the real `nuke_config.yml` through `config.GetConfig` and asserted on `ShouldInclude`: `alias/dedicated-test-key` is excluded and an unrelated `alias/some-random-test-key` is still nuked, so the exclusion is not over-broad.
- `gofmt`, `go vet`, and `go build ./...` clean.
- Unrelated pre-existing failure: `TestListECSClusters/timeAfter|timeBefore` also fails on a clean master checkout, untouched by this PR.

## Follow-up needed

The currently live key (`1a870050-0fbe-4c4b-a5fa-19048b358ae1`) is already in `PendingDeletion` with a deletion date of 2026-08-01. It needs `kms cancel-key-deletion` plus `enable-key` separately from this PR, otherwise there is nothing left for the exclusion to protect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KMS customer key `names_regex` filtering to correctly match both `alias/name` and unprefixed alias forms.
  * Ensured exclusion rules are applied safely per-alias, including for keys with multiple aliases.
  * Fixed anchored include/exclude behavior for KMS alias and key-name patterns.
* **Documentation**
  * Clarified that `names_regex` patterns are not implicitly anchored and must use `^`/`$` when needed.
  * Documented how alias matching behaves for customer-managed KMS keys.
* **Tests**
  * Added regression coverage for multi-alias exclusion and exclusion precedence across alias name representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->